### PR TITLE
chore: EC2 prod compose deploy smoke test

### DIFF
--- a/infra/DEPLOY_RUNBOOK.md
+++ b/infra/DEPLOY_RUNBOOK.md
@@ -1,21 +1,67 @@
 # TripKey Production Compose Runbook
 
-## Scope
+## 범위
 
-This runbook targets a single-host Docker Compose deployment, such as an AWS EC2
-instance. Supabase is used as the managed PostgreSQL database.
+이 문서는 AWS EC2 같은 단일 호스트에서 Docker Compose로 TripKey production
+구성을 배포하는 절차를 다룹니다. 데이터베이스는 별도 RDS가 아니라 현재 사용 중인
+Supabase 관리형 PostgreSQL을 사용합니다.
 
-## Prerequisites
+## 사전 준비
 
-- Docker and Docker Compose are installed on the host.
-- Supabase schema is already applied.
-- Required env files are present on the host:
+- 호스트에 Docker와 Docker Compose가 설치되어 있어야 합니다.
+- Supabase schema가 이미 적용되어 있어야 합니다.
+- 호스트에 필요한 env 파일이 있어야 합니다.
   - `apps/backend/.env`
   - `apps/ai-engine/.env`
+- EC2 Security Group에서 필요한 접속 범위에 대해 TCP `80` inbound가 열려 있어야 합니다.
 
-Do not commit real env files or secrets.
+실제 env 파일이나 secret 값은 커밋하지 않습니다.
 
-## Required Backend Env
+## EC2 호스트 설정
+
+Amazon Linux 2023:
+
+```bash
+sudo dnf update -y
+sudo dnf install -y docker git
+sudo systemctl enable --now docker
+sudo usermod -aG docker $USER
+newgrp docker
+docker compose version
+```
+
+Ubuntu:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl git
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo usermod -aG docker $USER
+newgrp docker
+docker compose version
+```
+
+## 코드 체크아웃
+
+```bash
+git clone <REPO_URL> tripkey-main
+cd tripkey-main
+git checkout chore/78-aws-prod-compose
+```
+
+## Backend 필수 Env
 
 ```env
 SPRING_PROFILES_ACTIVE=prod
@@ -26,7 +72,7 @@ AI_ENGINE_URL=http://tripkey-ai-engine:8000
 AI_ENGINE_TIMEOUT_SECONDS=90
 ```
 
-## Required AI Engine Env
+## AI Engine 필수 Env
 
 ```env
 GEMINI_API_KEY=
@@ -34,27 +80,48 @@ GOOGLE_MAPS_API_KEY=
 AI_ENGINE_WORKERS=2
 ```
 
-## Start
+EC2 호스트에서 직접 파일을 만들거나, 팀에서 사용하는 secret 관리 경로를 통해
+복사합니다. 파일 위치 예시는 다음과 같습니다.
+
+```bash
+vi apps/backend/.env
+vi apps/ai-engine/.env
+chmod 600 apps/backend/.env apps/ai-engine/.env
+```
+
+## 실행
+
+실행 전 dev compose와 prod compose가 병합된 최종 설정을 확인합니다.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml config
+```
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 ```
 
-Only the frontend container publishes a host port by default:
+기본적으로 host port를 외부에 공개하는 컨테이너는 frontend뿐입니다.
 
 - `frontend`: `80:80`
-- `backend`: internal Docker network only
-- `ai-engine`: internal Docker network only
+- `backend`: Docker 내부 네트워크에서만 접근 가능
+- `ai-engine`: Docker 내부 네트워크에서만 접근 가능
 
-The frontend nginx container proxies `/api/*` to `backend:8080/v1/*`.
+frontend nginx 컨테이너는 `/api/*` 요청을 `backend:8080/v1/*`로 프록시합니다.
 
-## Logs
+컨테이너 상태를 확인합니다.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
+```
+
+## 로그
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f
 ```
 
-Service-specific logs:
+서비스별 로그는 다음 명령으로 확인합니다.
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f backend
@@ -62,7 +129,7 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f ai-engin
 docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f frontend
 ```
 
-## Stop
+## 중지
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.prod.yml down
@@ -70,16 +137,73 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml down
 
 ## Smoke Test
 
-From the host:
+EC2 호스트 내부에서 frontend 응답을 확인합니다.
 
 ```bash
 curl http://localhost/
 ```
 
-Through the frontend proxy:
+frontend proxy를 통해 backend API 응답을 확인합니다.
 
 ```bash
-curl 'http://localhost/api/trips/destinations/search?q=도쿄'
+curl -G 'http://localhost/api/trips/destinations/search' --data-urlencode 'q=도쿄'
 ```
 
-If the API request fails, inspect backend and frontend logs first.
+API 요청이 실패하면 backend와 frontend 로그를 먼저 확인합니다.
+
+로컬 PC에서는 `<EC2_PUBLIC_IP>`를 실제 EC2 public IP로 바꿔서 확인합니다.
+
+```bash
+curl http://<EC2_PUBLIC_IP>/
+curl -G 'http://<EC2_PUBLIC_IP>/api/trips/destinations/search' --data-urlencode 'q=도쿄'
+```
+
+backend와 ai-engine이 EC2 외부에서 직접 접근되지 않는지 확인합니다.
+
+```bash
+curl --connect-timeout 5 http://<EC2_PUBLIC_IP>:8080/v1/trips/destinations/search?q=health
+curl --connect-timeout 5 http://<EC2_PUBLIC_IP>:8000/health
+```
+
+두 외부 직접 접근 요청은 실패하거나 timeout이 발생해야 정상입니다. 둘 중 하나라도
+성공하면 해당 inbound Security Group rule을 제거하고, `docker-compose.prod.yml`에서
+`backend` 또는 `ai-engine` port가 publish되고 있지 않은지 확인합니다.
+
+Smoke test 기대 결과:
+
+- `http://<EC2_PUBLIC_IP>/`에서 frontend HTML이 응답됩니다.
+- `/api/trips/destinations/search`에서 JSON 목적지 검색 응답이 반환됩니다.
+- EC2 외부에서 `:8080`으로 직접 접근할 수 없습니다.
+- EC2 외부에서 `:8000`으로 직접 접근할 수 없습니다.
+
+이슈 코멘트 예시:
+
+```md
+EC2 production compose 배포 및 smoke test를 완료했습니다.
+
+확인한 내용:
+- `http://<EC2_PUBLIC_IP>/`에서 frontend HTML 응답 확인
+- `/api/trips/destinations/search?q=도쿄`가 frontend nginx proxy를 통해 정상 응답
+- Backend는 외부에서 `:8080`으로 직접 접근 불가
+- AI engine은 외부에서 `:8000`으로 직접 접근 불가
+
+이번 이슈 범위 제외:
+- RDS
+- S3
+```
+
+## 테스트 인스턴스 정리
+
+임시 smoke test용 EC2 인스턴스라면 검증 후 stop 또는 terminate합니다.
+
+애플리케이션만 내리고 인스턴스는 유지하려면 다음 명령을 실행합니다.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml down
+```
+
+그 다음 AWS 콘솔 또는 CLI에서 EC2 인스턴스를 stop합니다. Stop하면 EBS volume과 env
+파일은 유지되지만, Elastic IP를 사용하지 않는 경우 public IP가 바뀔 수 있습니다.
+
+인스턴스를 다시 사용할 계획이 없다면 terminate합니다. Root EBS volume 삭제 설정이
+켜져 있다면 terminate 시 인스턴스와 env 파일이 함께 삭제됩니다.


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- EC2에서 production docker compose 구성으로 TripKey 서비스를 배포하고 smoke test를 수행했습니다.
- `infra/DEPLOY_RUNBOOK.md`에 EC2 호스트 설정, env 배치, 실행, smoke test, 테스트 인스턴스 정리 절차를 보강했습니다.
- Supabase는 기존 구성 그대로 사용하며, RDS/S3는 이번 이슈 범위에서 제외했습니다.


## 🔗 관련 이슈

closes #83 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?


## 검증
- `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build`
- `http://52.79.226.49/`에서 frontend HTML 응답 확인
- frontend nginx `/api` proxy 동작 확인

```bash
curl -G 'http://52.79.226.49/api/trips/destinations/search' --data-urlencode 'q=도쿄'
Response:

json

{"results":[{"name":"도쿄","country":"일본","place_id":null}]}
```
- Backend는 외부에서 :8080 직접 접근 불가 확인
- AI engine은 외부에서 :8000 직접 접근 불가 확인

## Not Verified
EC2 배포 환경에서 01 → 02 → 02P frontend flow 직접 조작
EC2 배포 환경에서 AI parsing E2E
Supabase place_cards 저장 여부
parse job status polling

## Notes
이번 검증은 production compose 배포 및 /api proxy 중심의 smoke test입니다.
AI parsing E2E는 현재 frontend 라우팅/UI 상태상 배포 서버에서 직접 검증하지 않았습니다.
로컬 환경에서는 기존에 01 → 02 → 02P E2E 및 AI parse 결과 저장까지 확인된 상태입니다.
HTML document title이 현재 Mini Shop으로 남아 있습니다.
위치: apps/frontend/index.html
frontend 영역의 별도 정리 사항으로 남깁니다.
