### PR TITLE
feat: AI Engine Gemini 연동 및 parse 응답 처리 구현

### DIFF
--- a/apps/ai-engine/.env.example
+++ b/apps/ai-engine/.env.example
@@ -1,5 +1,6 @@
 # External APIs
 GEMINI_API_KEY=
+GEMINI_COOLDOWN_SECONDS=60
 GOOGLE_MAPS_API_KEY=
 
 # Supabase (필요 시)

--- a/apps/ai-engine/app/main.py
+++ b/apps/ai-engine/app/main.py
@@ -18,6 +18,7 @@ def health() -> dict[str, str]:
 
 
 @app.post("/internal/ai/parse")
+<<<<<<< HEAD
 def parse_user_input(
     req: ParseRequest,
 ) -> dict:  ## 이후 pydantic BaseModel로 응답 스키마 정의 필요
@@ -36,3 +37,8 @@ def parse_user_input(
         ],
         "context_summary": "오사카 중심 여행",
     }
+=======
+def parse_user_input(req: dict):
+    text = req.get("text", "")
+    return {"raw": text, "places": ["도톤보리", "유니버셜 스튜디오"]}
+>>>>>>> 247d476 (feat: add /test/ai/parse endpoint and validate AI Engine call flow)

--- a/apps/ai-engine/app/main.py
+++ b/apps/ai-engine/app/main.py
@@ -18,7 +18,6 @@ def health() -> dict[str, str]:
 
 
 @app.post("/internal/ai/parse")
-<<<<<<< HEAD
 def parse_user_input(
     req: ParseRequest,
 ) -> dict:  ## 이후 pydantic BaseModel로 응답 스키마 정의 필요
@@ -37,8 +36,3 @@ def parse_user_input(
         ],
         "context_summary": "오사카 중심 여행",
     }
-=======
-def parse_user_input(req: dict):
-    text = req.get("text", "")
-    return {"raw": text, "places": ["도톤보리", "유니버셜 스튜디오"]}
->>>>>>> 247d476 (feat: add /test/ai/parse endpoint and validate AI Engine call flow)

--- a/apps/ai-engine/app/main.py
+++ b/apps/ai-engine/app/main.py
@@ -1,6 +1,23 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-import uuid
+from dotenv import load_dotenv
+
+import json
+from json import JSONDecodeError
+import time
+
+from google.api_core.exceptions import ResourceExhausted
+import google.generativeai as genai
+import googlemaps
+import os
+
+load_dotenv()  # .env 파일에서 환경 변수 로드
+
+genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
+gmaps = googlemaps.Client(key=os.getenv("GOOGLE_MAPS_API_KEY"))
+model = genai.GenerativeModel("gemini-2.5-flash")
+GEMINI_COOLDOWN_SECONDS = int(os.getenv("GEMINI_COOLDOWN_SECONDS", "60"))
+gemini_blocked_until = 0.0
 
 
 class ParseRequest(BaseModel):
@@ -17,22 +34,119 @@ def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+# --- [build prompt] --- #
+def build_prompt(req: ParseRequest) -> str:
+    return f"""
+    사용자 입력을 여행 일정 후보로 파싱해줘.
+    입력 {req.text} destination: {req.destination} travel_days: {req.travel_days}
+    
+    반드시 JSON 객체만 반환해줘.
+    마크다운,설명문,코드블록을 절대 포함하지마.
+    오로지 응답은 JSON 하나만 반환해.
+    사용자 입력이 도시 단위로만 주어져도 cards를 최소 3개 이상 채워라.
+    Cards를 비우지 마라.
+    실존하는 대표 관광지 후보를 반환해라.
+    형식:
+    {{
+    "cards": [
+    {{
+        "place_id": "string",
+        "instance_id": "string",
+        "name": "string",
+        "category": "string",
+        "classification": "confirmed" | "unconfirmed",
+        "estimated_duration_min": number,
+        "coordinates": {{
+            "lat": number,
+            "lng": number
+        }},
+        "status": "success" | "failure"
+    }}
+    ],
+    "context_summary": "string"
+    }}
+    """
+
+
+def call_gemini(prompt: str) -> str:
+    if time.monotonic() < gemini_blocked_until:
+        retry_after = int(gemini_blocked_until - time.monotonic()) + 1
+        raise RuntimeError(f"Gemini temporarily blocked. Retry after {retry_after} seconds.")
+
+    response = model.generate_content(prompt)
+    text = getattr(response, "text", None)
+
+    if not text:
+        raise ValueError("Gemini returned an empty response")
+
+    return text
+
+
+def clean_gemini_response(raw: str) -> str:
+    cleaned = raw.strip()
+
+    if cleaned.startswith("```json"):
+        cleaned = cleaned.removeprefix("```json").strip()
+    elif cleaned.startswith("```"):
+        cleaned = cleaned.removeprefix("```").strip()
+
+    if cleaned.endswith("```"):
+        cleaned = cleaned.removesuffix("```").strip()
+
+    return cleaned
+
+
+def parse_gemini_response(raw: str) -> dict:
+    cleaned = clean_gemini_response(raw)
+    return json.loads(cleaned)
+
+
 @app.post("/internal/ai/parse")
 def parse_user_input(
     req: ParseRequest,
 ) -> dict:  ## 이후 pydantic BaseModel로 응답 스키마 정의 필요
-    return {
-        "cards": [
-            {
-                "place_id": "mock-place-id-1",
-                "instance_id": str(uuid.uuid4()),
-                "name": "도톤보리",
-                "category": "관광",
-                "classification": "confirmed",
-                "estimated_duration_min": 90,
-                "coordinates": {"lat": 34.6687, "lng": 135.5013},
-                "status": "success",
-            }
-        ],
-        "context_summary": "오사카 중심 여행",
-    }
+    global gemini_blocked_until
+    prompt = build_prompt(req)
+
+    try:
+        raw = call_gemini(prompt)
+    except ResourceExhausted as e:
+        gemini_blocked_until = time.monotonic() + GEMINI_COOLDOWN_SECONDS
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "message": "Gemini quota/rate limit reached. Temporary cooldown enabled.",
+                "retry_after_sec": GEMINI_COOLDOWN_SECONDS,
+                "error": str(e),
+            },
+        ) from e
+    except ValueError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "message": "Gemini returned an empty response",
+                "prompt": prompt,
+                "error": str(e),
+            },
+        ) from e
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "message": "Failed to call Gemini",
+                "prompt": prompt,
+                "error": str(e),
+            },
+        ) from e
+
+    try:
+        return parse_gemini_response(raw)
+    except JSONDecodeError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "message": "Gemini response was not valid JSON",
+                "raw": raw,
+                "error": str(e),
+            },
+        ) from e

--- a/apps/ai-engine/requirements.txt
+++ b/apps/ai-engine/requirements.txt
@@ -10,6 +10,7 @@ pydantic-settings==2.7.0
 google-generativeai==0.8.3
 
 # ── External API (Google Maps Directions) ────────────
+googlemaps==4.10.0
 httpx==0.28.1
 
 # ── Environment ──────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,9 @@ services:
       - "8000" # 내부 통신용 포트 (외부 노출은 backend → ai-engine 통신만)
     env_file:
       - ./apps/ai-engine/.env
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    volumes:
+      - ./apps/ai-engine:/app
     networks:
       - tripkey-network
     restart: unless-stopped


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- AI Engine `parse` 엔드포인트에 Gemini 연동을 추가하고, 응답을 서비스 스펙에 맞는 JSON 형태로 파싱하도록 구현했습니다.

## 🔗 관련 이슈

Refs #9 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- `apps/ai-engine/app/main.py`의 Gemini 호출, 응답 정제, JSON 파싱 흐름을 중점적으로 봐주시면 좋겠습니다.
- `docker-compose.yml`에서 `ai-engine` 개발용 hot reload 설정을 추가했습니다.

###테스트 방법:
docker compose up -d --build ai-engine backend

curl -X POST http://localhost:8080/test/ai/parse \
  -H "Content-Type: application/json" \
  -d '{"text":"오사카 여행"}'


이번 PR은 AI Engine에서 Gemini를 직접 호출해서 테스트하려면 `apps/ai-engine/.env`에 `GEMINI_API_KEY`가 필요합니다.
`.env.example` 기준으로 값 채워서 실행해주시면 되고, 키가 필요하면 따로 전달드릴게요.

언제든 궁금하신게 생기시면 편하게 물어봐주세요.. ^ㅡ^