### PR TITLE
Feat/6 dump api spec fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,8 @@ Thumbs.db
 **/*.log
 **/docker/data/ # 로컬 DB 대비
 
-# docs
+# docs (schema.sql은 예외)
 docs/
+!shared/docs/
+shared/docs/*
+!shared/docs/schema.sql

--- a/apps/ai-engine/app/main.py
+++ b/apps/ai-engine/app/main.py
@@ -7,3 +7,9 @@ app = FastAPI(title="TripKey AI Engine")
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.post("/internal/ai/parse")
+def parse_user_input(req: dict):
+    text = req.get("text", "")
+    return {"raw": text, "places": ["도톤보리", "유니버셜 스튜디오"]}

--- a/apps/ai-engine/app/main.py
+++ b/apps/ai-engine/app/main.py
@@ -1,4 +1,12 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
+import uuid
+
+
+class ParseRequest(BaseModel):
+    text: str
+    destination: str | None = None
+    travel_days: int | None = None
 
 
 app = FastAPI(title="TripKey AI Engine")
@@ -10,6 +18,21 @@ def health() -> dict[str, str]:
 
 
 @app.post("/internal/ai/parse")
-def parse_user_input(req: dict):
-    text = req.get("text", "")
-    return {"raw": text, "places": ["도톤보리", "유니버셜 스튜디오"]}
+def parse_user_input(
+    req: ParseRequest,
+) -> dict:  ## 이후 pydantic BaseModel로 응답 스키마 정의 필요
+    return {
+        "cards": [
+            {
+                "place_id": "mock-place-id-1",
+                "instance_id": str(uuid.uuid4()),
+                "name": "도톤보리",
+                "category": "관광",
+                "classification": "confirmed",
+                "estimated_duration_min": 90,
+                "coordinates": {"lat": 34.6687, "lng": 135.5013},
+                "status": "success",
+            }
+        ],
+        "context_summary": "오사카 중심 여행",
+    }

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -4,9 +4,14 @@ SPRING_PROFILES_ACTIVE=dev
 # AI Engine
 AI_ENGINE_URL=http://tripkey-ai-engine:8000
 
-#SUPABASE
+# Supabase API/Auth
 SUPABASE_URL=
 SUPABASE_KEY=
+
+# Supabase DB (PostgreSQL)
+SUPABASE_DB_URL=jdbc:postgresql://aws-1-ap-southeast-1.pooler.supabase.com:5432/postgres
+SUPABASE_DB_USERNAME=postgres
+SUPABASE_DB_PASSWORD=
 
 #External APIs
 GEMINI_API_KEY=

--- a/apps/backend/src/main/java/com/tripkey/TripKeyApplication.java
+++ b/apps/backend/src/main/java/com/tripkey/TripKeyApplication.java
@@ -2,15 +2,8 @@ package com.tripkey;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 
-@SpringBootApplication(
-        exclude = {
-                DataSourceAutoConfiguration.class,
-                HibernateJpaAutoConfiguration.class
-        }
-)
+@SpringBootApplication
 public class TripKeyApplication {
 
     public static void main(String[] args) {

--- a/apps/backend/src/main/java/com/tripkey/common/converter/StringListConverter.java
+++ b/apps/backend/src/main/java/com/tripkey/common/converter/StringListConverter.java
@@ -1,0 +1,40 @@
+package com.tripkey.common.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to convert list to JSON", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            return mapper.readValue(dbData, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to convert JSON to list", e);
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/common/exception/DumpNotCompletedException.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/DumpNotCompletedException.java
@@ -1,0 +1,8 @@
+package com.tripkey.common.exception;
+
+public class DumpNotCompletedException extends RuntimeException {
+
+    public DumpNotCompletedException() {
+        super("파싱이 아직 완료되지 않았어요");
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/common/exception/DumpNotFoundException.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/DumpNotFoundException.java
@@ -1,0 +1,10 @@
+package com.tripkey.common.exception;
+
+import java.util.UUID;
+
+public class DumpNotFoundException extends RuntimeException {
+
+    public DumpNotFoundException(UUID tripId) {
+        super("여행 세션을 찾을 수 없어요");
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/common/exception/DumpNotFoundException.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/DumpNotFoundException.java
@@ -5,6 +5,6 @@ import java.util.UUID;
 public class DumpNotFoundException extends RuntimeException {
 
     public DumpNotFoundException(UUID tripId) {
-        super("여행 세션을 찾을 수 없어요");
+        super("여행 세션을 찾을 수 없어요. tripId=" + tripId);
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/common/exception/DumpUrlNotAllowedException.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/DumpUrlNotAllowedException.java
@@ -1,0 +1,8 @@
+package com.tripkey.common.exception;
+
+public class DumpUrlNotAllowedException extends RuntimeException {
+
+    public DumpUrlNotAllowedException() {
+        super("URL은 입력할 수 없어요. 텍스트로 적어주세요");
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
@@ -13,13 +13,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(TripNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleTripNotFound(TripNotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse("TRIP_NOT_FOUND", e.getMessage()));
+                .body(new ErrorResponse("TRIP_NOT_FOUND", "여행 세션을 찾을 수 없어요"));
     }
 
     @ExceptionHandler(DumpNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleDumpNotFound(DumpNotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse("TRIP_NOT_FOUND", e.getMessage()));
+                .body(new ErrorResponse("TRIP_NOT_FOUND", "여행 세션을 찾을 수 없어요"));
     }
 
     @ExceptionHandler(DumpNotCompletedException.class)

--- a/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.tripkey.common.exception;
+
+import com.tripkey.dto.common.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(TripNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleTripNotFound(TripNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("TRIP_NOT_FOUND", e.getMessage()));
+    }
+
+    @ExceptionHandler(DumpNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleDumpNotFound(DumpNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("TRIP_NOT_FOUND", e.getMessage()));
+    }
+
+    @ExceptionHandler(DumpNotCompletedException.class)
+    public ResponseEntity<ErrorResponse> handleDumpNotCompleted(DumpNotCompletedException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("DUMP_NOT_COMPLETED", e.getMessage()));
+    }
+
+    @ExceptionHandler(DumpUrlNotAllowedException.class)
+    public ResponseEntity<ErrorResponse> handleDumpUrlNotAllowed(DumpUrlNotAllowedException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("DUMP_URL_NOT_ALLOWED", e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(f -> f.getDefaultMessage())
+                .orElse("입력값을 확인해주세요");
+
+        String code = "VALIDATION_ERROR";
+        if (message.contains("blank") || message.contains("10자")) {
+            code = "DUMP_TOO_SHORT";
+            message = "최소 10자 이상 입력해주세요";
+        } else if (message.contains("3000")) {
+            code = "DUMP_TOO_LONG";
+            message = "최대 글자 수에 도달했어요";
+        }
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(code, message));
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/common/exception/TripNotFoundException.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/TripNotFoundException.java
@@ -1,0 +1,10 @@
+package com.tripkey.common.exception;
+
+import java.util.UUID;
+
+public class TripNotFoundException extends RuntimeException {
+
+    public TripNotFoundException(UUID tripId) {
+        super("여행 세션을 찾을 수 없어요");
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/common/exception/TripNotFoundException.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/TripNotFoundException.java
@@ -5,6 +5,6 @@ import java.util.UUID;
 public class TripNotFoundException extends RuntimeException {
 
     public TripNotFoundException(UUID tripId) {
-        super("여행 세션을 찾을 수 없어요");
+        super("여행 세션을 찾을 수 없어요. tripId=" + tripId);
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/controller/AiTestController.java
+++ b/apps/backend/src/main/java/com/tripkey/controller/AiTestController.java
@@ -1,0 +1,19 @@
+package com.tripkey.controller;
+
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/test/ai")
+public class AiTestController {
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @PostMapping("/parse")
+    public Object test(@RequestBody Map<String, String> body) {
+        String aiUrl = "http://tripkey-ai-engine:8000/internal/ai/parse";
+
+        return restTemplate.postForObject(aiUrl, body, Object.class);
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpController.java
@@ -1,0 +1,49 @@
+package com.tripkey.domain.dump;
+
+import com.tripkey.dto.dump.DumpResultResponse;
+import com.tripkey.dto.dump.DumpStatusResponse;
+import com.tripkey.dto.dump.DumpSubmitRequest;
+import com.tripkey.dto.dump.DumpSubmitResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/trips/{tripId}/dump")
+@RequiredArgsConstructor
+public class DumpController {
+
+    private final DumpService dumpService;
+
+    /**
+     * 1) Dump 텍스트 제출 + AI 파싱 시작
+     */
+    @PostMapping
+    public ResponseEntity<DumpSubmitResponse> submitDump(
+            @PathVariable UUID tripId,
+            @Valid @RequestBody DumpSubmitRequest request) {
+
+        DumpSubmitResponse response = dumpService.submit(tripId, request.dumpText());
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
+    }
+
+    /**
+     * 2) 파싱 진행 상태 조회 (SCR-02P 프로그레스)
+     */
+    @GetMapping("/status")
+    public ResponseEntity<DumpStatusResponse> getDumpStatus(@PathVariable UUID tripId) {
+        return ResponseEntity.ok(dumpService.getStatus(tripId));
+    }
+
+    /**
+     * 3) 파싱 결과 조회 (PlaceCard 배열)
+     */
+    @GetMapping("/result")
+    public ResponseEntity<DumpResultResponse> getDumpResult(@PathVariable UUID tripId) {
+        return ResponseEntity.ok(dumpService.getResult(tripId));
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJob.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJob.java
@@ -1,0 +1,83 @@
+package com.tripkey.domain.dump;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "dump_jobs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DumpJob {
+
+    @Id
+    @Column(name = "job_id", columnDefinition = "uuid")
+    private UUID jobId;
+
+    @Column(name = "trip_id", nullable = false, columnDefinition = "uuid")
+    private UUID tripId;
+
+    @Column(name = "dump_text", nullable = false, columnDefinition = "text")
+    private String dumpText;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+
+    @Column(name = "step")
+    private Short step;
+
+    @Column(name = "error_code")
+    private String errorCode;
+
+    @Column(name = "context_summary", columnDefinition = "text")
+    private String contextSummary;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public static DumpJob create(UUID tripId, String dumpText) {
+        DumpJob job = new DumpJob();
+        job.jobId = UUID.randomUUID();
+        job.tripId = tripId;
+        job.dumpText = dumpText;
+        job.status = "pending";
+        job.step = null;
+        return job;
+    }
+
+    public void updateStatus(String status) {
+        this.status = status;
+    }
+
+    public void updateStep(Short step) {
+        this.step = step;
+    }
+
+    public void fail(String errorCode) {
+        this.status = "failed";
+        this.errorCode = errorCode;
+    }
+
+    public void complete(String contextSummary) {
+        this.status = "completed";
+        this.contextSummary = contextSummary;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = OffsetDateTime.now();
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJobRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJobRepository.java
@@ -1,0 +1,11 @@
+package com.tripkey.domain.dump;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DumpJobRepository extends JpaRepository<DumpJob, UUID> {
+
+    Optional<DumpJob> findFirstByTripIdOrderByCreatedAtDesc(UUID tripId);
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpService.java
@@ -1,0 +1,99 @@
+package com.tripkey.domain.dump;
+
+import com.tripkey.common.exception.DumpNotCompletedException;
+import com.tripkey.common.exception.DumpNotFoundException;
+import com.tripkey.common.exception.DumpUrlNotAllowedException;
+import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.dump.DumpResultResponse;
+import com.tripkey.dto.dump.DumpStatusResponse;
+import com.tripkey.dto.dump.DumpSubmitResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class DumpService {
+
+    private static final Pattern URL_PATTERN = Pattern.compile(
+            "(https?://|www\\.)[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]+"
+    );
+
+    private final DumpJobRepository dumpJobRepository;
+    private final PlaceCardRepository placeCardRepository;
+    private final TripRepository tripRepository;
+
+    @Transactional
+    public DumpSubmitResponse submit(UUID tripId, String dumpText) {
+        if (!tripRepository.existsById(tripId)) {
+            throw new TripNotFoundException(tripId);
+        }
+
+        if (URL_PATTERN.matcher(dumpText).find()) {
+            throw new DumpUrlNotAllowedException();
+        }
+
+        DumpJob job = DumpJob.create(tripId, dumpText);
+        dumpJobRepository.save(job);
+
+        // TODO: AI Engine 비동기 호출 (파싱 요청)
+
+        return new DumpSubmitResponse(job.getJobId(), job.getStatus());
+    }
+
+    @Transactional(readOnly = true)
+    public DumpStatusResponse getStatus(UUID tripId) {
+        DumpJob job = dumpJobRepository.findFirstByTripIdOrderByCreatedAtDesc(tripId)
+                .orElseThrow(() -> new DumpNotFoundException(tripId));
+
+        return new DumpStatusResponse(job.getJobId(), job.getStatus(), job.getStep(), job.getErrorCode());
+    }
+
+    @Transactional(readOnly = true)
+    public DumpResultResponse getResult(UUID tripId) {
+        DumpJob job = dumpJobRepository.findFirstByTripIdOrderByCreatedAtDesc(tripId)
+                .orElseThrow(() -> new DumpNotFoundException(tripId));
+
+        if (!"completed".equals(job.getStatus())) {
+            throw new DumpNotCompletedException();
+        }
+
+        List<PlaceCard> cards = placeCardRepository.findAllByTripId(tripId);
+
+        List<DumpResultResponse.PlaceCardDto> cardDtos = cards.stream()
+                .map(c -> new DumpResultResponse.PlaceCardDto(
+                        c.getInstanceId(),
+                        c.getPlaceId(),
+                        c.getStatus(),
+                        c.getName(),
+                        c.getCategory(),
+                        c.getClassification(),
+                        c.getEstimatedDurationMin(),
+                        c.getTimeConstraint(),
+                        c.getIsAiGenerated(),
+                        c.getConflictType(),
+                        c.getConflictReason(),
+                        c.getRemind(),
+                        (c.getLat() != null && c.getLng() != null)
+                                ? new DumpResultResponse.CoordinatesDto(c.getLat(), c.getLng())
+                                : null
+                ))
+                .toList();
+
+        // TODO: AlertCard 로직 구현 후 실제 데이터로 교체
+        List<DumpResultResponse.AlertCardDto> alertCards = List.of();
+
+        return new DumpResultResponse(
+                cardDtos,
+                job.getContextSummary(),
+                alertCards
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -1,0 +1,83 @@
+package com.tripkey.domain.place;
+
+import com.tripkey.common.converter.StringListConverter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "place_cards")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlaceCard {
+
+    @Id
+    @Column(name = "instance_id", columnDefinition = "uuid")
+    private UUID instanceId;
+
+    @Column(name = "trip_id", nullable = false, columnDefinition = "uuid")
+    private UUID tripId;
+
+    @Column(name = "place_id", columnDefinition = "text")
+    private String placeId;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+
+    @Column(name = "name", nullable = false, columnDefinition = "text")
+    private String name;
+
+    @Column(name = "category", nullable = false)
+    private String category;
+
+    @Column(name = "classification", nullable = false)
+    private String classification;
+
+    @Column(name = "estimated_duration_min")
+    private Short estimatedDurationMin;
+
+    @Column(name = "time_constraint", columnDefinition = "text")
+    private String timeConstraint;
+
+    @Column(name = "is_ai_generated", nullable = false)
+    private Boolean isAiGenerated;
+
+    @Column(name = "conflict_type")
+    private String conflictType;
+
+    @Column(name = "conflict_reason", columnDefinition = "text")
+    private String conflictReason;
+
+    @Column(name = "remind", columnDefinition = "text")
+    @Convert(converter = StringListConverter.class)
+    private List<String> remind;
+
+    @Column(name = "lat")
+    private Double lat;
+
+    @Column(name = "lng")
+    private Double lng;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.instanceId = UUID.randomUUID();
+        this.createdAt = OffsetDateTime.now();
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -1,0 +1,11 @@
+package com.tripkey.domain.place;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
+
+    List<PlaceCard> findAllByTripId(UUID tripId);
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/Trip.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/Trip.java
@@ -1,0 +1,53 @@
+package com.tripkey.domain.trip;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "trips")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Trip {
+
+    @Id
+    @Column(name = "trip_id", columnDefinition = "uuid")
+    private UUID tripId;
+
+    @Column(name = "travel_days", nullable = false)
+    private Short travelDays;
+
+    @Column(name = "companion_count", nullable = false)
+    private Short companionCount;
+
+    @Column(name = "has_flight", nullable = false)
+    private Boolean hasFlight;
+
+    @Column(name = "has_accommodation", nullable = false)
+    private Boolean hasAccommodation;
+
+    @Column(name = "confirmed_at")
+    private OffsetDateTime confirmedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.tripId = UUID.randomUUID();
+        this.createdAt = OffsetDateTime.now();
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/TripRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/TripRepository.java
@@ -1,0 +1,8 @@
+package com.tripkey.domain.trip;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TripRepository extends JpaRepository<Trip, UUID> {
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/common/ErrorResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/common/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.tripkey.dto.common;
+
+public record ErrorResponse(
+        String code,
+        String message
+) {
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/dump/DumpResultResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/dump/DumpResultResponse.java
@@ -1,0 +1,41 @@
+package com.tripkey.dto.dump;
+
+import java.util.List;
+import java.util.UUID;
+
+public record DumpResultResponse(
+        List<PlaceCardDto> cards,
+        String contextSummary,
+        List<AlertCardDto> alertCards
+) {
+
+    public record PlaceCardDto(
+            UUID instanceId,
+            String placeId,
+            String status,
+            String name,
+            String category,
+            String classification,
+            Short estimatedDurationMin,
+            String timeConstraint,
+            Boolean isAiGenerated,
+            String conflictType,
+            String conflictReason,
+            List<String> remind,
+            CoordinatesDto coordinates
+    ) {
+    }
+
+    public record CoordinatesDto(
+            Double lat,
+            Double lng
+    ) {
+    }
+
+    public record AlertCardDto(
+            String type,
+            String message,
+            List<UUID> relatedInstanceIds
+    ) {
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/dump/DumpStatusResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/dump/DumpStatusResponse.java
@@ -1,0 +1,11 @@
+package com.tripkey.dto.dump;
+
+import java.util.UUID;
+
+public record DumpStatusResponse(
+        UUID jobId,
+        String status,
+        Short step,
+        String errorCode
+) {
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/dump/DumpSubmitRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/dump/DumpSubmitRequest.java
@@ -1,0 +1,11 @@
+package com.tripkey.dto.dump;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record DumpSubmitRequest(
+        @NotBlank
+        @Size(min = 10, max = 3000, message = "10자 이상 3000자 이하로 입력해주세요")
+        String dumpText
+) {
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/dump/DumpSubmitResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/dump/DumpSubmitResponse.java
@@ -1,0 +1,9 @@
+package com.tripkey.dto.dump;
+
+import java.util.UUID;
+
+public record DumpSubmitResponse(
+        UUID jobId,
+        String status
+) {
+}

--- a/apps/backend/src/main/resources/application-dev.yml
+++ b/apps/backend/src/main/resources/application-dev.yml
@@ -2,7 +2,13 @@ spring:
   config:
     activate:
       on-profile: dev
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+  datasource:
+    url: ${SUPABASE_DB_URL:}
+    username: ${SUPABASE_DB_USERNAME:postgres}
+    password: ${SUPABASE_DB_PASSWORD:}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -1,6 +1,17 @@
 spring:
   application:
     name: backend
+  datasource:
+    url: ${SUPABASE_DB_URL}
+    username: ${SUPABASE_DB_USERNAME}
+    password: ${SUPABASE_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
 
 server:
   port: 8080

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -1,0 +1,48 @@
+-- SCR-02 최소 스키마
+
+-- 여행 세션 (SCR-01 온보딩에서 생성)
+create table if not exists public.trips (
+  trip_id           uuid        primary key,                    -- 여행 세션 고유 ID
+  travel_days       smallint    not null,                       -- 여행 일수
+  companion_count   smallint    not null,                       -- 동행 인원 (1 = 혼자)
+  has_flight        boolean     not null,                       -- 항공편 보유 여부
+  has_accommodation boolean     not null,                       -- 숙소 보유 여부
+  confirmed_at      timestamptz,                                -- 일정 확정 시각 (SCR-05)
+  created_at        timestamptz not null default now(),
+  updated_at        timestamptz not null default now()
+);
+
+-- Dump 파싱 작업 (SCR-02 텍스트 제출 시 생성, SCR-02P에서 상태 폴링)
+create table if not exists public.dump_jobs (
+  job_id          uuid        primary key,                      -- 파싱 작업 고유 ID
+  trip_id         uuid        not null references public.trips(trip_id), -- 소속 여행 세션
+  dump_text       text        not null,                         -- 사용자가 입력한 자유 텍스트
+  status          varchar     not null default 'pending',       -- 작업 상태: pending / processing / completed / failed
+  step            smallint,                                     -- 파싱 진행 단계 (1~3), null이면 미시작
+  error_code      varchar,                                      -- 실패 시 오류 코드: PARSE_FAILED / NO_PLACES_FOUND
+  context_summary text,                                         -- AI가 파악한 여행 스타일 요약
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+-- 장소 카드 (AI 파싱 결과로 생성)
+create table if not exists public.place_cards (
+  instance_id            uuid        primary key,               -- 카드 인스턴스 ID (중복 장소 허용)
+  trip_id                uuid        not null references public.trips(trip_id), -- 소속 여행 세션
+  place_id               text,                                  -- Google Places place_id
+  status                 varchar     not null default 'loading', -- 카드 상태: loading / success / error
+  name                   text        not null,                   -- 장소명
+  category               varchar     not null default '미분류',   -- 카테고리: 관광 / 쇼핑 / 식사 / 숙박 / 교통 / 미분류
+  classification         varchar     not null default 'unassigned', -- 분류: confirmed / open_question / undecided / unassigned
+  estimated_duration_min smallint    default 60,                 -- 예상 체류시간 (분)
+  time_constraint        text,                                   -- 시간 제약 설명
+  is_ai_generated        boolean     not null default false,     -- AI 자동 생성 여부
+  conflict_type          varchar,                                -- 충돌 유형: timing_constraint / choice_conflict
+  conflict_reason        text,                                   -- 충돌 사유
+  remind                 text,                                   -- 방문 전 주의사항 (JSON 배열)
+  lat                    double precision,                       -- 위도
+  lng                    double precision,                       -- 경도
+  created_at             timestamptz not null default now(),
+  updated_at             timestamptz not null default now()
+);
+


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- dump api 호출 3개 구현 및 supabase 연동 및 db 스키마 작성.
- docs 폴더의 schema.sql 파일 git.ignore에서 제외

## 🔗 관련 이슈

closes #이슈번호

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [ ] 로컬에서 정상 동작 확인했나요?
- [ ] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [ ] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [ ] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게
---
  API 테스트 방법

  사전 준비

  1. .env.example을 참고하여 apps/backend/.env 파일을 작성합니다.
  2. Supabase DB 비밀번호는 팀 내부 채널에서 확인해주세요.
  3. 도커 실행:
  docker compose up --build backend
 
API 엔드포인트

1. POST /trips/{tripId}/dump - 덤프 제출

  POST http://localhost:8080/trips/550e8400-e29b-41d4-a716-446655440000/dump
  Content-Type: application/json
  {
    "dumpText": "제주도 3박 4일 여행인데 첫날은 공항 근처 카페 가고 싶고, 둘째 날은 성산일출봉이랑 섭지코지 갈 거야"
  }
  응답 (202):
  {
    "jobId": "generated-uuid",
    "status": "pending"
  }

2. GET /trips/{tripId}/dump/status - 파싱 상태 조회

  GET http://localhost:8080/trips/550e8400-e29b-41d4-a716-446655440000/dump/status
  응답 (200):
  {
    "jobId": "...",
    "status": "pending",
    "step": null,
    "errorCode": null
  }

3. GET /trips/{tripId}/dump/result - 파싱 결과 조회

  GET http://localhost:8080/trips/550e8400-e29b-41d4-a716-446655440000/dump/result
  현재 AI 파싱이 미구현이므로 409 응답:
  {
    "code": "DUMP_NOT_COMPLETED",
    "message": "파싱이 아직 완료되지 않았습니다"
  }

에러 케이스
글자 수 부족(10자 미만) - Body:{"dumpText": "제주도"}  예상 응답:  400 - DUMP_TOO_SHORT 
빈 텍스트 - Body:{"dumpText": ""} 예상 응답:  400 - DUMP_TOO_SHORT  
URL 포함 - Body: {"dumpText": "제주도 여행 https://naver.com 참고"} 예상 응답:  400 - DUMP_URL_NOT_ALLOWED
존재하지 않는 tripId: tripId를 00000000-...으로 변경 예상 응답: 404 - TRIP_NOT_FOUND

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.