### PR TITLE
feat(be): SCR-04 stock groups view via PostGIS clustering  

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupController.java
@@ -1,7 +1,6 @@
 package com.tripkey.domain.group;
 
 import com.tripkey.common.exception.InvalidViewParamException;
-import com.tripkey.dto.group.Groups03Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,13 +19,14 @@ public class GroupController {
     private final GroupService groupService;
 
     @GetMapping
-    public ResponseEntity<Groups03Response> getGroups(
+    public ResponseEntity<?> getGroups(
             @PathVariable UUID tripId,
             @RequestParam("view") String view) {
 
-        if (!"03".equals(view)) {
-            throw new InvalidViewParamException();
-        }
-        return ResponseEntity.ok(groupService.getGroups03(tripId));
+        return switch (view) {
+            case "03" -> ResponseEntity.ok(groupService.getGroups03(tripId));
+            case "04" -> ResponseEntity.ok(groupService.getGroups04(tripId));
+            default -> throw new InvalidViewParamException();
+        };
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
@@ -6,18 +6,28 @@ import com.tripkey.domain.place.PlaceCardRepository;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.group.Groups03Response;
+import com.tripkey.dto.group.Groups04Response;
+import com.tripkey.dto.group.StockGroup;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class GroupService {
+
+    private static final double SCR04_CLUSTER_EPS_DEGREES = 0.018;
+    private static final int SCR04_CLUSTER_MIN_POINTS = 1;
+    private static final String FALLBACK_LABEL = "기타";
 
     private final TripRepository tripRepository;
     private final PlaceCardRepository placeCardRepository;
@@ -54,5 +64,120 @@ public class GroupService {
                 });
 
         return Groups03Response.of(inputRequired, selectRequired, fixRequired, reviewOnly, excluded);
+    }
+
+    @Transactional(readOnly = true)
+    public Groups04Response getGroups04(UUID tripId) {
+        if (!tripRepository.existsById(tripId)) {
+            throw new TripNotFoundException(tripId);
+        }
+
+        List<PlaceCard> unavailable = new ArrayList<>();
+        List<PlaceCard> pendingReorder = new ArrayList<>();
+        List<PlaceCard> availableCandidates = new ArrayList<>();
+
+        for (PlaceCard card : placeCardRepository.findAllByTripId(tripId)) {
+            if (Boolean.TRUE.equals(card.getIsExcluded())) {
+                continue;
+            }
+            String placement = card.getPlacementStatus();
+            String processing = card.getProcessingStatus();
+            if ("blocked".equals(placement) || "needs_input".equals(placement) || "failed".equals(processing)) {
+                unavailable.add(card);
+                continue;
+            }
+            if ("processing".equals(processing) || card.getGeom() == null) {
+                pendingReorder.add(card);
+                continue;
+            }
+            availableCandidates.add(card);
+        }
+
+        List<StockGroup> available = clusterIntoStockGroups(tripId, availableCandidates);
+
+        return Groups04Response.of(
+                available,
+                toSortedDtos(pendingReorder),
+                toSortedDtos(unavailable)
+        );
+    }
+
+    private List<StockGroup> clusterIntoStockGroups(UUID tripId, List<PlaceCard> candidates) {
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        Map<UUID, Integer> clusterIdByInstance = placeCardRepository
+                .clusterAvailableCards(tripId, SCR04_CLUSTER_EPS_DEGREES, SCR04_CLUSTER_MIN_POINTS).stream()
+                .filter(row -> row[1] != null)
+                .collect(Collectors.toMap(
+                        row -> (UUID) row[0],
+                        row -> ((Number) row[1]).intValue(),
+                        (a, b) -> a
+                ));
+
+        Map<Integer, List<PlaceCard>> cardsByCluster = new HashMap<>();
+        for (PlaceCard card : candidates) {
+            Integer clusterId = clusterIdByInstance.get(card.getInstanceId());
+            if (clusterId == null) {
+                continue;
+            }
+            cardsByCluster.computeIfAbsent(clusterId, k -> new ArrayList<>()).add(card);
+        }
+
+        record LabeledCluster(int clusterId, String dominantLabel, List<PlaceCard> cards) {}
+
+        List<LabeledCluster> clusters = cardsByCluster.entrySet().stream()
+                .map(e -> new LabeledCluster(e.getKey(), dominantLocation(e.getValue()), e.getValue()))
+                .toList();
+
+        Map<String, List<LabeledCluster>> byLabel = clusters.stream()
+                .collect(Collectors.groupingBy(LabeledCluster::dominantLabel));
+
+        List<StockGroup> result = new ArrayList<>();
+        for (Map.Entry<String, List<LabeledCluster>> entry : byLabel.entrySet()) {
+            String baseLabel = entry.getKey();
+            List<LabeledCluster> group = entry.getValue();
+            if (group.size() == 1) {
+                result.add(StockGroup.of(baseLabel, toSortedDtos(group.get(0).cards())));
+                continue;
+            }
+            List<LabeledCluster> ordered = group.stream()
+                    .sorted(Comparator
+                            .comparingInt((LabeledCluster c) -> c.cards().size()).reversed()
+                            .thenComparingInt(LabeledCluster::clusterId))
+                    .toList();
+            for (int i = 0; i < ordered.size(); i++) {
+                result.add(StockGroup.of(
+                        baseLabel + " " + (i + 1),
+                        toSortedDtos(ordered.get(i).cards())
+                ));
+            }
+        }
+
+        result.sort(Comparator
+                .comparingInt((StockGroup g) -> g.cards().size()).reversed()
+                .thenComparing(StockGroup::label));
+        return result;
+    }
+
+    private static String dominantLocation(List<PlaceCard> cards) {
+        return cards.stream()
+                .map(PlaceCard::getLocation)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.groupingBy(s -> s, Collectors.counting()))
+                .entrySet().stream()
+                .max(Map.Entry.<String, Long>comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(FALLBACK_LABEL);
+    }
+
+    private static List<CardDto> toSortedDtos(List<PlaceCard> cards) {
+        return cards.stream()
+                .sorted(Comparator.comparing(PlaceCard::getCreatedAt))
+                .map(CardDto::from)
+                .toList();
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -157,7 +157,7 @@ public class PlaceCard {
         card.name = defaultString(name, "이름 미정");
         card.category = normalizeCategory(category);
         card.classification = "confirmed";
-        card.placementStatus = "ready";
+        card.placementStatus = "ready_partial";
         card.processingStatus = "processing";
         card.actionType = "review_only";
         card.canExclude = !NON_EXCLUDABLE_CATEGORIES.contains(card.category);
@@ -233,11 +233,7 @@ public class PlaceCard {
     }
 
     private void recomputeActionType() {
-        this.actionType = computeActionType(
-                this.classification,
-                this.placementStatus,
-                this.processingStatus,
-                this.options);
+        this.actionType = computeActionType(this.classification, this.placementStatus);
     }
 
     public static PlaceCard createFromAiResponse(UUID tripId, AiPlaceCardDto dto) {
@@ -255,7 +251,7 @@ public class PlaceCard {
                 : DUPLICATE_DEFAULT_CATEGORIES.contains(card.category);
         card.canExclude = !NON_EXCLUDABLE_CATEGORIES.contains(card.category);
         card.isExcluded = false;
-        card.actionType = computeActionType(card.classification, card.placementStatus, card.processingStatus, dto.options());
+        card.actionType = computeActionType(card.classification, card.placementStatus);
 
         card.estimatedDurationMin = dto.estimatedDurationMin();
         if (dto.coordinates() != null) {
@@ -336,20 +332,17 @@ public class PlaceCard {
         };
     }
 
-    private static String computeActionType(String classification, String placementStatus, String processingStatus, List<String> options) {
-        if ("failed".equals(processingStatus)) {
-            return "fix_required";
-        }
-        if ("blocked".equals(placementStatus)) {
-            return "fix_required";
-        }
-        if ("needs_input".equals(placementStatus)) {
-            return "input_required";
-        }
-        if ("undecided".equals(classification) && options != null && !options.isEmpty()) {
-            return "select_required";
-        }
-        return "review_only";
+    private static String computeActionType(String classification, String placementStatus) {
+        return switch (classification) {
+            case "confirmed", "open_question" -> "review_only";
+            case "undecided" -> switch (placementStatus) {
+                case "ready_partial" -> "select_required";
+                case "needs_input" -> "input_required";
+                default -> "review_only";
+            };
+            case "unassigned" -> "blocked".equals(placementStatus) ? "fix_required" : "review_only";
+            default -> "review_only";
+        };
     }
 
     private static String trimToNull(String value) {

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -22,4 +22,18 @@ public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
     @Transactional
     @Query("delete from PlaceCard p where p.tripId = :tripId")
     void deleteAllByTripId(@Param("tripId") UUID tripId);
+
+    @Query(value = """
+            select instance_id, st_clusterdbscan(geom, :eps, :minPts) over () as cluster_id
+            from place_cards
+            where trip_id = :tripId
+              and is_excluded = false
+              and placement_status in ('ready', 'ready_partial')
+              and processing_status = 'completed'
+              and geom is not null
+            """, nativeQuery = true)
+    List<Object[]> clusterAvailableCards(
+            @Param("tripId") UUID tripId,
+            @Param("eps") double eps,
+            @Param("minPts") int minPts);
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/group/Groups04Response.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/group/Groups04Response.java
@@ -1,0 +1,20 @@
+package com.tripkey.dto.group;
+
+import com.tripkey.dto.card.CardDto;
+
+import java.util.List;
+
+public record Groups04Response(
+        String view,
+        List<StockGroup> available,
+        List<CardDto> pendingReorder,
+        List<CardDto> unavailable
+) {
+    public static Groups04Response of(
+            List<StockGroup> available,
+            List<CardDto> pendingReorder,
+            List<CardDto> unavailable
+    ) {
+        return new Groups04Response("04", available, pendingReorder, unavailable);
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/group/StockGroup.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/group/StockGroup.java
@@ -1,0 +1,15 @@
+package com.tripkey.dto.group;
+
+import com.tripkey.dto.card.CardDto;
+
+import java.util.List;
+
+public record StockGroup(
+        String label,
+        String groupReason,
+        List<CardDto> cards
+) {
+    public static StockGroup of(String label, List<CardDto> cards) {
+        return new StockGroup(label, null, cards);
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
@@ -4,9 +4,16 @@ import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
 import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.group.Groups03Response;
+import com.tripkey.dto.group.Groups04Response;
+import com.tripkey.dto.group.StockGroup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,10 +26,16 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GroupServiceTest {
+
+    private static final GeometryFactory GEOMETRY_FACTORY =
+            new GeometryFactory(new PrecisionModel(), 4326);
 
     @Mock
     private TripRepository tripRepository;
@@ -115,6 +128,169 @@ class GroupServiceTest {
                 .containsExactly(older.getInstanceId(), newer.getInstanceId());
     }
 
+    @Test
+    void getGroups04ThrowsTripNotFoundWhenTripMissing() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(false);
+
+        assertThatThrownBy(() -> groupService.getGroups04(tripId))
+                .isInstanceOf(TripNotFoundException.class);
+    }
+
+    @Test
+    void getGroups04ReturnsAllEmptyGroupsWhenNoCards() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.view()).isEqualTo("04");
+        assertThat(response.available()).isEmpty();
+        assertThat(response.pendingReorder()).isEmpty();
+        assertThat(response.unavailable()).isEmpty();
+    }
+
+    @Test
+    void getGroups04ClassifiesUnavailableByBlockedNeedsInputOrFailed() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard blocked = stockCard(tripId, "blocked", "completed", null, "신주쿠", at(10, 0));
+        PlaceCard needsInput = stockCard(tripId, "needs_input", "completed", null, "신주쿠", at(10, 1));
+        PlaceCard failed = stockCard(tripId, "ready", "failed", null, "신주쿠", at(10, 2));
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(blocked, needsInput, failed));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.unavailable())
+                .extracting(CardDto::instanceId)
+                .containsExactlyInAnyOrder(
+                        blocked.getInstanceId(),
+                        needsInput.getInstanceId(),
+                        failed.getInstanceId());
+        assertThat(response.available()).isEmpty();
+        assertThat(response.pendingReorder()).isEmpty();
+    }
+
+    @Test
+    void getGroups04ClassifiesPendingReorderByProcessingOrMissingGeom() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard stillProcessing = stockCard(tripId, "ready_partial", "processing",
+                point(139.7, 35.69), "신주쿠", at(10, 0));
+        PlaceCard noGeom = stockCard(tripId, "ready_partial", "completed", null, "신주쿠", at(10, 1));
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(stillProcessing, noGeom));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.pendingReorder())
+                .extracting(CardDto::instanceId)
+                .containsExactlyInAnyOrder(stillProcessing.getInstanceId(), noGeom.getInstanceId());
+        assertThat(response.available()).isEmpty();
+        assertThat(response.unavailable()).isEmpty();
+    }
+
+    @Test
+    void getGroups04SkipsExcludedCards() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard excluded = stockCard(tripId, "blocked", "completed", null, "신주쿠", at(10, 0));
+        setField(excluded, "isExcluded", true);
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(excluded));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).isEmpty();
+        assertThat(response.pendingReorder()).isEmpty();
+        assertThat(response.unavailable()).isEmpty();
+    }
+
+    @Test
+    void getGroups04ClustersAvailableCardsWithDominantLocationLabel() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), "시부야", at(10, 0));
+        PlaceCard b = stockCard(tripId, "ready_partial", "completed",
+                point(139.7020, 35.6590), "시부야", at(10, 1));
+        PlaceCard c = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), null, at(10, 2));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a, b, c));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.of(
+                        new Object[]{a.getInstanceId(), 0},
+                        new Object[]{b.getInstanceId(), 0},
+                        new Object[]{c.getInstanceId(), 0}
+                ));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(1);
+        StockGroup group = response.available().get(0);
+        assertThat(group.label()).isEqualTo("시부야");
+        assertThat(group.cards()).hasSize(3)
+                .extracting(CardDto::instanceId)
+                .containsExactly(a.getInstanceId(), b.getInstanceId(), c.getInstanceId());
+    }
+
+    @Test
+    void getGroups04AppliesSuffixWhenSameLabelAcrossMultipleClusters() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), "신주쿠", at(10, 0));
+        PlaceCard b = stockCard(tripId, "ready_partial", "completed",
+                point(139.7020, 35.6590), "신주쿠", at(10, 1));
+        PlaceCard c = stockCard(tripId, "ready_partial", "completed",
+                point(139.7700, 35.6700), "신주쿠", at(10, 2));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a, b, c));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.of(
+                        new Object[]{a.getInstanceId(), 0},
+                        new Object[]{b.getInstanceId(), 0},
+                        new Object[]{c.getInstanceId(), 1}
+                ));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(2);
+        assertThat(response.available())
+                .extracting(StockGroup::label)
+                .containsExactly("신주쿠 1", "신주쿠 2");
+        assertThat(response.available().get(0).cards()).hasSize(2);
+        assertThat(response.available().get(1).cards()).hasSize(1);
+    }
+
+    @Test
+    void getGroups04LabelsClusterAsFallbackWhenNoLocation() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), null, at(10, 0));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.<Object[]>of(new Object[]{a.getInstanceId(), 0}));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(1);
+        assertThat(response.available().get(0).label()).isEqualTo("기타");
+    }
+
     private PlaceCard cardWith(UUID tripId, String actionType, boolean excluded, OffsetDateTime createdAt) {
         PlaceCard card = PlaceCard.createUserCard(
                 tripId, "테스트 카드", "place", null, null, null, null, null, null, null
@@ -124,6 +300,29 @@ class GroupServiceTest {
         setField(card, "isExcluded", excluded);
         setField(card, "createdAt", createdAt);
         return card;
+    }
+
+    private PlaceCard stockCard(
+            UUID tripId,
+            String placementStatus,
+            String processingStatus,
+            Point geom,
+            String location,
+            OffsetDateTime createdAt
+    ) {
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, "테스트 카드", "place", location, null, null, null, null, null, null
+        );
+        setField(card, "instanceId", UUID.randomUUID());
+        setField(card, "placementStatus", placementStatus);
+        setField(card, "processingStatus", processingStatus);
+        setField(card, "geom", geom);
+        setField(card, "createdAt", createdAt);
+        return card;
+    }
+
+    private static Point point(double lng, double lat) {
+        return GEOMETRY_FACTORY.createPoint(new Coordinate(lng, lat));
     }
 
     private static OffsetDateTime at(int hour, int minute) {

--- a/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
@@ -87,7 +87,7 @@ class CardServiceTest {
 
         assertThat(created.classification()).isEqualTo("confirmed");
         assertThat(created.processingStatus()).isEqualTo("processing");
-        assertThat(created.placementStatus()).isEqualTo("ready");
+        assertThat(created.placementStatus()).isEqualTo("ready_partial");
         assertThat(created.actionType()).isEqualTo("review_only");
         assertThat(created.isAiGenerated()).isFalse();
         assertThat(created.canExclude()).isTrue();


### PR DESCRIPTION
## 📝 작업 내용                                                                                 
                                                                                                  
  > SCR-04 (Stock 배치) 화면용 거리 기반 카드 그룹 조회 API (`GET /trips/{tripId}/groups?view=04`)
   백엔드 구현. 함께 들어간 action_type 매트릭스 정렬 fix 포함.                                   
                                                                                                  
  ### feat(be): SCR-04 stock groups view via PostGIS clustering                                 
  - `Groups04Response` / `StockGroup` DTO 추가 (`view`, `available[StockGroup]`,                  
  `pending_reorder[Card]`, `unavailable[Card]`)                                                   
  - `PlaceCardRepository.clusterAvailableCards`: native `ST_ClusterDBSCAN` 쿼리 (eps=0.018° ≈ 2km,
   minPts=1)                                                                                      
  - `GroupService.getGroups04`: 카드를 unavailable / pending_reorder / available 로 분배
    - **excluded**: `is_excluded=true` → 응답에서 완전 제외                                       
    - **pending_reorder**: `processing_status=processing` OR `geom IS NULL`                       
    - **available**: 나머지 (ready / ready_partial + completed + geom 존재) → DBSCAN 클러스터링   
  - 클러스터 라벨링: 가장 많이 등장한 `location` 사용. 동일 라벨이 여러 클러스터에 걸치면 카드 수 
  desc / cluster_id asc 순으로 `"신주쿠 1"`, `"신주쿠 2"` suffix                                  
  - location 없으면 fallback `"기타"`                                                             
  - `available` 정렬: 카드 수 desc → 라벨 alphabetic. 그룹 안 카드 정렬: `createdAt ASC`          
  - `GroupController` 의 `view` 분기에 `"04"` 추가                                                
                                                                                                  
  ### fix(be): align action_type with classification × placement_status matrix                    
  - `computeActionType` 를 매트릭스 기반으로 재작성:                                              
    - `confirmed` / `open_question` + any → `review_only`                                         
    - `undecided` × `ready_partial` → `select_required`                                           
    - `undecided` × `needs_input` → `input_required`                                              
    - `unassigned` × `blocked` → `fix_required`                                                   
  - 시그니처 단순화: `processing_status`, `options` 인자 제거 (action_type 은 이제 classification 
  + placement_status 만의 함수)                                                                   
  - `createUserCard` 의 `placement_status` default 를 `"ready_partial"` 로 정렬                   
                                                                                                  
  ## 🔗 관련 이슈                                                                                 
                  
  closes #84                                                                                      
                  
  ## 🗂️  변경 범위
                 
  - [ ] Frontend (apps/frontend)                                                                  
  - [x] Backend (apps/backend)  
  - [ ] AI Engine (apps/ai-engine)                                                                
  - [ ] 공통 / 설정 / 문서                                                                        
                          
  ## ✅ 작업 체크리스트                                                                           
                       
  - [x] 로컬에서 정상 동작 확인했나요?                                                            
  - [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
  - [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?                                        
  - [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?                                              
                                                                                                  
  ## 👀 리뷰어에게                                                                                
                                                                                                  
  > **action_type 매트릭스 fix 포함** — 직전 피드백 (classification × placement_status 매트릭스   
  정렬) 을 본 PR 첫 커밋 (`bf478dd`) 으로 반영. 본 SCR-04 작업과는 별개지만 함께 들어가 있습니다. 
  분리 머지가 필요하면 알려주세요.                                                                
  >                               
  > **클러스터링 임계값 (eps = 0.018° ≈ 2km, minPts = 1)** — 도쿄/서울 위도 기준 한 동네 단위     
  가정으로 시작. 추후 실데이터 보면서 튜닝 필요할 수 있음. 상수는                             
  `GroupService.SCR04_CLUSTER_EPS_DEGREES`, `SCR04_CLUSTER_MIN_POINTS` 에 추출되어 있습니다.      
  >                                                                                         
  > **카드 분배 정책 결정 사항 — 합의 받지 못했지만 적용한 두 가지** :                            
  > 1. `is_excluded=true` 카드는 응답에서 완전 제외 (unavailable 에도 안 들어감). Stock 배치 
  화면에서 사라져서 다시 포함시키려면 SCR-03 에서 `is_excluded=false` 로 변경 필요합니다.                                                                                   
  > 2. `placement_status='needs_input'` 카드는 `unavailable` 로 분배. SCR-03 에서 입력 받지 못한  
  카드 = 좌표 부족으로 클러스터링 불가능 → unavailable 가 자연스럽다고 판단했습니다. 만약 "사용자 
  입력 들어오면 자동으로 클러스터에 편입돼야 하니 pending_reorder 가 맞다" 같은 의견이 있으면     
  알려주세요.                                                                                 
  >                                                                                               
  > **테스트** — 6개 신규 (trip 404 / 빈 카드 / unavailable 분배 / pending 분배 / excluded 스킵 / 
  클러스터 라벨 / suffix dedup / fallback "기타"). native 쿼리는 mock 으로 처리.                  
                                                                                                  
  ## 📸 스크린샷
                                                                                                  
  > 없음 (BE 전용)