### PR TITLE
feat: SCR-01 온보딩 API 구현 (여행 세션 생성, 여행지 검색)

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
@@ -42,15 +42,19 @@ public class GlobalExceptionHandler {
                 .orElse("입력값을 확인해주세요");
 
         String code = "VALIDATION_ERROR";
+        HttpStatus status = HttpStatus.UNPROCESSABLE_ENTITY;
+
         if (message.contains("blank") || message.contains("10자")) {
             code = "DUMP_TOO_SHORT";
             message = "최소 10자 이상 입력해주세요";
+            status = HttpStatus.BAD_REQUEST;
         } else if (message.contains("3000")) {
             code = "DUMP_TOO_LONG";
             message = "최대 글자 수에 도달했어요";
+            status = HttpStatus.BAD_REQUEST;
         }
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(status)
                 .body(new ErrorResponse(code, message));
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/Trip.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/Trip.java
@@ -33,6 +33,13 @@ public class Trip {
     @Column(name = "confirmed_at")
     private OffsetDateTime confirmedAt;
 
+    public Trip(Short travelDays, Short companionCount, Boolean hasFlight, Boolean hasAccommodation) {
+        this.travelDays = travelDays;
+        this.companionCount = companionCount;
+        this.hasFlight = hasFlight;
+        this.hasAccommodation = hasAccommodation;
+    }
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/TripController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/TripController.java
@@ -1,0 +1,30 @@
+package com.tripkey.domain.trip;
+
+import com.tripkey.dto.trip.DestinationSearchResponse;
+import com.tripkey.dto.trip.TripCreateRequest;
+import com.tripkey.dto.trip.TripCreateResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/trips")
+@RequiredArgsConstructor
+public class TripController {
+
+    private final TripService tripService;
+
+    @GetMapping("/destinations/search")
+    public ResponseEntity<DestinationSearchResponse> searchDestinations(@RequestParam String q) {
+        DestinationSearchResponse response = tripService.searchDestinations(q);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<TripCreateResponse> create(@Valid @RequestBody TripCreateRequest request) {
+        TripCreateResponse response = tripService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/TripDestination.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/TripDestination.java
@@ -1,0 +1,33 @@
+package com.tripkey.domain.trip;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "trip_destinations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TripDestination {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id", nullable = false)
+    private Trip trip;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "sort_order", nullable = false)
+    private Short sortOrder;
+
+    public TripDestination(Trip trip, String name, Short sortOrder) {
+        this.trip = trip;
+        this.name = name;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/TripDestinationRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/TripDestinationRepository.java
@@ -1,0 +1,11 @@
+package com.tripkey.domain.trip;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TripDestinationRepository extends JpaRepository<TripDestination, Long> {
+
+    List<TripDestination> findByTripTripIdOrderBySortOrder(UUID tripId);
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/TripService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/TripService.java
@@ -1,0 +1,68 @@
+package com.tripkey.domain.trip;
+
+import com.tripkey.dto.trip.DestinationSearchResponse;
+import com.tripkey.dto.trip.DestinationSearchResponse.DestinationDto;
+import com.tripkey.dto.trip.TripCreateRequest;
+import com.tripkey.dto.trip.TripCreateResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TripService {
+
+    private final TripRepository tripRepository;
+    private final TripDestinationRepository tripDestinationRepository;
+
+    private static final List<DestinationDto> FALLBACK_DESTINATIONS = List.of(
+            new DestinationDto("오사카", "일본", null),
+            new DestinationDto("도쿄", "일본", null),
+            new DestinationDto("교토", "일본", null),
+            new DestinationDto("후쿠오카", "일본", null),
+            new DestinationDto("방콕", "태국", null),
+            new DestinationDto("파리", "프랑스", null),
+            new DestinationDto("런던", "영국", null),
+            new DestinationDto("뉴욕", "미국", null),
+            new DestinationDto("하노이", "베트남", null),
+            new DestinationDto("다낭", "베트남", null),
+            new DestinationDto("싱가포르", "싱가포르", null),
+            new DestinationDto("타이베이", "대만", null)
+    );
+
+    @Transactional(readOnly = true)
+    public DestinationSearchResponse searchDestinations(String query) {
+        // TODO: Google Places API 연동 후 실제 검색으로 교체
+        List<DestinationDto> filtered = FALLBACK_DESTINATIONS.stream()
+                .filter(d -> d.name().contains(query) || d.country().contains(query))
+                .toList();
+
+        return new DestinationSearchResponse(filtered);
+    }
+
+    @Transactional
+    public TripCreateResponse create(TripCreateRequest request) {
+        Trip trip = new Trip(
+                request.travelDays(),
+                request.companionCount(),
+                request.hasFlight(),
+                request.hasAccommodation()
+        );
+        tripRepository.save(trip);
+
+        for (short i = 0; i < request.destinations().size(); i++) {
+            TripDestination destination = new TripDestination(
+                    trip,
+                    request.destinations().get(i),
+                    i
+            );
+            tripDestinationRepository.save(destination);
+        }
+
+        return new TripCreateResponse(trip.getTripId(), trip.getCreatedAt());
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/trip/DestinationSearchResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/trip/DestinationSearchResponse.java
@@ -1,0 +1,14 @@
+package com.tripkey.dto.trip;
+
+import java.util.List;
+
+public record DestinationSearchResponse(
+        List<DestinationDto> results
+) {
+    public record DestinationDto(
+            String name,
+            String country,
+            String placeId
+    ) {
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/trip/TripCreateRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/trip/TripCreateRequest.java
@@ -1,0 +1,30 @@
+package com.tripkey.dto.trip;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record TripCreateRequest(
+        @NotEmpty(message = "여행지를 하나 이상 선택해주세요")
+        List<String> destinations,
+
+        @NotNull(message = "여행 일수를 입력해주세요")
+        @Min(value = 1, message = "여행 일수는 1일 이상이어야 해요")
+        @Max(value = 30, message = "여행 일수는 30일 이하여야 해요")
+        Short travelDays,
+
+        @NotNull(message = "동행 인원을 입력해주세요")
+        @Min(value = 1, message = "동행 인원은 1명 이상이어야 해요")
+        @Max(value = 20, message = "동행 인원은 20명 이하여야 해요")
+        Short companionCount,
+
+        @NotNull(message = "항공편 보유 여부를 선택해주세요")
+        Boolean hasFlight,
+
+        @NotNull(message = "숙소 보유 여부를 선택해주세요")
+        Boolean hasAccommodation
+) {
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/trip/TripCreateResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/trip/TripCreateResponse.java
@@ -1,0 +1,10 @@
+package com.tripkey.dto.trip;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record TripCreateResponse(
+        UUID tripId,
+        OffsetDateTime createdAt
+) {
+}

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -12,6 +12,14 @@ create table if not exists public.trips (
   updated_at        timestamptz not null default now()
 );
 
+-- 여행지 목록 (SCR-01 온보딩에서 저장)
+create table if not exists public.trip_destinations (
+  id          bigserial   primary key,
+  trip_id     uuid        not null references public.trips(trip_id),
+  name        text        not null,                                 -- 여행지명
+  sort_order  smallint    not null default 0                        -- 정렬 순서
+);
+
 -- Dump 파싱 작업 (SCR-02 텍스트 제출 시 생성, SCR-02P에서 상태 폴링)
 create table if not exists public.dump_jobs (
   job_id          uuid        primary key,                      -- 파싱 작업 고유 ID


### PR DESCRIPTION
## 📝 작업 내용

> SCR-01 온보딩 API 구현 (여행 세션 생성, 여행지 검색)
- POST /trips: 여행 세션 생성 API (trip_id, created_at 반환)
- GET /trips/destinations/search: 여행지 퍼지서치 API (fallback 목록 기반)                                                                                                 
- trip_destinations 테이블 및 JPA 엔티티 추가                             
- 입력 유효성 오류 시 422 VALIDATION_ERROR 반환

## 🔗 관련 이슈

closes #34 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [ ] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [ ] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게
- 여행지 검색은 Google Places API 연동 전이라 fallback 목록에서 필터링하는 방식으로 구현했습니다.                                                                          

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.