### PR TITLE
Feat/scr 02 dump integration

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
@@ -1,0 +1,82 @@
+package com.tripkey.domain.dump;
+
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.Trip;
+import com.tripkey.domain.trip.TripDestination;
+import com.tripkey.domain.trip.TripDestinationRepository;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiParseRequest;
+import com.tripkey.infra.aiengine.dto.AiParseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DumpAsyncProcessor {
+
+    private final DumpJobRepository dumpJobRepository;
+    private final TripRepository tripRepository;
+    private final TripDestinationRepository tripDestinationRepository;
+    private final PlaceCardRepository placeCardRepository;
+    private final AiEngineClient aiEngineClient;
+
+    @Async("dumpTaskExecutor")
+    public void process(UUID jobId) {
+        DumpJob job = dumpJobRepository.findById(jobId).orElse(null);
+        if (job == null) {
+            log.warn("Dump job not found. jobId={}", jobId);
+            return;
+        }
+
+        job.markProcessing((short) 1);
+        dumpJobRepository.save(job);
+
+        try {
+            Trip trip = tripRepository.findById(job.getTripId())
+                    .orElseThrow(() -> new IllegalStateException("Trip not found for dump job"));
+
+            String destinations = tripDestinationRepository.findByTripTripIdOrderBySortOrder(job.getTripId()).stream()
+                    .map(TripDestination::getName)
+                    .distinct()
+                    .reduce((left, right) -> left + ", " + right)
+                    .orElse(null);
+
+            AiParseResponse response = aiEngineClient.parseDump(
+                    new AiParseRequest(job.getDumpText(), destinations, trip.getTravelDays())
+            );
+
+            job.updateStep((short) 2);
+            dumpJobRepository.save(job);
+
+            List<PlaceCard> cards = response.cards() == null
+                    ? List.of()
+                    : response.cards().stream()
+                    .map(card -> PlaceCard.createFromAiResponse(job.getTripId(), card))
+                    .toList();
+
+            placeCardRepository.deleteAllByTripId(job.getTripId());
+
+            if (cards.isEmpty()) {
+                job.fail("NO_PLACES_FOUND");
+                dumpJobRepository.save(job);
+                return;
+            }
+
+            placeCardRepository.saveAll(cards);
+            job.complete(response.contextSummary());
+            dumpJobRepository.save(job);
+        } catch (Exception e) {
+            log.error("Failed to parse dump job. jobId={}", jobId, e);
+            job.fail("PARSE_FAILED");
+            dumpJobRepository.save(job);
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +30,7 @@ public class DumpAsyncProcessor {
     private final AiEngineClient aiEngineClient;
 
     @Async("dumpTaskExecutor")
+    @Transactional
     public void process(UUID jobId) {
         DumpJob job = dumpJobRepository.findById(jobId).orElse(null);
         if (job == null) {

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJob.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJob.java
@@ -60,6 +60,12 @@ public class DumpJob {
         this.step = step;
     }
 
+    public void markProcessing(Short step) {
+        this.status = "processing";
+        this.step = step;
+        this.errorCode = null;
+    }
+
     public void fail(String errorCode) {
         this.status = "failed";
         this.errorCode = errorCode;
@@ -67,6 +73,8 @@ public class DumpJob {
 
     public void complete(String contextSummary) {
         this.status = "completed";
+        this.step = 3;
+        this.errorCode = null;
         this.contextSummary = contextSummary;
     }
 

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpService.java
@@ -29,8 +29,8 @@ public class DumpService {
     private final DumpJobRepository dumpJobRepository;
     private final PlaceCardRepository placeCardRepository;
     private final TripRepository tripRepository;
+    private final DumpAsyncProcessor dumpAsyncProcessor;
 
-    @Transactional
     public DumpSubmitResponse submit(UUID tripId, String dumpText) {
         if (!tripRepository.existsById(tripId)) {
             throw new TripNotFoundException(tripId);
@@ -42,8 +42,7 @@ public class DumpService {
 
         DumpJob job = DumpJob.create(tripId, dumpText);
         dumpJobRepository.save(job);
-
-        // TODO: AI Engine 비동기 호출 (파싱 요청)
+        dumpAsyncProcessor.process(job.getJobId());
 
         return new DumpSubmitResponse(job.getJobId(), job.getStatus());
     }

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -1,6 +1,7 @@
 package com.tripkey.domain.place;
 
 import com.tripkey.common.converter.StringListConverter;
+import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -69,6 +70,29 @@ public class PlaceCard {
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
 
+    public static PlaceCard createFromAiResponse(UUID tripId, AiPlaceCardDto dto) {
+        PlaceCard card = new PlaceCard();
+        card.tripId = tripId;
+        card.placeId = dto.placeId();
+        card.status = normalizeStatus(dto.status());
+        card.name = defaultString(dto.name(), "이름 미정");
+        card.category = defaultString(dto.category(), "미분류");
+        card.classification = normalizeClassification(dto.classification());
+        card.estimatedDurationMin = dto.estimatedDurationMin() != null ? dto.estimatedDurationMin() : (short) 60;
+        card.timeConstraint = dto.timeConstraint();
+        card.isAiGenerated = true;
+        card.conflictType = dto.conflictType();
+        card.conflictReason = dto.conflictReason();
+        card.remind = dto.remind() != null ? dto.remind() : List.of();
+
+        if (dto.coordinates() != null) {
+            card.lat = dto.coordinates().lat();
+            card.lng = dto.coordinates().lng();
+        }
+
+        return card;
+    }
+
     @PrePersist
     protected void onCreate() {
         this.instanceId = UUID.randomUUID();
@@ -79,5 +103,35 @@ public class PlaceCard {
     @PreUpdate
     protected void onUpdate() {
         this.updatedAt = OffsetDateTime.now();
+    }
+
+    private static String normalizeStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return "success";
+        }
+
+        return switch (status.toLowerCase()) {
+            case "failure", "error" -> "error";
+            case "loading" -> "loading";
+            default -> "success";
+        };
+    }
+
+    private static String normalizeClassification(String classification) {
+        if (classification == null || classification.isBlank()) {
+            return "undecided";
+        }
+
+        return switch (classification.toLowerCase()) {
+            case "confirmed" -> "confirmed";
+            case "open_question" -> "open_question";
+            case "unassigned" -> "unassigned";
+            case "undecided", "unconfirmed" -> "undecided";
+            default -> "undecided";
+        };
+    }
+
+    private static String defaultString(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -1,6 +1,10 @@
 package com.tripkey.domain.place;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -9,5 +13,8 @@ public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
 
     List<PlaceCard> findAllByTripId(UUID tripId);
 
-    void deleteAllByTripId(UUID tripId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("delete from PlaceCard p where p.tripId = :tripId")
+    void deleteAllByTripId(@Param("tripId") UUID tripId);
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -8,4 +8,6 @@ import java.util.UUID;
 public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
 
     List<PlaceCard> findAllByTripId(UUID tripId);
+
+    void deleteAllByTripId(UUID tripId);
 }

--- a/apps/backend/src/main/java/com/tripkey/global/config/AsyncConfig.java
+++ b/apps/backend/src/main/java/com/tripkey/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.tripkey.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "dumpTaskExecutor")
+    public Executor dumpTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("dump-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/global/config/WebClientConfig.java
+++ b/apps/backend/src/main/java/com/tripkey/global/config/WebClientConfig.java
@@ -1,0 +1,30 @@
+package com.tripkey.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient aiEngineWebClient(
+            @Value("${app.ai-engine.base-url}") String aiEngineBaseUrl
+    ) {
+        HttpClient httpClient = HttpClient.create()
+                .responseTimeout(Duration.ofSeconds(20));
+
+        return WebClient.builder()
+                .baseUrl(aiEngineBaseUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
@@ -1,0 +1,35 @@
+package com.tripkey.infra.aiengine;
+
+import com.tripkey.infra.aiengine.dto.AiParseRequest;
+import com.tripkey.infra.aiengine.dto.AiParseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Component
+@RequiredArgsConstructor
+public class AiEngineClient {
+
+    private final WebClient aiEngineWebClient;
+
+    public AiParseResponse parseDump(AiParseRequest request) {
+        try {
+            AiParseResponse response = aiEngineWebClient.post()
+                    .uri("/internal/ai/parse")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(AiParseResponse.class)
+                    .block();
+
+            if (response == null) {
+                throw new IllegalStateException("ai-engine returned an empty response body");
+            }
+
+            return response;
+        } catch (WebClientResponseException | WebClientRequestException e) {
+            throw new IllegalStateException("Failed to call ai-engine parse endpoint", e);
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiParseRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiParseRequest.java
@@ -1,0 +1,11 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AiParseRequest(
+        String text,
+        String destination,
+        @JsonProperty("travel_days")
+        Short travelDays
+) {
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiParseResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiParseResponse.java
@@ -1,0 +1,12 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record AiParseResponse(
+        List<AiPlaceCardDto> cards,
+        @JsonProperty("context_summary")
+        String contextSummary
+) {
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiPlaceCardDto.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiPlaceCardDto.java
@@ -1,0 +1,33 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record AiPlaceCardDto(
+        @JsonProperty("place_id")
+        String placeId,
+        @JsonProperty("instance_id")
+        String instanceId,
+        String name,
+        String category,
+        String classification,
+        @JsonProperty("estimated_duration_min")
+        Short estimatedDurationMin,
+        Coordinates coordinates,
+        String status,
+        @JsonProperty("time_constraint")
+        String timeConstraint,
+        @JsonProperty("conflict_type")
+        String conflictType,
+        @JsonProperty("conflict_reason")
+        String conflictReason,
+        List<String> remind
+) {
+
+    public record Coordinates(
+            Double lat,
+            Double lng
+    ) {
+    }
+}

--- a/apps/backend/src/main/resources/application-dev.yml
+++ b/apps/backend/src/main/resources/application-dev.yml
@@ -6,6 +6,16 @@ spring:
     url: ${SUPABASE_DB_URL}
     username: ${SUPABASE_DB_USERNAME}
     password: ${SUPABASE_DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 2
+      minimum-idle: 0
+      idle-timeout: 10000
+      keepalive-time: 0
+      max-lifetime: 30000
+      connection-timeout: 10000
+      data-source-properties:
+        prepareThreshold: 0
+        preparedStatementCacheQueries: 0
   jpa:
     hibernate:
       ddl-auto: validate

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
 
 server:
   port: 8080
+
+app:
+  ai-engine:
+    base-url: ${AI_ENGINE_URL:http://tripkey-ai-engine:8000}

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: backend
+  jackson:
+    property-naming-strategy: SNAKE_CASE
   datasource:
     url: ${SUPABASE_DB_URL}
     username: ${SUPABASE_DB_USERNAME}
@@ -16,6 +18,8 @@ spring:
 
 server:
   port: 8080
+  servlet:
+    context-path: /v1
 
 app:
   ai-engine:

--- a/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
+++ b/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
@@ -1,0 +1,98 @@
+package com.tripkey.common.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tripkey.dto.dump.DumpResultResponse;
+import com.tripkey.dto.dump.DumpStatusResponse;
+import com.tripkey.dto.trip.TripCreateResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JsonTest
+class JsonNamingStrategyTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void serializesTopLevelResponseFieldsAsSnakeCase() throws Exception {
+        TripCreateResponse tripResponse = new TripCreateResponse(UUID.randomUUID(), OffsetDateTime.parse("2026-04-13T12:00:00Z"));
+        DumpStatusResponse dumpStatusResponse = new DumpStatusResponse(UUID.randomUUID(), "completed", (short) 3, "PARSE_FAILED");
+
+        String tripJson = objectMapper.writeValueAsString(tripResponse);
+        String dumpStatusJson = objectMapper.writeValueAsString(dumpStatusResponse);
+
+        assertThat(tripJson)
+                .contains("trip_id")
+                .contains("created_at")
+                .doesNotContain("tripId")
+                .doesNotContain("createdAt");
+
+        assertThat(dumpStatusJson)
+                .contains("job_id")
+                .contains("error_code")
+                .doesNotContain("jobId")
+                .doesNotContain("errorCode");
+    }
+
+    @Test
+    void serializesNestedResponseFieldsAsSnakeCase() throws Exception {
+        DumpResultResponse response = new DumpResultResponse(
+                List.of(
+                        new DumpResultResponse.PlaceCardDto(
+                                UUID.randomUUID(),
+                                "place-1",
+                                "success",
+                                "Dotonbori",
+                                "tour",
+                                "confirmed",
+                                (short) 90,
+                                "night_only",
+                                true,
+                                "duplicate",
+                                "already added",
+                                List.of("visit at night"),
+                                new DumpResultResponse.CoordinatesDto(34.6687, 135.5013)
+                        )
+                ),
+                "Osaka city route",
+                List.of(
+                        new DumpResultResponse.AlertCardDto(
+                                "warning",
+                                "Review this card",
+                                List.of(UUID.randomUUID())
+                        )
+                )
+        );
+
+        String json = objectMapper.writeValueAsString(response);
+
+        assertThat(json)
+                .contains("context_summary")
+                .contains("alert_cards")
+                .contains("instance_id")
+                .contains("place_id")
+                .contains("estimated_duration_min")
+                .contains("time_constraint")
+                .contains("is_ai_generated")
+                .contains("conflict_type")
+                .contains("conflict_reason")
+                .contains("related_instance_ids")
+                .doesNotContain("contextSummary")
+                .doesNotContain("alertCards")
+                .doesNotContain("instanceId")
+                .doesNotContain("placeId")
+                .doesNotContain("estimatedDurationMin")
+                .doesNotContain("timeConstraint")
+                .doesNotContain("isAiGenerated")
+                .doesNotContain("conflictType")
+                .doesNotContain("conflictReason")
+                .doesNotContain("relatedInstanceIds");
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
@@ -1,0 +1,90 @@
+package com.tripkey.domain.dump;
+
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.Trip;
+import com.tripkey.domain.trip.TripDestination;
+import com.tripkey.domain.trip.TripDestinationRepository;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiParseResponse;
+import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DumpAsyncProcessorTest {
+
+    @Mock
+    private DumpJobRepository dumpJobRepository;
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private TripDestinationRepository tripDestinationRepository;
+
+    @Mock
+    private PlaceCardRepository placeCardRepository;
+
+    @Mock
+    private AiEngineClient aiEngineClient;
+
+    @InjectMocks
+    private DumpAsyncProcessor dumpAsyncProcessor;
+
+    @Test
+    void processMarksJobCompletedAndStoresParsedCards() {
+        UUID tripId = UUID.randomUUID();
+        DumpJob job = DumpJob.create(tripId, "오사카 3박4일 여행입니다.");
+        Trip trip = new Trip((short) 4, (short) 2, false, false);
+        TripDestination destination = new TripDestination(trip, "오사카", (short) 0);
+
+        AiParseResponse response = new AiParseResponse(
+                List.of(
+                        new AiPlaceCardDto(
+                                "place-1",
+                                null,
+                                "도톤보리",
+                                "관광",
+                                "confirmed",
+                                (short) 90,
+                                new AiPlaceCardDto.Coordinates(34.6687, 135.5013),
+                                "success",
+                                null,
+                                null,
+                                null,
+                                List.of("야간 방문 추천")
+                        )
+                ),
+                "오사카 시내 중심 동선"
+        );
+
+        when(dumpJobRepository.findById(job.getJobId())).thenReturn(Optional.of(job));
+        when(dumpJobRepository.save(any(DumpJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
+        when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(tripId)).thenReturn(List.of(destination));
+        when(aiEngineClient.parseDump(any())).thenReturn(response);
+
+        dumpAsyncProcessor.process(job.getJobId());
+
+        verify(placeCardRepository).deleteAllByTripId(tripId);
+        verify(placeCardRepository).saveAll(any());
+
+        assertThat(job.getStatus()).isEqualTo("completed");
+        assertThat(job.getStep()).isEqualTo((short) 3);
+        assertThat(job.getContextSummary()).isEqualTo("오사카 시내 중심 동선");
+        assertThat(job.getErrorCode()).isNull();
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpServiceTest.java
@@ -1,0 +1,55 @@
+package com.tripkey.domain.dump;
+
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.dump.DumpSubmitResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DumpServiceTest {
+
+    @Mock
+    private DumpJobRepository dumpJobRepository;
+
+    @Mock
+    private PlaceCardRepository placeCardRepository;
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private DumpAsyncProcessor dumpAsyncProcessor;
+
+    @InjectMocks
+    private DumpService dumpService;
+
+    @Test
+    void submitStartsAsyncParseAfterCreatingDumpJob() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(dumpJobRepository.save(any(DumpJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DumpSubmitResponse response = dumpService.submit(tripId, "오사카 3박4일 여행입니다.");
+
+        ArgumentCaptor<DumpJob> jobCaptor = ArgumentCaptor.forClass(DumpJob.class);
+        verify(dumpJobRepository).save(jobCaptor.capture());
+        verify(dumpAsyncProcessor).process(response.jobId());
+
+        DumpJob savedJob = jobCaptor.getValue();
+        assertThat(savedJob.getTripId()).isEqualTo(tripId);
+        assertThat(response.jobId()).isEqualTo(savedJob.getJobId());
+        assertThat(response.status()).isEqualTo("pending");
+    }
+}

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://backend:8080/;
+        proxy_pass http://backend:8080/v1/;
         proxy_http_version 1.1;
 
         proxy_set_header Host $host;

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8080',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+        rewrite: (path) => path.replace(/^\/api/, '/v1'),
       },
     },
   },


### PR DESCRIPTION
## 📝 작업 내용

> dump 입력 이후 backend가 ai-engine parse를 비동기로 호출해 place_cards를 생성하고, API 응답 JSON 필드를 snake_case로 통일했습니다. frontend/backend 프록시 경로를 /api -> /v1로 정렬하고, nginx 프록시 경로를 /v1 으로 수정하였습니다.

## 🔗 관련 이슈

closes #45

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [ ] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 테스트 방법
파싱 연동은 아래 시나리오로 확인 부탁드립니다. (응답/요청 JSON 필드는 snake_case 기준)
 1 Trip 생성
  curl -i -X POST http://localhost:8080/v1/trips \
    -H "Content-Type: application/json" \
    -d '{
      "destinations": ["오사카"],
      "travel_days": 4,
      "companion_count": 2,
      "has_flight": false,
      "has_accommodation": false
    }'

  - 기대값: 201, 응답에 trip_id, created_at

  2. Dump 제출 (파싱 시작)

  curl -i -X POST http://localhost:8080/v1/trips/{trip_id}/dump \
    -H "Content-Type: application/json" \
    -d '{
      "dump_text": "오사카 3박4일 여행이고 도톤보리, 유니버설, 오사카성 위주로 동선 추천해줘"
    }'

  - 기대값: 202, 응답에 job_id, status (pending)

  3. 상태 폴링

  curl -s http://localhost:8080/v1/trips/{trip_id}/dump/status

  - 기대값: 최종적으로 status=completed, step=3
  - 실패 시 status=failed, error_code (PARSE_FAILED 또는 NO_PLACES_FOUND)

  4. 결과 조회

  curl -s http://localhost:8080/v1/trips/{trip_id}/dump/result

  - 기대값: cards 배열과 context_summary 반환
  - 필드가 snake_case인지 확인 (instance_id, place_id, estimated_duration_min, is_ai_generated 등)

  추가 실패 케이스 확인:

  - dump_text에 URL 포함 시 400 + DUMP_URL_NOT_ALLOWED
  - 완료 전 /result 호출 시 409 + DUMP_NOT_COMPLETED

(전효빈) --- 추가사항: .env 내 Supabase 포트를 6543으로 변경후 빌드 진행 필요