### PR TITLE
Fix/69 align ai engine parse schema

### DIFF
--- a/apps/ai-engine/app/main.py
+++ b/apps/ai-engine/app/main.py
@@ -78,17 +78,24 @@ def health() -> dict[str, str]:
 
 # --- [build prompt] --- #
 def build_prompt(req: ParseRequest) -> str:
+    destination = req.destination if req.destination else "not provided"
+    travel_days = req.travel_days if req.travel_days is not None else "not provided"
+    trip_id = req.trip_id if req.trip_id else "not provided"
+
     return f"""
     Parse the user's dump text into travel place candidate cards.
 
     Input:
-    - trip_id: {req.trip_id}
-    - dump_text: {req.dump_text}
+    - trip_id: {trip_id}
+    - destination: {destination}
+    - travel_days: {travel_days}
+    - text: {req.text}
 
     Follow all rules below.
     - Return exactly one JSON object.
     - Do not return markdown, code fences, explanations, or comments.
     - The cards array must not be empty.
+    - Use destination and travel_days as grounding context when they are provided.
     - If the input only contains a city or destination, return at least 3 likely place cards.
     - Only return places that are likely to exist in the real world.
     - Do not generate instance_id.

--- a/apps/ai-engine/app/schemas/parse.py
+++ b/apps/ai-engine/app/schemas/parse.py
@@ -14,8 +14,10 @@ class AlertCard(BaseModel):
 class ParseRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    trip_id: str
-    dump_text: str
+    text: str
+    destination: str | None = None
+    travel_days: int | None = None
+    trip_id: str | None = None
 
 
 class ParseResponse(BaseModel):

--- a/apps/backend/src/main/java/com/tripkey/controller/AiTestController.java
+++ b/apps/backend/src/main/java/com/tripkey/controller/AiTestController.java
@@ -1,9 +1,8 @@
 package com.tripkey.controller;
 
+import com.tripkey.infra.aiengine.dto.AiParseRequest;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/test/ai")
@@ -11,7 +10,7 @@ public class AiTestController {
     private final RestTemplate restTemplate = new RestTemplate();
 
     @PostMapping("/parse")
-    public Object test(@RequestBody Map<String, String> body) {
+    public Object test(@RequestBody AiParseRequest body) {
         String aiUrl = "http://tripkey-ai-engine:8000/internal/ai/parse";
 
         return restTemplate.postForObject(aiUrl, body, Object.class);

--- a/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
+++ b/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tripkey.dto.dump.DumpResultResponse;
 import com.tripkey.dto.dump.DumpStatusResponse;
 import com.tripkey.dto.trip.TripCreateResponse;
+import com.tripkey.infra.aiengine.dto.AiParseRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
@@ -94,5 +95,24 @@ class JsonNamingStrategyTest {
                 .doesNotContain("conflictType")
                 .doesNotContain("conflictReason")
                 .doesNotContain("relatedInstanceIds");
+    }
+
+    @Test
+    void serializesAiParseRequestWithBackendToAiContract() throws Exception {
+        AiParseRequest request = new AiParseRequest(
+                "Osaka 4-day trip with Dotonbori and USJ",
+                "Osaka",
+                (short) 4
+        );
+
+        String json = objectMapper.writeValueAsString(request);
+
+        assertThat(json)
+                .contains("\"text\"")
+                .contains("\"destination\"")
+                .contains("\"travel_days\"")
+                .doesNotContain("travelDays")
+                .doesNotContain("dump_text")
+                .doesNotContain("trip_id");
     }
 }

--- a/shared/docs/TripKey_SSOT.md
+++ b/shared/docs/TripKey_SSOT.md
@@ -116,14 +116,17 @@ tripkey-main/
 
 ### Dump Parse 계약
 - backend → ai-engine parse request:
-  - `trip_id: string`
-  - `dump_text: string`
+  - `text: string`
+  - `destination?: string`
+  - `travel_days?: number`
+  - `trip_id?: string`
 - ai-engine → backend parse response:
   - `cards: PlaceCard[]`
   - `context_summary?: string`
   - `alert_cards?: AlertCard[]`
 - `instance_id`는 ai-engine이 생성하지 않는다.
-- `instance_id`는 backend가 발급하고 저장 책임을 가진다.
+- `instance_id`와 `trip_id` 저장 책임은 backend가 가진다.
+- `trip_id`는 세션/저장 식별자이며, ai-engine의 저장 책임을 의미하지 않는다.
 
 ---
 
@@ -279,14 +282,39 @@ Dump:
 frontend → backend → ai → polling  
 
 Dump Parse:
-backend는 ai-engine raw response를 그대로 신뢰하지 않는다.
-ai-engine은 raw response를 normalization한 뒤 schema validation을 통과한 결과만 backend에 전달한다.
+backend → ai-engine 호출 시 `text`, `destination`, `travel_days`를 전달한다.
+ai-engine은 raw response를 normalization한 뒤 schema validation을 통과한 결과만 backend에 반환한다.
+backend는 ai-engine response를 그대로 신뢰하지 않고, 저장 직전에 도메인 규칙으로 한 번 더 normalization한다.
 
 Schedule:
 drag & drop → PATCH → DB  
 
 Verify:
 Maps API → fallback  
+
+---
+
+## 🔐 Dependency Update 정책
+
+### Dependabot 운영 원칙
+- 기본 운영은 `security-only`
+- 일반 version update PR은 받지 않는다.
+- 보안 취약점이 있는 dependency에 대해서만 PR을 생성한다.
+- auto-merge는 사용하지 않는다.
+- security PR은 CI 통과 후 사람이 확인하고 머지한다.
+
+### Dependabot 설정 원칙
+- `open-pull-requests-limit: 0`을 사용해 version updates를 비활성화한다.
+- security updates는 ecosystem별로 그룹화할 수 있다.
+- semver major 보안 업데이트도 차단하지 않는다.
+- default branch 기준으로 security updates가 생성되도록 운영한다.
+
+### 현재 적용 대상
+- frontend npm
+- backend gradle
+- ai-engine pip
+- github-actions
+- docker
 
 ---
 


### PR DESCRIPTION
## 변경 내용
- ai-engine parse request schema를 backend contract에 맞게 정렬했습니다.
- `ParseRequest`가 이제 `text`, `destination`, `travel_days`, `trip_id?`를 받도록 수정했습니다.
- `build_prompt()`가 `dump_text` 대신 `text`를 사용하고, `destination`과 `travel_days`를 문맥으로 활용하도록 변경했습니다.
- 테스트용 `AiTestController`도 동일한 `AiParseRequest` contract를 사용하도록 정리했습니다.
- backend에서 ai-engine으로 보내는 JSON이 `text / destination / travel_days`로 직렬화되는지 확인하는 contract 테스트를 추가했습니다.
- 추가적으로 SSOT 수정도 이루어졌습니다. (이전 PR 내용인 Dependabot에 관한 내용도 추가했습니다)

## 이유
- 기존에는 backend와 ai-engine 사이 parse request 필드가 서로 달라 계약 드리프트가 있었습니다.
- 실제 운영 경로인 `DumpAsyncProcessor -> AiEngineClient -> ai-engine` 기준으로 요청 계약을 일치시키는 것이 필요했습니다.


## 🔗 관련 이슈

closes #69 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [X] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

### 검증 방법
- `./gradlew test --tests com.tripkey.common.json.JsonNamingStrategyTest --tests com.tripkey.domain.dump.DumpAsyncProcessorTest`
- `PYTHONPYCACHEPREFIX=/tmp python3 -m py_compile apps/ai-engine/app/main.py apps/ai-engine/app/schemas/parse.py apps/ai-engine/app/schemas/place_card.py`

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.