### PR TITLE
Fix/49/normalize dump validation errors and PlaceCard input mapping

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.tripkey.common.exception;
 import com.tripkey.dto.common.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -36,22 +37,28 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
-        String message = e.getBindingResult().getFieldErrors().stream()
+        FieldError fieldError = e.getBindingResult().getFieldErrors().stream()
                 .findFirst()
-                .map(f -> f.getDefaultMessage())
-                .orElse("입력값을 확인해주세요");
-
+                .orElse(null);
+        String message = fieldError != null ? fieldError.getDefaultMessage() : "입력값을 확인해주세요";
         String code = "VALIDATION_ERROR";
         HttpStatus status = HttpStatus.UNPROCESSABLE_ENTITY;
 
-        if (message.contains("blank") || message.contains("10자")) {
-            code = "DUMP_TOO_SHORT";
-            message = "최소 10자 이상 입력해주세요";
-            status = HttpStatus.BAD_REQUEST;
-        } else if (message.contains("3000")) {
-            code = "DUMP_TOO_LONG";
-            message = "최대 글자 수에 도달했어요";
-            status = HttpStatus.BAD_REQUEST;
+        if (fieldError != null && "dumpText".equals(fieldError.getField())) {
+            String validationCode = fieldError.getCode();
+            String value = fieldError.getRejectedValue() == null
+                    ? ""
+                    : String.valueOf(fieldError.getRejectedValue()).trim();
+
+            if ("NotBlank".equals(validationCode) || value.length() < 10) {
+                code = "DUMP_TOO_SHORT";
+                message = "최소 10자 이상 입력해주세요";
+                status = HttpStatus.BAD_REQUEST;
+            } else if ("Size".equals(validationCode) && value.length() > 3000) {
+                code = "DUMP_TOO_LONG";
+                message = "최대 글자 수에 도달했어요";
+                status = HttpStatus.BAD_REQUEST;
+            }
         }
 
         return ResponseEntity.status(status)

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 @Entity
@@ -73,15 +74,15 @@ public class PlaceCard {
     public static PlaceCard createFromAiResponse(UUID tripId, AiPlaceCardDto dto) {
         PlaceCard card = new PlaceCard();
         card.tripId = tripId;
-        card.placeId = dto.placeId();
+        card.placeId = normalizePlaceId(dto.placeId());
         card.status = normalizeStatus(dto.status());
         card.name = defaultString(dto.name(), "이름 미정");
-        card.category = defaultString(dto.category(), "미분류");
+        card.category = normalizeCategory(dto.category());
         card.classification = normalizeClassification(dto.classification());
         card.estimatedDurationMin = dto.estimatedDurationMin() != null ? dto.estimatedDurationMin() : (short) 60;
         card.timeConstraint = dto.timeConstraint();
         card.isAiGenerated = true;
-        card.conflictType = dto.conflictType();
+        card.conflictType = normalizeConflictType(dto.conflictType());
         card.conflictReason = dto.conflictReason();
         card.remind = dto.remind() != null ? dto.remind() : List.of();
 
@@ -129,6 +130,43 @@ public class PlaceCard {
             case "undecided", "unconfirmed" -> "undecided";
             default -> "undecided";
         };
+    }
+
+    private static String normalizeCategory(String category) {
+        if (category == null || category.isBlank()) {
+            return "미분류";
+        }
+
+        String normalized = category.trim().toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "관광", "tour", "attraction", "sightseeing", "landmark" -> "관광";
+            case "쇼핑", "shopping", "mart", "market" -> "쇼핑";
+            case "식사", "food", "dining", "restaurant", "cafe", "카페" -> "식사";
+            case "숙박", "stay", "lodging", "hotel", "accommodation" -> "숙박";
+            case "교통", "transport", "transportation", "transit" -> "교통";
+            case "미분류", "unknown", "other" -> "미분류";
+            default -> "미분류";
+        };
+    }
+
+    private static String normalizeConflictType(String conflictType) {
+        if (conflictType == null || conflictType.isBlank()) {
+            return null;
+        }
+
+        String normalized = conflictType.trim().toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "timing_constraint", "time_constraint", "timing", "time" -> "timing_constraint";
+            case "choice_conflict", "duplicate", "duplication", "choice" -> "choice_conflict";
+            default -> null;
+        };
+    }
+
+    private static String normalizePlaceId(String placeId) {
+        if (placeId == null || placeId.isBlank()) {
+            return "unknown:" + UUID.randomUUID();
+        }
+        return placeId.trim();
     }
 
     private static String defaultString(String value, String fallback) {

--- a/apps/backend/src/test/java/com/tripkey/common/exception/GlobalExceptionHandlerTest.java
+++ b/apps/backend/src/test/java/com/tripkey/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,96 @@
+package com.tripkey.common.exception;
+
+import com.tripkey.dto.common.ErrorResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleValidationReturnsDumpTooShortForBlankDumpText() throws Exception {
+        MethodArgumentNotValidException exception = buildValidationException(
+                "dumpText",
+                " ",
+                "NotBlank",
+                "must not be blank"
+        );
+
+        ResponseEntity<ErrorResponse> response = handler.handleValidation(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("DUMP_TOO_SHORT");
+        assertThat(response.getBody().message()).isEqualTo("최소 10자 이상 입력해주세요");
+    }
+
+    @Test
+    void handleValidationReturnsDumpTooLongForOverLimitDumpText() throws Exception {
+        MethodArgumentNotValidException exception = buildValidationException(
+                "dumpText",
+                "a".repeat(3001),
+                "Size",
+                "10자 이상 3000자 이하로 입력해주세요"
+        );
+
+        ResponseEntity<ErrorResponse> response = handler.handleValidation(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("DUMP_TOO_LONG");
+        assertThat(response.getBody().message()).isEqualTo("최대 글자 수에 도달했어요");
+    }
+
+    @Test
+    void handleValidationKeepsGenericValidationErrorForOtherFields() throws Exception {
+        MethodArgumentNotValidException exception = buildValidationException(
+                "travelDays",
+                null,
+                "NotNull",
+                "여행 일수를 입력해주세요"
+        );
+
+        ResponseEntity<ErrorResponse> response = handler.handleValidation(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("VALIDATION_ERROR");
+        assertThat(response.getBody().message()).isEqualTo("여행 일수를 입력해주세요");
+    }
+
+    private MethodArgumentNotValidException buildValidationException(
+            String field,
+            Object rejectedValue,
+            String validationCode,
+            String defaultMessage
+    ) throws NoSuchMethodException {
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "request");
+        bindingResult.addError(new FieldError(
+                "request",
+                field,
+                rejectedValue,
+                false,
+                new String[]{validationCode},
+                null,
+                defaultMessage
+        ));
+
+        Method method = GlobalExceptionHandlerTest.class.getDeclaredMethod("dummyValidatedMethod", String.class);
+        MethodParameter methodParameter = new MethodParameter(method, 0);
+        return new MethodArgumentNotValidException(methodParameter, bindingResult);
+    }
+
+    @SuppressWarnings("unused")
+    private void dummyValidatedMethod(String ignored) {
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardTest.java
@@ -1,0 +1,81 @@
+package com.tripkey.domain.place;
+
+import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaceCardTest {
+
+    @Test
+    void createFromAiResponseNormalizesCategoryAndConflictType() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                "place-1",
+                null,
+                "Dotonbori",
+                "restaurant",
+                "confirmed",
+                (short) 90,
+                null,
+                "success",
+                null,
+                "duplicate",
+                null,
+                List.of("visit at night")
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto);
+
+        assertThat(card.getCategory()).isEqualTo("식사");
+        assertThat(card.getConflictType()).isEqualTo("choice_conflict");
+        assertThat(card.getPlaceId()).isEqualTo("place-1");
+    }
+
+    @Test
+    void createFromAiResponseFallsBackForUnknownCategoryAndConflictType() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                "place-2",
+                null,
+                "Unknown Spot",
+                "museum",
+                "confirmed",
+                (short) 60,
+                null,
+                "success",
+                null,
+                "something_else",
+                null,
+                List.of()
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto);
+
+        assertThat(card.getCategory()).isEqualTo("미분류");
+        assertThat(card.getConflictType()).isNull();
+    }
+
+    @Test
+    void createFromAiResponseGeneratesFallbackPlaceIdWhenMissing() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                "   ",
+                null,
+                "No Place Id",
+                "tour",
+                "confirmed",
+                (short) 60,
+                null,
+                "success",
+                null,
+                null,
+                null,
+                List.of()
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto);
+
+        assertThat(card.getPlaceId()).startsWith("unknown:");
+    }
+}


### PR DESCRIPTION
## 작업 내용
- `GlobalExceptionHandler`의 `dumpText` 검증 예외 처리 로직을 정규화했습니다.
- 검증 결과를 `DUMP_TOO_SHORT`, `DUMP_TOO_LONG` 오류 코드/메시지로 일관되게 매핑했습니다.
- `PlaceCard.createFromAiResponse` 입력 정규화를 보강했습니다.
  - `category` canonical 매핑
  - `conflictType` canonical 매핑
  - `placeId` 누락 시 `unknown:{UUID}` fallback 생성
- 위 동작을 검증하는 단위 테스트를 추가했습니다.

## 변경 파일
- `apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java`
- `apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java`
- `apps/backend/src/test/java/com/tripkey/common/exception/GlobalExceptionHandlerTest.java`
- `apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardTest.java`

## 이슈 연동
- Closes #49
