### PR TITLE
chore(be): chore/85/introduce PostGIS foundation for place_cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,10 @@ Thumbs.db
 **/*.log
 **/docker/data/ # 로컬 DB 대비
 
-# docs (schema.sql은 예외)
+# docs (schema.sql / migrations 는 예외 — 그 외 내부 문서는 외부 관리)
 docs/
 !shared/docs/
 shared/docs/*
 !shared/docs/schema.sql
+!shared/docs/migrations/
+!shared/docs/migrations/**

--- a/apps/backend/build.gradle
+++ b/apps/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     // ── Database ─────────────────────────────────────────
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.orm:hibernate-spatial'
     runtimeOnly 'org.postgresql:postgresql'
 
     // ── WebClient (Google API, AI Engine HTTP 호출) ───────

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -79,6 +80,9 @@ public class PlaceCard {
 
     @Column(name = "lng")
     private Double lng;
+
+    @Column(name = "geom", insertable = false, updatable = false, columnDefinition = "geometry(Point,4326)")
+    private Point geom;
 
     @Column(name = "location", columnDefinition = "text")
     private String location;

--- a/shared/docs/migrations/V001__postgis_foundation.sql
+++ b/shared/docs/migrations/V001__postgis_foundation.sql
@@ -1,0 +1,58 @@
+-- TripKey migration: PostGIS foundation
+-- Date: 2026-05-04
+-- Scope: place_cards 공간 컬럼/인덱스 추가 (SCR-04 거리 클러스터링 / SCR-04V 동선 검증 기반)
+--
+-- 적용 대상: Supabase (dev / production 모두)
+-- 적용 방법: Supabase SQL Editor 에서 본 파일 전체 실행
+-- 동기 산출물: shared/docs/schema.sql, shared/docs/ERD.md 가 본 마이그레이션 적용 후 상태와 일치해야 함
+
+-- 1. PostGIS 확장 활성화
+create extension if not exists postgis;
+
+-- 2. place_cards.geom 컬럼 추가 (lat/lng 기반 generated column)
+--    - lat/lng 가 변경되면 DB가 자동으로 geom 을 갱신.
+--    - lat/lng 둘 중 하나라도 NULL 이면 geom 도 NULL.
+--    - SRID 4326 = WGS84 (위경도).
+--    - 미터 단위 거리/반경 쿼리는 geom::geography 캐스트 또는 ST_DistanceSphere 사용.
+alter table public.place_cards
+  add column if not exists geom geometry(Point, 4326)
+    generated always as (
+      case
+        when lat is not null and lng is not null
+          then st_setsrid(st_makepoint(lng, lat), 4326)
+        else null
+      end
+    ) stored;
+
+-- 3. GiST 공간 인덱스
+--    반경 검색 (ST_DWithin), 클러스터링 (ST_ClusterDBSCAN), KNN (<->) 등에서 사용.
+create index if not exists idx_place_cards_geom
+  on public.place_cards using gist (geom);
+
+-- ─────────────────────────────────────────────
+-- 검증 (적용 후 Supabase SQL Editor 에서 실행하여 확인)
+-- ─────────────────────────────────────────────
+-- 1) PostGIS 확장 설치 확인
+--    select extname, extversion from pg_extension where extname = 'postgis';
+--
+-- 2) geom 컬럼/인덱스 확인
+--    select column_name, data_type, is_generated, generation_expression
+--    from information_schema.columns
+--    where table_name = 'place_cards' and column_name = 'geom';
+--
+--    select indexname from pg_indexes
+--    where tablename = 'place_cards' and indexname = 'idx_place_cards_geom';
+--
+-- 3) lat/lng 와 geom 동기화 확인 (기존 데이터)
+--    select instance_id, lat, lng, st_y(geom) as geom_lat, st_x(geom) as geom_lng
+--    from public.place_cards
+--    where lat is not null and lng is not null
+--    limit 5;
+--
+-- 4) 미터 단위 거리 계산 동작 확인 (도쿄 신주쿠역 기준 가까운 카드)
+--    select instance_id, name, location,
+--           st_distancesphere(geom, st_setsrid(st_makepoint(139.7006, 35.6896), 4326)) as dist_m
+--    from public.place_cards
+--    where geom is not null
+--    order by dist_m
+--    limit 5;

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -2,6 +2,7 @@
 -- Scope: SCR-02P까지 도입된 Card SSOT 모델의 완전한 스키마.
 --        notes / memo / day 컬럼은 SCR-03/04/05에서 채워짐 (이 시점엔 NULL).
 -- Source of truth: Supabase. 이 파일은 Supabase 실제 스키마를 미러링합니다.
+-- 의존 확장: postgis (place_cards.geom 컬럼 / GiST 인덱스에서 사용)
 
 -- 여행 세션 (SCR-01 온보딩에서 생성)
 create table if not exists public.trips (
@@ -89,8 +90,19 @@ create table if not exists public.place_cards (
   -- 교통 전용
   flight_number          text,                                     -- 항공편 번호
 
+  -- 공간 (lat/lng 기반 generated column, SRID 4326)
+  geom                   geometry(Point, 4326)
+    generated always as (
+      case
+        when lat is not null and lng is not null
+          then st_setsrid(st_makepoint(lng, lat), 4326)
+        else null
+      end
+    ) stored,
+
   created_at             timestamptz not null default now(),
   updated_at             timestamptz not null default now()
 );
 
 create index if not exists idx_place_cards_trip_id on public.place_cards (trip_id);
+create index if not exists idx_place_cards_geom    on public.place_cards using gist (geom);


### PR DESCRIPTION
## 📝 작업 내용
                                                                                                  
  > SCR-04 거리 클러스터링 / SCR-04V 동선 검증의 기반이 되는 PostGIS 확장과 `place_cards.geom`    
  공간 컬럼/인덱스를 도입합니다.                                                                  
                                                                                                  
  - Supabase `postgis` 확장 활성화 (마이그레이션 `V001` 로 분리)
  - `place_cards.geom geometry(Point, 4326)` 추가 — `lat`/`lng` 기반 generated column (DB가 자동  
  동기화, JPA는 read-only 매핑)                                                                   
  - GiST 공간 인덱스 `idx_place_cards_geom` 추가 (반경 검색 / 클러스터링 / KNN)                   
  - `hibernate-spatial` 의존성 추가, `PlaceCard.geom` 을 JTS `Point` 로 매핑                      
  - `shared/docs/schema.sql` 미러 갱신                                                            
  - 마이그레이션 폴더 신설: `shared/docs/migrations/V001__postgis_foundation.sql` (Flyway 호환    
  명명) + `.gitignore` 화이트리스트                                                               
                                                                                                  
  ## 🔗 관련 이슈                                                                                 
                  
  closes #85                                                                              
  
  ## 🗂️  변경 범위                                                                                 
                  
  어떤 레이어를 건드렸나요? (해당하는 것 체크)                                                    
  
  - [ ] Frontend (apps/frontend) 
  - [ ] Backend (apps/backend)                                                                 
  - [ ] AI Engine (apps/ai-engine)
  - [x] 공통 / 설정 / 문서        
                                                                                                  
  ## ✅ 작업 체크리스트
                                                                                                  
  - [x] 로컬에서 정상 동작 확인했나요?
  - [x] 기존 기능이 깨지지 않았나요? (회귀 확인)                                                  
  - [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
  - [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?                                              
                                                                                                  
  ## 👀 리뷰어에게                                                                                
                                                                                                  
  > **본 PR 머지 전에 Supabase 적용 필요 — 이미 dev DB 적용 완료**                                
  > `V001__postgis_foundation.sql` 을 Supabase SQL Editor 에서 실행 → 검증 쿼리 4종(확장 / 컬럼 / 
  인덱스 / generated column 식 / 거리 계산) 통과 확인 완료. `ddl-auto: validate` 부팅 시점에      
  schema mismatch 발생하지 않습니다.                                                              
  >                                 
  > **마이그레이션 컨벤션 신설**                                                                  
  > `shared/docs/migrations/V<버전>__<설명>.sql` 형식. schema.sql 은 변경 후 상태 
  미러, V001 은 변경 이력 — 역할 분리. 다른 위치/형식이 더 맞다고 판단되시면 의견 주세요.         
  >                                                                                               
  > **타입 선택 근거**                                                                            
  > `geometry(Point, 4326)` 채택. 이유: hibernate-spatial 6 에서 JTS `Point` 가 `geometry` 로     
  자연스럽게 매핑되어 `ddl-auto: validate` 가 추가 설정 없이 통과. 미터 단위 거리/반경 쿼리는 
  사용처에서 `geom::geography` 캐스트 또는 `ST_DistanceSphere` 사용 (V001 검증 4 에서 정상 동작   
  확인).                                                                                        
  >                                                                                               
  > **`geom` 동기화 방식**
  > DB 측 `GENERATED ALWAYS AS ... STORED` 채택. lat/lng 변경 시 DB가 자동 갱신. 외부 SQL 직접 
  변경에도 정합성 유지. 엔티티 측은 `insertable=false, updatable=false` 로 read-only.             
  >                                                                                               
  > **schema.sql ↔ Supabase 정합성 검증 통과**                                                    
  > 36 컬럼 + 3 인덱스(PK/btree/GiST) + 1 FK(trip_id→trips) + geom generation expression 전부 1:1 
  일치 확인.                                                                                      
                                                                                                  
  ## 📸 스크린샷                                                                                  
                                                                                                  
  > 없음 (BE / DB 인프라 변경)