### PR TITLE
chore: Claude Code MCP 서버 + shadcn-ui skill 셋업

### DIFF
--- a/.claude/skills/shadcn-ui/SKILL.md
+++ b/.claude/skills/shadcn-ui/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: Shadcn UI & Blocks
+description: This skill should be used when the user asks to "build a frontend", "create a landing page", "add shadcn components", "install shadcn blocks", "set up shadcn", "add a hero section", "add pricing section", "build a UI with Tailwind", "use shadcnblocks", "add UI blocks", "add a contact form", "build a dashboard", "create an ecommerce page", "add a navbar", "add a footer", or is building any frontend that could leverage shadcn/ui components and Tailwind CSS. It provides knowledge of 1,338 premium blocks and 1,189 free components from ShadcnBlocks, enabling intelligent selection and installation of the right UI elements for any frontend task.
+---
+
+# Shadcn UI & ShadcnBlocks Integration
+
+This skill enables building polished frontends using [shadcn/ui](https://ui.shadcn.com/) components and premium [ShadcnBlocks](https://shadcnblocks.com/) templates. Its primary capability is **intelligently recommending the best block or component** for any UI need — not just the right category, but the right *variant* within that category — then handling setup and installation.
+
+## When to Use
+
+Activate this skill when:
+- Creating a new frontend, landing page, marketing site, or app UI
+- The project uses or should use React/Next.js with Tailwind CSS
+- Pre-built UI sections (hero, pricing, features, testimonials, etc.) would accelerate development
+- The user needs a specific UI element (form, chart, dialog, navigation, etc.)
+- The user mentions shadcn, shadcn/ui, shadcnblocks, or Tailwind-based UI components
+
+## Blocks vs Components
+
+| | Blocks | Components |
+|---|--------|------------|
+| **What** | Full page sections | Reusable UI elements |
+| **Size** | Hero, pricing, footer, etc. | Buttons, inputs, dialogs, etc. |
+| **Count** | 1,338 across 71 categories | 1,189 across 60+ groups |
+| **Access** | Premium (API key required) | Free |
+| **Install** | `@shadcnblocks/<name><number>` | `@shadcnblocks/<type>-<style>-<number>` |
+
+**Use blocks** to compose full page layouts from pre-built sections.
+**Use components** for individual UI elements inside custom code.
+
+---
+
+## Intelligent Block Selection
+
+### The 0-2 Question Rule
+
+When recommending blocks, follow this progressive disclosure flow:
+
+- **0 questions**: The user's request is specific enough to match directly (e.g., "add a hero with email capture form" → match on `cta_pattern: form_capture`)
+- **1 question**: The section is clear but the style/layout is ambiguous (e.g., "add a feature section" → ask about layout preference)
+- **2 questions max**: Both section and style are unclear (e.g., "add a section to show our product" → ask section type, then style)
+
+**Never ask more than 2 questions.** If still ambiguous, pick the best 2-3 and explain the tradeoffs.
+
+### Decision Flow: Infer → Ask → Shortlist
+
+**Step 1 — Infer from the request (always do this first)**
+
+Extract as many constraints as possible before asking anything:
+- **Section type**: hero, feature, pricing, testimonial, cta, faq, navbar, footer, contact, stats
+- **Goal keywords**: "signup" → convert/capture_leads, "trust" → trust, "compare plans" → compare
+- **Layout hints**: "grid" → grid_cards, "side by side" → split, "accordion" → accordion interaction
+- **Tone hints**: "clean" → minimal, "bold" → bold, "professional" → enterprise
+- **Media hints**: "with screenshots" → screenshot media, "video" → video media
+- **Density hints**: "simple" → minimal density, "detailed" → rich density
+
+**Step 2 — Ask targeted questions (only if needed)**
+
+Use `AskUserQuestion` for structured multiple-choice refinement. Consult `references/block-index.md` → `selection_prompts` for the pre-defined questions and options per section.
+
+**Sections with pre-defined prompts:** hero, feature, pricing, testimonial, cta, faq, navbar, footer, contact, stats.
+
+Example for a feature section request:
+
+```
+AskUserQuestion:
+  question: "How do you want to showcase your features?"
+  options:
+    - "Card grid (3-4 columns with icons)" — Classic feature grid with icon + description per card
+    - "Alternating image + text rows" — Deep-dive with large visuals, great for product tours
+    - "Bento / asymmetric grid" — Modern editorial layout with mixed-size cards
+    - "Simple icon list or checklist" — Compact, scannable benefit list
+```
+
+If `AskUserQuestion` is unavailable, ask the same question inline with numbered options.
+
+**Step 3 — Match tags and return 2-3 best picks**
+
+Map the user's answer to tag filters, then match against `references/block-index.md` entries. Return exactly **2-3 recommendations** in this format:
+
+```
+Here are the best matches for your [section type]:
+
+1. **[block-id]** — [1-line "why this one"]
+   Layout: [layout] · Tone: [tone] · [key differentiator]
+
+2. **[block-id]** — [1-line "why this one"]
+   Layout: [layout] · Tone: [tone] · [key differentiator]
+
+3. **[block-id]** — [1-line "why this one"]
+   Layout: [layout] · Tone: [tone] · [key differentiator]
+
+Which one works best? I'll install it and set it up.
+```
+
+After the user picks, provide the install command and compose it into the page.
+
+### Tag Dimensions Used for Matching
+
+These are the key dimensions from `references/block-index.md` used to differentiate blocks:
+
+| Dimension | What it tells you | Example values |
+|-----------|-------------------|----------------|
+| `layout` | Visual arrangement | centered, split_right_media, grid_cards, bento, alternating |
+| `tone` | Aesthetic feel | minimal, modern, bold, enterprise, elegant, playful |
+| `goal` | Business purpose | awareness, explain, trust, convert, capture_leads, compare |
+| `cta_pattern` | Action type | single_primary, primary_secondary, form_capture, multi_action |
+| `media` | Visual content | screenshot, illustration, video, icons, avatars, logos |
+| `interaction` | Dynamic behavior | static, accordion, tabs, carousel, toggle, hover |
+| `items_count` | Number of items displayed | few, moderate, many |
+| `content_density` | How much content | minimal, standard, rich |
+| `complexity` | Implementation effort | low, medium, high |
+
+### When to Use Which Reference
+
+| Scenario | Use |
+|----------|-----|
+| Recommending best-fit blocks (default) | `references/block-index.md` — tagged picks with selection prompts |
+| User wants a specific numbered variant | `references/block-catalog.md` — full catalog with all variant numbers |
+| Section not in block-index (e.g., blog, gallery) | `references/block-catalog.md` — fall back to category defaults |
+| User wants to browse all options | Direct to https://shadcnblocks.com/explorer/blocks |
+| Need an individual UI element | `references/component-catalog.md` — free components |
+
+---
+
+## Quick Category Reference
+
+For sections **not yet in block-index.md**, use these defaults:
+
+### Content & Blog
+| Need | Category | Start With |
+|------|----------|------------|
+| Blog listing | `blog` (22 variants) | `blog1` |
+| Blog post page | `blogpost` (7 variants) | `blogpost1` |
+| Changelog | `changelog` (7 variants) | `changelog1` |
+| Code snippets | `code-example` (5 variants) | `code-example1` |
+
+### About & Team
+| Need | Category | Start With |
+|------|----------|------------|
+| About section | `about` (17 variants) | `about1` |
+| Team page | `team` (14 variants) | `team1` |
+| Company timeline | `timeline` (15 variants) | `timeline1` |
+| Job listings | `careers` (9 variants) | `careers1` |
+
+### Ecommerce
+| Need | Category | Start With |
+|------|----------|------------|
+| Product cards | `product-card` (10 variants) | `product-card1` |
+| Product listing | `product-list` (10 variants) | `product-list1` |
+| Product detail | `product-detail` (10 variants) | `product-detail1` |
+| Shopping cart | `shopping-cart` (11 variants) | `shopping-cart1` |
+| Checkout | `checkout` (6 variants) | `checkout1` |
+| Order history | `order-history` (5 variants) | `order-history1` |
+
+### App & Dashboard
+| Need | Category | Start With |
+|------|----------|------------|
+| Dashboard charts | `chart-card` (27 variants) | `chart-card10` |
+| Data tables | `data-table` (32 variants) | `data-table1` |
+| App sidebar | `sidebar` (21 variants) | `sidebar1` |
+| App shell layout | `application-shell` (14 variants) | `application-shell1` |
+| User profile | `user-profile` (12 variants) | `user-profile1` |
+
+### Portfolio
+| Need | Category | Start With |
+|------|----------|------------|
+| Image gallery | `gallery` (48 variants) | `gallery1` |
+| Project listing | `projects` (25 variants) | `projects1` |
+| Project detail | `project` (33 variants) | `project1` |
+| Case studies | `case-studies` (6 variants) | `case-studies1` |
+
+### Visual & Decorative
+| Need | Category | Start With |
+|------|----------|------------|
+| Background patterns | `background-pattern` (40 variants) | `background-pattern1` |
+| Animated shaders | `shader` (10 variants) | `shader1` |
+| Bento grid layout | `bento` (8 variants) | `bento1` |
+
+### Navigation & Misc
+| Need | Category | Start With |
+|------|----------|------------|
+| Announcement bar | `banner` (7 variants) | `banner1` |
+| Sale/promo bar | `promo-banner` (7 variants) | `promo-banner1` |
+| Partner logos | `logos` (13 variants) | `logos1` |
+| Comparisons | `compare` (10 variants) | `compare1` |
+
+---
+
+## Selecting the Right Component
+
+Consult `references/component-catalog.md` for the full catalog. Key groups:
+
+| Need | Component Group | Example |
+|------|----------------|---------|
+| Form layout | Form (86) | `form-signin-1` |
+| Labeled input | Field (38) | `field-standard-1` |
+| Input with addon | Input Group (39) | `input-group-standard-1` |
+| Searchable select | Combobox (42) | `combobox-standard-1` |
+| File upload | File Upload (44) | `file-upload-standard-1` |
+| Date picker | Date Picker (8) | `date-picker-standard-1` |
+| Alert message | Alert (25) | `alert-error-1` |
+| Confirm dialog | Alert Dialog (39) | `alert-dialog-standard-1` |
+| Loading skeleton | Skeleton (30) | `skeleton-standard-1` |
+| Toast notification | Sonner (24) | `sonner-standard-1` |
+| Empty state | Empty (22) | `empty-standard-1` |
+| Modal dialog | Dialog (17) | `dialog-standard-1` |
+| Side panel | Sheet (29) / Drawer (22) | `sheet-standard-1` |
+| Accordion | Accordion (21) | `accordion-standard-1` |
+| Data chart | Chart (70) | `chart-standard-1` |
+| Command palette | Command (21) | `command-standard-1` |
+| Dropdown menu | Dropdown Menu (30) | `dropdown-menu-standard-1` |
+| Keyboard shortcuts | KBD (39) | `kbd-standard-1` |
+
+---
+
+## Core Workflow
+
+### 1. Ensure Project Foundation
+
+Verify the project has shadcn/ui initialized. If not:
+
+```bash
+npx shadcn@latest init
+```
+
+This creates `components.json` in the project root.
+
+### 2. Configure ShadcnBlocks Registry
+
+Check if `components.json` already has the `@shadcnblocks` registry. If not, run:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/skills/shadcn-ui/scripts/setup-shadcnblocks.sh" .
+```
+
+This adds the `@shadcnblocks` registry to `components.json` and sets `SHADCNBLOCKS_API_KEY` in `.env`.
+
+If the script can't run (e.g., `jq` missing), configure manually:
+
+1. Add to `.env`: `SHADCNBLOCKS_API_KEY=<key>`
+2. Add registry to `components.json`:
+```json
+{
+  "registries": {
+    "@shadcnblocks": {
+      "url": "https://shadcnblocks.com/r/{name}",
+      "headers": {
+        "Authorization": "Bearer ${SHADCNBLOCKS_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### 3. Select and Install Blocks
+
+Use the intelligent selection flow (above) to recommend the best blocks, then install:
+
+```bash
+# Blocks (full page sections)
+npx shadcn add @shadcnblocks/hero125
+npx shadcn add @shadcnblocks/pricing3
+
+# Components (UI elements)
+npx shadcn add @shadcnblocks/accordion-standard-1
+npx shadcn add @shadcnblocks/file-upload-standard-1
+```
+
+### 4. Compose the Page
+
+Import and compose blocks in the page layout:
+
+```tsx
+import { Navbar1 } from "@/components/navbar1";
+import { Hero125 } from "@/components/hero125";
+import { Feature3 } from "@/components/feature3";
+import { Footer1 } from "@/components/footer1";
+
+export default function LandingPage() {
+  return (
+    <>
+      <Navbar1 />
+      <Hero125 />
+      <Feature3 />
+      <Footer1 />
+    </>
+  );
+}
+```
+
+Blocks are fully editable source code, not locked dependencies. Customize props and content after installation.
+
+## Landing Page Assembly Pattern
+
+For a typical marketing landing page, use the intelligent selection flow for each section. A common assembly:
+
+```bash
+npx shadcn add @shadcnblocks/navbar1      # Simple nav with CTA
+npx shadcn add @shadcnblocks/hero125      # Modern centered hero
+npx shadcn add @shadcnblocks/logos1        # Trust logos strip
+npx shadcn add @shadcnblocks/feature3     # 3-column feature cards
+npx shadcn add @shadcnblocks/stats1       # Metrics bar
+npx shadcn add @shadcnblocks/testimonial1 # Social proof grid
+npx shadcn add @shadcnblocks/pricing3     # 3-tier pricing cards
+npx shadcn add @shadcnblocks/faq1         # Accordion FAQ
+npx shadcn add @shadcnblocks/cta1         # Final call to action
+npx shadcn add @shadcnblocks/footer1      # Multi-column footer
+```
+
+Each of these was selected for a "modern SaaS" tone. For different tones (enterprise, minimal, bold, playful), the selection flow will recommend different variants.
+
+## API Key Management
+
+The ShadcnBlocks API key can be provided in multiple ways (checked in order):
+
+1. **Environment variable** (simplest): Set `SHADCNBLOCKS_API_KEY` in your shell or `.env` file
+2. **1Password CLI**: The helper script uses `op read` to retrieve the key. Set `OP_SHADCNBLOCKS_REF` to your 1Password reference path, or it defaults to `op://Platform Infra/ShadcnBlocks API Key/credential`
+
+Retrieve the key using the helper script:
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/skills/shadcn-ui/scripts/get-api-key.sh"
+```
+
+**Security:** Never hardcode the API key in source files. Always use `.env` with `SHADCNBLOCKS_API_KEY` and ensure `.env` is in `.gitignore`.
+
+## Troubleshooting
+
+| Issue | Resolution |
+|-------|-----------|
+| Auth error on install | Verify `SHADCNBLOCKS_API_KEY` is set in `.env` with a valid key |
+| Registry not found | Check `registries` key exists in `components.json` |
+| `components.json` missing | Run `npx shadcn@latest init` |
+| 1Password access | Run `op signin`; verify vault with `op vault list` |
+| Block not found | Check block name at https://shadcnblocks.com |
+
+## Reference Files
+
+- **`references/block-index.md`** — Tagged picks with selection prompts for intelligent block recommendation (primary source)
+- **`references/block-catalog.md`** — Full catalog of 1,338 blocks across 71 categories with variant numbers and install commands
+- **`references/component-catalog.md`** — Full catalog of 1,189 components across 60+ groups with install syntax
+- **`references/setup-guide.md`** — Detailed step-by-step setup with troubleshooting
+
+## Scripts
+
+- **`scripts/setup-shadcnblocks.sh`** — Automated project setup (retrieves key, configures registry)
+- **`scripts/get-api-key.sh`** — Retrieve API key (env var or 1Password)

--- a/.claude/skills/shadcn-ui/references/block-catalog.md
+++ b/.claude/skills/shadcn-ui/references/block-catalog.md
@@ -1,0 +1,660 @@
+# ShadcnBlocks Block Catalog
+
+> 1,338 blocks across 71 categories. Browse visually at https://shadcnblocks.com/explorer/blocks
+
+## Intelligent Selection
+
+For best-fit block recommendations, consult **`block-index.md`** which contains tagged picks with multi-dimensional metadata (layout, tone, goal, media, interaction) and per-section selection prompts. This catalog serves as the comprehensive reference for all variant numbers and categories.
+
+## Install Syntax
+
+```bash
+npx shadcn add @shadcnblocks/<block-name>
+```
+
+Block names use the pattern `<category><number>` (e.g., `hero1`, `pricing3`, `feature85`).
+
+## Archetypes
+
+Blocks are tagged by use-case archetype:
+
+| Archetype | Count | Description |
+|-----------|-------|-------------|
+| Marketing | 865 | Landing pages, promotional sites, brand pages |
+| App | 190 | Application UI, dashboards, admin panels, settings |
+| Ecommerce | 122 | Product pages, carts, checkout, order management |
+| Portfolio | 111 | Project showcases, galleries, case studies |
+| Background | 50 | Decorative patterns and shader backgrounds |
+
+---
+
+## Block Categories
+
+### Marketing & Landing Page Blocks
+
+#### Hero Sections — `hero` (175 blocks)
+Full-width landing page hero sections with headings, CTAs, imagery, and badges.
+**Common subtypes:** `centered` · `split_left/right_media` · `full_bleed` · `form_capture` · `video` · `with_logos`
+**Variants:** 1-16, 18, 20, 21, 24-40, 45, 47, 49-51, 53, 55, 57-60, 64, 67, 68, 70, 71, 74-76, 78-80, 82-87, 89-91, 99-101, 103, 104, 107, 108, 111, 112, 115, 116, 123, 125, 127, 129, 134-136, 141, 143-146, 149, 151, 152, 157-160, 162-168, 170-175, 177-180, 183, 185-187, 187a, 187b, 190, 192, 194-197, 200-206, 210-216, 218-234, 234a, 234b, 236-248, 256, 258, 259
+```bash
+npx shadcn add @shadcnblocks/hero1       # 2-column with badge, heading, CTA buttons, and image
+npx shadcn add @shadcnblocks/hero125     # Modern centered with gradient accents
+npx shadcn add @shadcnblocks/hero200     # Multi-CTA with feature highlights
+```
+
+#### Feature Sections — `feature` (272 blocks)
+Feature grids, showcases, comparison sections, and benefit highlights.
+**Common subtypes:** `grid_cards` · `grid_icons` · `alternating` · `bento` · `tabs` · `checklist` · `split_media` · `stacked`
+**Variants:** 1-44, 50-83, 85-99, 101-207, 209-225, 227-257, 261, 266-272, 274-289, 292-295, 297, 299, 312-314, 322, 323
+```bash
+npx shadcn add @shadcnblocks/feature1    # 2-column split with image
+npx shadcn add @shadcnblocks/feature3    # 3-column card grid with icons
+npx shadcn add @shadcnblocks/feature10   # 4-column icon grid ("Why Us?" style)
+npx shadcn add @shadcnblocks/feature14   # Alternating rows with checklists
+npx shadcn add @shadcnblocks/feature42   # Tabbed feature explorer
+```
+
+#### CTA (Call to Action) — `cta` (26 blocks)
+Conversion-focused sections with buttons, forms, and urgency elements.
+**Common subtypes:** `simple_button` · `form_capture` · `split_with_image` · `multi_action` · `with_social_proof`
+**Variants:** 1, 3-7, 10-23, 26-28, 30-32
+```bash
+npx shadcn add @shadcnblocks/cta1    # Simple headline + button
+npx shadcn add @shadcnblocks/cta10   # Email capture form
+npx shadcn add @shadcnblocks/cta20   # Multiple action paths
+```
+
+#### Pricing — `pricing` (35 blocks)
+Pricing tables, cards, tier comparisons, and toggle monthly/annual layouts.
+**Common subtypes:** `grid_cards` · `comparison_table` · `toggle` · `single_plan` · `enterprise`
+**Variants:** 1-16, 20-24, 26-38, 40
+```bash
+npx shadcn add @shadcnblocks/pricing3    # 3-tier cards with highlighted plan
+npx shadcn add @shadcnblocks/pricing8    # Monthly/annual toggle
+npx shadcn add @shadcnblocks/pricing11   # Feature comparison table
+```
+
+#### Testimonial — `testimonial` (28 blocks)
+Customer quotes, review carousels, social proof, and rating displays.
+**Common subtypes:** `grid_cards` · `carousel` · `featured_single` · `masonry` · `star_ratings` · `video`
+**Variants:** 1-4, 6-21, 23-30
+```bash
+npx shadcn add @shadcnblocks/testimonial1  # Quote cards grid with avatars
+npx shadcn add @shadcnblocks/testimonial3  # Single large featured quote
+npx shadcn add @shadcnblocks/testimonial8  # Scrollable carousel
+```
+
+#### FAQ — `faq` (16 blocks)
+Frequently asked questions with accordion, list, or grid layouts.
+**Common subtypes:** `accordion` · `grid` · `sidebar_categories` · `with_contact_cta`
+**Variants:** 1-12, 14-17
+```bash
+npx shadcn add @shadcnblocks/faq1    # Classic accordion
+npx shadcn add @shadcnblocks/faq5    # Two-column grid (all visible)
+npx shadcn add @shadcnblocks/faq10   # Category sidebar navigation
+```
+
+#### Stats — `stats` (18 blocks)
+Metrics, counters, KPIs, and data visualization sections.
+**Common subtypes:** `number_row` · `with_icons` · `with_image` · `animated_counters`
+**Variants:** 1, 2, 4-19
+```bash
+npx shadcn add @shadcnblocks/stats1    # Bold numbers in a row
+npx shadcn add @shadcnblocks/stats5    # Stats with icons and descriptions
+npx shadcn add @shadcnblocks/stats10   # Split section with image
+```
+
+#### Logos — `logos` (13 blocks)
+Partner, client, or technology logo showcase strips and clouds.
+**Variants:** 1-5, 7-13
+```bash
+npx shadcn add @shadcnblocks/logos1
+```
+
+#### Trust Strip — `trust-strip` (4 blocks)
+Compact trust indicator bars (certifications, partner logos, security badges).
+**Variants:** 1-4
+```bash
+npx shadcn add @shadcnblocks/trust-strip1
+```
+
+#### Compare — `compare` (10 blocks)
+Side-by-side product or feature comparison layouts.
+**Variants:** 1-10
+```bash
+npx shadcn add @shadcnblocks/compare1
+```
+
+#### Compare Products — `compare-products` (3 blocks)
+Detailed product-vs-product comparison tables.
+**Variants:** 1-3
+```bash
+npx shadcn add @shadcnblocks/compare-products1
+```
+
+#### Integration — `integration` (16 blocks)
+Integration partner grids, API showcases, and connected services displays.
+**Variants:** 1-13
+```bash
+npx shadcn add @shadcnblocks/integration1
+```
+
+#### Community — `community` (7 blocks)
+Community sections with member counts, forums, or open-source contributor displays.
+**Variants:** 1-7
+```bash
+npx shadcn add @shadcnblocks/community1
+```
+
+#### Awards — `awards` (5 blocks)
+Award badges, recognition sections, and achievement displays.
+**Variants:** 1-5
+```bash
+npx shadcn add @shadcnblocks/awards1
+```
+
+#### Incentives — `incentives` (4 blocks)
+Value proposition strips (free shipping, money-back guarantee, etc.).
+**Variants:** 1, 2, 6, 7
+```bash
+npx shadcn add @shadcnblocks/incentives1
+```
+
+#### Industries — `industries` (4 blocks)
+Industry-specific landing sections or vertical market showcases.
+**Variants:** 1-4
+```bash
+npx shadcn add @shadcnblocks/industries1
+```
+
+---
+
+### Navigation & Layout Blocks
+
+#### Navbar — `navbar` (18 blocks)
+Navigation bars, site headers, and mega menus.
+**Common subtypes:** `simple` · `dropdown` · `mega_menu` · `centered_logo` · `app_style`
+**Variants:** 1-11, 14, 17, 18, 21, 22, 24, 29
+```bash
+npx shadcn add @shadcnblocks/navbar1    # Simple logo + links + CTA
+npx shadcn add @shadcnblocks/navbar5    # With dropdown menus
+npx shadcn add @shadcnblocks/navbar9    # Mega menu with rich panels
+```
+
+#### Footer — `footer` (25 blocks)
+Page footers with links, social icons, newsletter signup, and legal links.
+**Common subtypes:** `multi_column` · `simple_row` · `with_newsletter` · `with_cta` · `minimal`
+**Variants:** 1-18, 23-25, 27, 30-32
+```bash
+npx shadcn add @shadcnblocks/footer1    # Multi-column with link groups
+npx shadcn add @shadcnblocks/footer5    # Simple single row
+npx shadcn add @shadcnblocks/footer10   # With newsletter signup form
+```
+
+#### Banner — `banner` (7 blocks)
+Top-of-page announcement banners and notification bars.
+**Variants:** 1-7
+```bash
+npx shadcn add @shadcnblocks/banner1
+```
+
+#### Promo Banner — `promo-banner` (7 blocks)
+Promotional banners for sales, events, or product launches.
+**Variants:** 1-7
+```bash
+npx shadcn add @shadcnblocks/promo-banner1
+```
+
+---
+
+### Content & Blog Blocks
+
+#### Blog — `blog` (22 blocks)
+Blog listing pages, post grids, featured article layouts.
+**Variants:** 1, 4-8, 11-14, 16, 17, 19, 21-24, 26-30
+```bash
+npx shadcn add @shadcnblocks/blog1
+```
+
+#### Blog Post — `blogpost` (7 blocks)
+Individual blog post page layouts with content, author, and metadata.
+**Variants:** 1-7
+```bash
+npx shadcn add @shadcnblocks/blogpost1
+```
+
+#### Content — `content` (4 blocks)
+Generic content sections with rich text and media.
+**Variants:** 1-4
+```bash
+npx shadcn add @shadcnblocks/content1
+```
+
+#### Changelog — `changelog` (7 blocks)
+Product changelog and release notes displays.
+**Variants:** 1-6, 8
+```bash
+npx shadcn add @shadcnblocks/changelog1
+```
+
+#### Code Example — `code-example` (5 blocks)
+Code snippet displays with syntax highlighting and copy buttons.
+**Variants:** 1-5
+```bash
+npx shadcn add @shadcnblocks/code-example1
+```
+
+#### Resources — `resources` (5 blocks)
+Resource library, downloadable content, or documentation link grids.
+**Variants:** 1-5
+```bash
+npx shadcn add @shadcnblocks/resources1
+```
+
+#### Resource — `resource` (3 blocks)
+Single resource detail or download page layout.
+**Variants:** 1-3
+```bash
+npx shadcn add @shadcnblocks/resource1
+```
+
+---
+
+### About & Team Blocks
+
+#### About — `about` (17 blocks)
+Company about sections, mission statements, and origin stories.
+**Variants:** 1-10, 13-19
+```bash
+npx shadcn add @shadcnblocks/about1
+```
+
+#### Team — `team` (14 blocks)
+Team member grids, profile cards, and org charts.
+**Variants:** 1-13, 15
+```bash
+npx shadcn add @shadcnblocks/team1
+```
+
+#### Timeline — `timeline` (15 blocks)
+Company history, roadmap, or milestone timeline displays.
+**Variants:** 1-14
+```bash
+npx shadcn add @shadcnblocks/timeline1
+```
+
+#### Experience — `experience` (4 blocks)
+Work experience, resume, or professional background sections.
+**Variants:** 1-3, 5
+```bash
+npx shadcn add @shadcnblocks/experience1
+```
+
+#### Skills — `skills` (2 blocks)
+Skill bars, competency charts, or expertise displays.
+**Variants:** 1, 2
+```bash
+npx shadcn add @shadcnblocks/skills1
+```
+
+#### Careers — `careers` (9 blocks)
+Job listing pages, open positions, and career sections.
+**Variants:** 1-9
+```bash
+npx shadcn add @shadcnblocks/careers1
+```
+
+---
+
+### Contact & Forms Blocks
+
+#### Contact — `contact` (17 blocks)
+Contact forms, maps, and company contact information sections.
+**Common subtypes:** `form_with_sidebar` · `centered_form` · `contact_cards` · `with_map`
+**Variants:** 1-11, 14, 16-20
+```bash
+npx shadcn add @shadcnblocks/contact1    # Form with info sidebar
+npx shadcn add @shadcnblocks/contact5    # Centered form only
+npx shadcn add @shadcnblocks/contact10   # Contact method cards
+```
+
+#### Signup — `signup` (10 blocks)
+Account registration forms and onboarding flows.
+**Variants:** 1-10
+```bash
+npx shadcn add @shadcnblocks/signup1
+```
+
+#### Login — `login` (8 blocks)
+Login forms with email/password, social login, and SSO options.
+**Variants:** 1-7, 9
+```bash
+npx shadcn add @shadcnblocks/login1
+```
+
+#### Book a Demo — `book-a-demo` (3 blocks)
+Demo scheduling sections with calendar or form integration.
+**Variants:** 1-3
+```bash
+npx shadcn add @shadcnblocks/book-a-demo1
+```
+
+#### Waitlist — `waitlist` (4 blocks)
+Pre-launch waitlist signup forms.
+**Variants:** 1-3
+```bash
+npx shadcn add @shadcnblocks/waitlist1
+```
+
+#### Download — `download` (13 blocks)
+App download sections, file download pages, and store links.
+**Variants:** 1-11, 13
+```bash
+npx shadcn add @shadcnblocks/download1
+```
+
+#### Compliance — `compliance` (4 blocks)
+GDPR, privacy policy, and compliance information sections.
+**Variants:** 1, 5-7
+```bash
+npx shadcn add @shadcnblocks/compliance1
+```
+
+---
+
+### Portfolio & Projects Blocks
+
+#### Gallery — `gallery` (48 blocks)
+Image galleries, masonry layouts, and portfolio grids.
+**Variants:** 1-35
+```bash
+npx shadcn add @shadcnblocks/gallery1
+```
+
+#### Projects — `projects` (25 blocks)
+Project listing pages with cards, filters, and detail links.
+**Variants:** 1-18, 15a-15e, 17a, 17b
+```bash
+npx shadcn add @shadcnblocks/projects1
+```
+
+#### Project — `project` (33 blocks)
+Individual project detail pages with images, descriptions, and tech stacks.
+**Variants:** 1, 2, 2a-2d, 4, 4a-4c, 5, 5a-5g, 6, 6a, 7, 8, 8a-8e, 9, 10, 12, 13, 13a, 14
+```bash
+npx shadcn add @shadcnblocks/project1
+```
+
+#### Case Studies — `case-studies` (6 blocks)
+Case study listing pages and client success story grids.
+**Variants:** 1-5
+```bash
+npx shadcn add @shadcnblocks/case-studies1
+```
+
+#### Case Study — `case-study` (3 blocks)
+Individual case study detail layouts.
+**Variants:** 1, 3, 8
+```bash
+npx shadcn add @shadcnblocks/case-study1
+```
+
+#### Reviews — `reviews` (10 blocks)
+Customer review sections, star ratings, and feedback displays.
+**Variants:** 1-6, 8, 9, 18, 23
+```bash
+npx shadcn add @shadcnblocks/reviews1
+```
+
+---
+
+### Ecommerce Blocks
+
+#### Product Card — `product-card` (10 blocks)
+Product cards for grids and listings with image, price, and actions.
+**Variants:** 1-10
+```bash
+npx shadcn add @shadcnblocks/product-card1
+```
+
+#### Product List — `product-list` (10 blocks)
+Product listing pages with filters, sorting, and grid/list toggle.
+**Variants:** 1-10
+```bash
+npx shadcn add @shadcnblocks/product-list1
+```
+
+#### Product Detail — `product-detail` (10 blocks)
+Full product detail pages with gallery, specs, and add-to-cart.
+**Variants:** 1-10
+```bash
+npx shadcn add @shadcnblocks/product-detail1
+```
+
+#### Product Categories — `product-categories` (5 blocks)
+Category browsing grids and navigation sections.
+**Variants:** 1-5
+```bash
+npx shadcn add @shadcnblocks/product-categories1
+```
+
+#### Product Gallery — `product-gallery` (5 blocks)
+Product image galleries with zoom and thumbnails.
+**Variants:** 1-4, 7
+```bash
+npx shadcn add @shadcnblocks/product-gallery1
+```
+
+#### Product Quick View — `product-quick-view` (4 blocks)
+Modal/overlay product previews for quick browsing.
+**Variants:** 4-7
+```bash
+npx shadcn add @shadcnblocks/product-quick-view4
+```
+
+#### Product Specs — `product-specs` (2 blocks)
+Technical specification tables and comparison charts.
+**Variants:** 1, 2
+```bash
+npx shadcn add @shadcnblocks/product-specs1
+```
+
+#### Shopping Cart — `shopping-cart` (11 blocks)
+Cart pages, mini-carts, and cart drawers.
+**Variants:** 1-3, 7, 14-20
+```bash
+npx shadcn add @shadcnblocks/shopping-cart1
+```
+
+#### Checkout — `checkout` (6 blocks)
+Checkout flows, payment forms, and order review pages.
+**Variants:** 1-5, 8
+```bash
+npx shadcn add @shadcnblocks/checkout1
+```
+
+#### Order Summary — `order-summary` (6 blocks)
+Order confirmation and summary sections.
+**Variants:** 1-6
+```bash
+npx shadcn add @shadcnblocks/order-summary1
+```
+
+#### Order History — `order-history` (5 blocks)
+Past orders listing and order tracking pages.
+**Variants:** 1-5
+```bash
+npx shadcn add @shadcnblocks/order-history1
+```
+
+#### Payment Methods — `payment-methods` (4 blocks)
+Saved payment method management sections.
+**Variants:** 1-4
+```bash
+npx shadcn add @shadcnblocks/payment-methods1
+```
+
+#### Ecommerce Footer — `ecommerce-footer` (4 blocks)
+Footers tailored for ecommerce with shop links, policies, and payment icons.
+**Variants:** 1, 2, 19, 20
+```bash
+npx shadcn add @shadcnblocks/ecommerce-footer1
+```
+
+#### Live Purchase — `live-purchase` (3 blocks)
+Real-time purchase notification popups and social proof.
+**Variants:** 1-3
+```bash
+npx shadcn add @shadcnblocks/live-purchase1
+```
+
+#### Offer Modal — `offer-modal` (3 blocks)
+Promotional modals for discounts, exit-intent, and special offers.
+**Variants:** 1, 4, 5
+```bash
+npx shadcn add @shadcnblocks/offer-modal1
+```
+
+#### Wishlist — `wishlist` (2 blocks)
+Wishlist/favorites pages and saved item displays.
+**Variants:** 1, 2
+```bash
+npx shadcn add @shadcnblocks/wishlist1
+```
+
+---
+
+### Services Blocks
+
+#### Services — `services` (19 blocks)
+Services listing pages and offering overviews.
+**Variants:** 1, 3-16, 18-21
+```bash
+npx shadcn add @shadcnblocks/services1
+```
+
+#### Service — `service` (7 blocks)
+Individual service detail pages.
+**Variants:** 1-7
+```bash
+npx shadcn add @shadcnblocks/service1
+```
+
+#### Process — `process` (4 blocks)
+Step-by-step process or workflow visualizations.
+**Variants:** 1-4
+```bash
+npx shadcn add @shadcnblocks/process1
+```
+
+#### Rate Card — `rate-card` (2 blocks)
+Pricing rate cards for services or consulting.
+**Variants:** 1, 2
+```bash
+npx shadcn add @shadcnblocks/rate-card1
+```
+
+---
+
+### App & Dashboard Blocks
+
+#### Chart Card — `chart-card` (27 blocks)
+Dashboard chart cards with line, bar, area, and pie charts.
+**Variants:** 10-27 (newest first in explorer)
+```bash
+npx shadcn add @shadcnblocks/chart-card10
+```
+
+#### Data Table — `data-table` (32 blocks)
+Data tables with sorting, filtering, pagination, and row actions.
+```bash
+npx shadcn add @shadcnblocks/data-table1
+```
+
+#### Sidebar — `sidebar` (21 blocks)
+Application sidebar navigation layouts.
+```bash
+npx shadcn add @shadcnblocks/sidebar1
+```
+
+#### Application Shell — `application-shell` (14 blocks)
+Full app layout shells with sidebar, header, and content area.
+```bash
+npx shadcn add @shadcnblocks/application-shell1
+```
+
+#### User Profile — `user-profile` (12 blocks)
+User profile pages with avatar, info, and activity.
+```bash
+npx shadcn add @shadcnblocks/user-profile1
+```
+
+---
+
+### Misc Blocks
+
+#### Background Pattern — `background-pattern` (40 blocks)
+Decorative SVG/CSS background patterns.
+**Variants:** 1-40
+```bash
+npx shadcn add @shadcnblocks/background-pattern1
+```
+
+#### Shader — `shader` (10 blocks)
+WebGL/Canvas animated shader backgrounds.
+**Variants:** 1-10
+```bash
+npx shadcn add @shadcnblocks/shader1
+```
+
+#### Bento — `bento` (8 blocks)
+Bento grid layouts for feature or content showcases.
+```bash
+npx shadcn add @shadcnblocks/bento1
+```
+
+#### Address Book — `address-book` (2 blocks)
+Address management and contact list components.
+**Variants:** 1, 2
+```bash
+npx shadcn add @shadcnblocks/address-book1
+```
+
+#### Help — `help` (2 blocks)
+Help center or support page layouts.
+**Variants:** 1, 2
+```bash
+npx shadcn add @shadcnblocks/help1
+```
+
+#### List — `list` (3 blocks)
+Generic list layouts with various item styles.
+**Variants:** 1-3
+```bash
+npx shadcn add @shadcnblocks/list1
+```
+
+---
+
+## Quick Reference: Choosing the Right Block
+
+| Need | Recommended Category | Start With |
+|------|---------------------|------------|
+| Landing page hero | `hero` | `hero1` (classic), `hero125` (modern) |
+| Show features/benefits | `feature` | `feature1` (grid), `feature8` (alternating) |
+| Pricing page | `pricing` | `pricing3` (cards), `pricing11` (comparison) |
+| Customer proof | `testimonial` | `testimonial1` (quotes), `reviews1` (stars) |
+| Drive signups | `cta` | `cta1` (simple), `signup1` (full form) |
+| Q&A section | `faq` | `faq1` (accordion) |
+| Site navigation | `navbar` | `navbar1` (standard), `navbar9` (mega menu) |
+| Site footer | `footer` | `footer1` (multi-column) |
+| Blog listing | `blog` | `blog1` (grid cards) |
+| Product catalog | `product-list` | `product-list1` |
+| Shopping cart | `shopping-cart` | `shopping-cart1` |
+| Dashboard charts | `chart-card` | `chart-card10` |
+| Data management | `data-table` | `data-table1` |
+| About company | `about` | `about1` |
+| Team page | `team` | `team1` (grid) |
+| Contact page | `contact` | `contact1` (form + info) |
+| Portfolio | `projects` / `gallery` | `projects1`, `gallery1` |
+| Background decoration | `background-pattern` | `background-pattern1` |

--- a/.claude/skills/shadcn-ui/references/block-index.md
+++ b/.claude/skills/shadcn-ui/references/block-index.md
@@ -1,0 +1,1146 @@
+# Block Index — Tagged Picks for Intelligent Selection
+
+> Curated, tagged subset of blocks for the 10 highest-traffic sections. Used by the skill to narrow hundreds of options to 2-3 best-fit recommendations via 0-2 questions.
+
+For the full untagged catalog, see `block-catalog.md`.
+
+## How This Works
+
+1. Claude infers constraints from the user's request (section, goal, layout hints)
+2. If ambiguity remains, Claude asks 1-2 targeted questions using `selection_prompts`
+3. The user's answers map to tag filters
+4. Claude matches against the `blocks` entries below and returns 2-3 best picks with reasoning
+
+---
+
+## Tag Vocabulary
+
+```yaml
+layout:
+  - centered           # Content centered, single column flow
+  - split_left_media   # 2-col: media left, text right
+  - split_right_media  # 2-col: text left, media right
+  - grid_cards         # 3-4 column card grid
+  - grid_icons         # Icon-driven grid (no large images)
+  - bento              # Asymmetric/mixed-size grid
+  - alternating        # Rows alternate text/media sides
+  - stacked            # Vertically stacked sections
+  - full_bleed         # Full-width background image/media
+  - comparison_table   # Side-by-side comparison layout
+  - sidebar            # Content with sidebar
+  - multi_column       # 4+ columns of content
+  - carousel           # Horizontally scrollable
+  - timeline           # Sequential/chronological layout
+  - masonry            # Pinterest-style varied heights
+
+content_density:
+  - minimal            # Few elements, lots of whitespace
+  - standard           # Balanced content and space
+  - rich               # Dense with many elements/details
+
+tone:
+  - minimal            # Clean, simple, lots of whitespace
+  - modern             # Contemporary, sharp, current trends
+  - bold               # High contrast, large type, dramatic
+  - playful            # Rounded, colorful, friendly
+  - enterprise         # Professional, structured, conservative
+  - elegant            # Refined, subtle, sophisticated
+
+goal:
+  - awareness          # Brand/product introduction
+  - explain            # Describe features/benefits
+  - trust              # Social proof, credibility
+  - convert            # Drive specific action (signup, purchase)
+  - capture_leads      # Collect email/contact info
+  - compare            # Help users evaluate options
+  - navigate           # Wayfinding and site structure
+  - support            # Help/FAQ/contact
+
+cta_pattern:
+  - none               # No call-to-action
+  - single_primary     # One main button
+  - primary_secondary  # Main + secondary button
+  - form_capture       # Email/contact form
+  - multi_action       # Multiple distinct actions
+  - link_list          # Multiple text links
+
+media:
+  - none               # No images/media
+  - screenshot         # Product/app screenshot
+  - illustration       # Custom illustration or graphic
+  - photo              # Photography
+  - video              # Video embed or background
+  - icons              # Icon-driven (no large media)
+  - logos              # Brand/partner logos
+  - avatars            # People photos/avatars
+  - chart              # Data visualization
+
+interaction:
+  - static             # No interactive elements
+  - accordion          # Expandable/collapsible sections
+  - tabs               # Tabbed content switching
+  - carousel           # Horizontally scrollable
+  - toggle             # On/off or monthly/annual switch
+  - hover              # Hover-reveal effects
+  - filters            # Filterable content
+
+items_count:
+  - few                # 1-3 items
+  - moderate           # 4-6 items
+  - many               # 7+ items
+
+complexity:
+  - low                # Simple markup, quick to customize
+  - medium             # Moderate markup, some configuration
+  - high               # Complex markup, significant setup
+```
+
+---
+
+## Selection Prompts
+
+These are the 1-2 questions Claude asks when the user's request is ambiguous within a section. Each option maps to tag filters used to match blocks.
+
+```yaml
+selection_prompts:
+
+  hero:
+    question: "What style of hero section fits your page?"
+    options:
+      - label: "Centered headline with CTA buttons"
+        description: "Clean, focused — great for SaaS and product launches"
+        tags: { layout: [centered], cta_pattern: [single_primary, primary_secondary] }
+      - label: "Split layout with product screenshot"
+        description: "Show your product alongside the pitch — ideal for app landing pages"
+        tags: { layout: [split_left_media, split_right_media], media: [screenshot] }
+      - label: "Hero with email/lead capture form"
+        description: "Convert visitors immediately — best for waitlists, newsletters, early access"
+        tags: { cta_pattern: [form_capture] }
+      - label: "Bold visual with background image or video"
+        description: "High-impact first impression — great for creative, agency, or event sites"
+        tags: { layout: [full_bleed], media: [photo, video] }
+
+  feature:
+    question: "How do you want to showcase your features?"
+    options:
+      - label: "Card grid (3-4 columns with icons)"
+        description: "Classic feature grid — each feature gets its own card with icon and description"
+        tags: { layout: [grid_cards, grid_icons], items_count: [moderate, many] }
+      - label: "Alternating image + text rows"
+        description: "Deep-dive into each feature with large visuals — great for product tours"
+        tags: { layout: [alternating, split_left_media, split_right_media], media: [screenshot, illustration] }
+      - label: "Bento / asymmetric grid"
+        description: "Modern, editorial layout with mixed-size cards — visually distinctive"
+        tags: { layout: [bento], tone: [modern, bold] }
+      - label: "Simple icon list or checklist"
+        description: "Compact, scannable — works well for benefit lists and comparisons"
+        tags: { layout: [grid_icons, stacked], content_density: [minimal, standard] }
+
+  pricing:
+    question: "What pricing layout works best?"
+    options:
+      - label: "Pricing cards (2-4 tiers side by side)"
+        description: "Standard tier cards — clear comparison with CTAs per plan"
+        tags: { layout: [grid_cards], items_count: [few, moderate] }
+      - label: "Comparison table with feature rows"
+        description: "Detailed feature-by-feature comparison — best when tiers differ significantly"
+        tags: { layout: [comparison_table] }
+      - label: "Toggle between monthly/annual"
+        description: "Interactive pricing with billing toggle — highlights annual savings"
+        tags: { interaction: [toggle] }
+
+  testimonial:
+    question: "What type of social proof do you need?"
+    options:
+      - label: "Quote cards in a grid"
+        description: "Multiple testimonials displayed at once — great for volume of proof"
+        tags: { layout: [grid_cards], media: [avatars] }
+      - label: "Featured single quote (large)"
+        description: "One powerful testimonial front and center — high impact"
+        tags: { layout: [centered], content_density: [minimal] }
+      - label: "Scrollable carousel"
+        description: "Many testimonials in compact space — swipe through quotes"
+        tags: { layout: [carousel], interaction: [carousel] }
+      - label: "Star ratings / review cards"
+        description: "Ratings-focused — ideal for product reviews and aggregate scores"
+        tags: { media: [avatars], goal: [trust] }
+
+  cta:
+    question: "What's the primary conversion goal?"
+    options:
+      - label: "Simple CTA with headline + button"
+        description: "Clean, focused call to action — drives one clear next step"
+        tags: { cta_pattern: [single_primary, primary_secondary], content_density: [minimal] }
+      - label: "CTA with email capture form"
+        description: "Collect leads inline — great for newsletters, waitlists"
+        tags: { cta_pattern: [form_capture] }
+      - label: "CTA with multiple actions"
+        description: "Give visitors options — book demo, start trial, contact sales"
+        tags: { cta_pattern: [multi_action] }
+
+  faq:
+    question: "How should FAQ items be displayed?"
+    options:
+      - label: "Accordion (expand/collapse)"
+        description: "Compact, scannable — users click to reveal answers"
+        tags: { interaction: [accordion], layout: [stacked] }
+      - label: "Grid layout (all visible)"
+        description: "All answers visible at once — good for fewer questions"
+        tags: { layout: [grid_cards], interaction: [static] }
+      - label: "Two-column with sidebar"
+        description: "Categories on the left, questions on the right"
+        tags: { layout: [sidebar] }
+
+  navbar:
+    question: "What navigation style do you need?"
+    options:
+      - label: "Simple navbar (logo + links + CTA)"
+        description: "Clean top nav — works for most marketing sites"
+        tags: { content_density: [minimal], cta_pattern: [single_primary] }
+      - label: "Mega menu with dropdowns"
+        description: "Rich navigation with categories — for sites with many pages"
+        tags: { content_density: [rich], interaction: [hover] }
+      - label: "App-style navbar with user menu"
+        description: "Authenticated nav with avatar, notifications — for dashboards/apps"
+        tags: { goal: [navigate], media: [avatars] }
+
+  footer:
+    question: "What footer layout do you prefer?"
+    options:
+      - label: "Multi-column with link groups"
+        description: "Classic footer with organized link columns — Product, Company, Resources, etc."
+        tags: { layout: [multi_column], content_density: [standard, rich] }
+      - label: "Simple footer (logo + links + social)"
+        description: "Compact single-row footer — works for smaller sites"
+        tags: { layout: [centered], content_density: [minimal] }
+      - label: "Footer with newsletter signup"
+        description: "Includes email capture alongside links — maximize conversion"
+        tags: { cta_pattern: [form_capture] }
+
+  contact:
+    question: "What contact layout do you need?"
+    options:
+      - label: "Contact form with info sidebar"
+        description: "Form + address/phone/email displayed alongside"
+        tags: { layout: [split_left_media, split_right_media], cta_pattern: [form_capture] }
+      - label: "Contact form only (centered)"
+        description: "Clean, focused form — no distractions"
+        tags: { layout: [centered], cta_pattern: [form_capture] }
+      - label: "Contact cards (email, phone, office)"
+        description: "Multiple contact methods displayed as cards — no form"
+        tags: { layout: [grid_cards], cta_pattern: [multi_action] }
+
+  stats:
+    question: "How should metrics be displayed?"
+    options:
+      - label: "Number counters in a row"
+        description: "Bold numbers with labels — classic stats strip"
+        tags: { layout: [grid_cards], content_density: [minimal] }
+      - label: "Stats with icons and descriptions"
+        description: "More context per metric — includes supporting text"
+        tags: { layout: [grid_icons], content_density: [standard] }
+      - label: "Stats integrated with content"
+        description: "Numbers woven into a narrative section — more editorial"
+        tags: { layout: [split_left_media, split_right_media], content_density: [rich] }
+```
+
+---
+
+## Curated Block Entries
+
+Each entry is tagged across multiple dimensions. Claude matches user constraints against these tags to find the best 2-3 recommendations.
+
+### Hero Section Picks
+
+```yaml
+hero_blocks:
+  - id: hero1
+    why: "Classic 2-column hero — badge, heading, dual CTAs, and product image"
+    layout: [split_right_media]
+    content_density: standard
+    tone: [modern]
+    goal: [awareness, convert]
+    cta_pattern: primary_secondary
+    media: [screenshot]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: hero5
+    why: "Centered hero with large heading and single CTA — minimal and focused"
+    layout: [centered]
+    content_density: minimal
+    tone: [minimal, modern]
+    goal: [awareness]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: hero10
+    why: "Split layout with phone/device mockup — ideal for mobile app landing pages"
+    layout: [split_left_media]
+    content_density: standard
+    tone: [modern]
+    goal: [awareness, convert]
+    cta_pattern: primary_secondary
+    media: [screenshot]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: hero25
+    why: "Full-width background image hero with overlay text — high visual impact"
+    layout: [full_bleed]
+    content_density: minimal
+    tone: [bold, elegant]
+    goal: [awareness]
+    cta_pattern: primary_secondary
+    media: [photo]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: hero30
+    why: "Centered hero with email capture form — built for lead generation"
+    layout: [centered]
+    content_density: standard
+    tone: [modern]
+    goal: [capture_leads, convert]
+    cta_pattern: form_capture
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: medium
+
+  - id: hero40
+    why: "Hero with partner/trust logos strip below — combines intro with social proof"
+    layout: [centered]
+    content_density: standard
+    tone: [enterprise, modern]
+    goal: [awareness, trust]
+    cta_pattern: primary_secondary
+    media: [logos]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: hero80
+    why: "Split hero with video embed — show don't tell with product demo"
+    layout: [split_right_media]
+    content_density: standard
+    tone: [modern]
+    goal: [awareness, explain]
+    cta_pattern: primary_secondary
+    media: [video]
+    interaction: [static]
+    items_count: few
+    complexity: medium
+
+  - id: hero125
+    why: "Modern centered hero with gradient accents — popular choice for SaaS"
+    layout: [centered]
+    content_density: standard
+    tone: [modern, bold]
+    goal: [awareness, convert]
+    cta_pattern: primary_secondary
+    media: [screenshot]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: hero160
+    why: "Animated/gradient background hero — eye-catching for creative brands"
+    layout: [centered]
+    content_density: minimal
+    tone: [bold, playful]
+    goal: [awareness]
+    cta_pattern: single_primary
+    media: [illustration]
+    interaction: [hover]
+    items_count: few
+    complexity: medium
+
+  - id: hero200
+    why: "Multi-CTA hero with feature highlights — packed landing page opener"
+    layout: [split_right_media]
+    content_density: rich
+    tone: [enterprise]
+    goal: [awareness, convert, explain]
+    cta_pattern: multi_action
+    media: [screenshot]
+    interaction: [static]
+    items_count: moderate
+    complexity: medium
+
+  - id: hero230
+    why: "Bold typographic hero — text-focused with strong visual hierarchy"
+    layout: [centered]
+    content_density: minimal
+    tone: [bold, elegant]
+    goal: [awareness]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: hero245
+    why: "Dashboard preview hero — shows full app interface as the hero image"
+    layout: [stacked]
+    content_density: standard
+    tone: [modern, enterprise]
+    goal: [awareness, explain]
+    cta_pattern: primary_secondary
+    media: [screenshot]
+    interaction: [static]
+    items_count: few
+    complexity: low
+```
+
+### Feature Section Picks
+
+```yaml
+feature_blocks:
+  - id: feature1
+    why: "2-column split with title, description, dual CTAs, and image"
+    layout: [split_right_media]
+    content_density: standard
+    tone: [modern]
+    goal: [explain]
+    cta_pattern: primary_secondary
+    media: [screenshot]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: feature3
+    why: "3-column card grid — each card has icon, title, text, and image"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [modern]
+    goal: [explain]
+    cta_pattern: link_list
+    media: [screenshot]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: feature5
+    why: "Bento-style asymmetric grid with cards of varying widths"
+    layout: [bento]
+    content_density: standard
+    tone: [modern, bold]
+    goal: [explain]
+    cta_pattern: none
+    media: [icons, screenshot]
+    interaction: [static]
+    items_count: few
+    complexity: medium
+
+  - id: feature8
+    why: "Title + 2 feature showcase cards with logos and learn-more links"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [enterprise]
+    goal: [explain]
+    cta_pattern: link_list
+    media: [logos]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: feature10
+    why: "4-column icon grid — 'Why Us?' style with icon, title, and description per item"
+    layout: [grid_icons]
+    content_density: minimal
+    tone: [minimal, modern]
+    goal: [explain, trust]
+    cta_pattern: none
+    media: [icons]
+    interaction: [static]
+    items_count: moderate
+    complexity: low
+
+  - id: feature14
+    why: "2-column alternating sections with checkmark feature lists and images"
+    layout: [alternating]
+    content_density: standard
+    tone: [enterprise, modern]
+    goal: [explain]
+    cta_pattern: none
+    media: [screenshot]
+    interaction: [static]
+    items_count: moderate
+    complexity: medium
+
+  - id: feature25
+    why: "4-column layout with checkmark lists — compact benefit overview"
+    layout: [multi_column]
+    content_density: standard
+    tone: [enterprise]
+    goal: [explain]
+    cta_pattern: none
+    media: [none]
+    interaction: [static]
+    items_count: many
+    complexity: low
+
+  - id: feature42
+    why: "Tabbed feature explorer — users click tabs to see different feature details"
+    layout: [stacked]
+    content_density: rich
+    tone: [modern]
+    goal: [explain]
+    cta_pattern: none
+    media: [screenshot]
+    interaction: [tabs]
+    items_count: moderate
+    complexity: high
+
+  - id: feature50
+    why: "Large single-feature spotlight with image and detailed description"
+    layout: [split_left_media]
+    content_density: standard
+    tone: [elegant]
+    goal: [explain]
+    cta_pattern: single_primary
+    media: [screenshot]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: feature85
+    why: "Icon grid with 6+ features — compact overview with minimal descriptions"
+    layout: [grid_icons]
+    content_density: minimal
+    tone: [minimal]
+    goal: [explain]
+    cta_pattern: none
+    media: [icons]
+    interaction: [static]
+    items_count: many
+    complexity: low
+
+  - id: feature101
+    why: "Alternating rows with large screenshots — product tour style"
+    layout: [alternating]
+    content_density: rich
+    tone: [modern]
+    goal: [explain]
+    cta_pattern: link_list
+    media: [screenshot]
+    interaction: [static]
+    items_count: moderate
+    complexity: medium
+
+  - id: feature120
+    why: "Stats-integrated feature section — numbers alongside feature descriptions"
+    layout: [grid_cards]
+    content_density: rich
+    tone: [enterprise, bold]
+    goal: [explain, trust]
+    cta_pattern: none
+    media: [icons]
+    interaction: [static]
+    items_count: moderate
+    complexity: medium
+
+  - id: feature140
+    why: "Comparison-style features — before/after or us vs. them layout"
+    layout: [comparison_table]
+    content_density: standard
+    tone: [enterprise]
+    goal: [explain, compare]
+    cta_pattern: single_primary
+    media: [icons]
+    interaction: [static]
+    items_count: moderate
+    complexity: medium
+
+  - id: feature200
+    why: "Video-integrated feature — embedded product demo with supporting text"
+    layout: [split_right_media]
+    content_density: standard
+    tone: [modern]
+    goal: [explain]
+    cta_pattern: single_primary
+    media: [video]
+    interaction: [static]
+    items_count: few
+    complexity: medium
+
+  - id: feature280
+    why: "Minimal stacked features — clean vertical flow with subtle dividers"
+    layout: [stacked]
+    content_density: minimal
+    tone: [minimal, elegant]
+    goal: [explain]
+    cta_pattern: none
+    media: [icons]
+    interaction: [static]
+    items_count: moderate
+    complexity: low
+```
+
+### Pricing Section Picks
+
+```yaml
+pricing_blocks:
+  - id: pricing1
+    why: "Simple 2-tier pricing cards with feature lists and CTAs"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [minimal, modern]
+    goal: [compare, convert]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: pricing3
+    why: "3-tier pricing cards with highlighted recommended plan"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [modern]
+    goal: [compare, convert]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: pricing8
+    why: "Pricing with monthly/annual toggle — shows savings for annual billing"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [modern]
+    goal: [compare, convert]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [toggle]
+    items_count: few
+    complexity: medium
+
+  - id: pricing11
+    why: "Feature comparison table — detailed row-by-row feature breakdown per tier"
+    layout: [comparison_table]
+    content_density: rich
+    tone: [enterprise]
+    goal: [compare, convert]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [static]
+    items_count: many
+    complexity: medium
+
+  - id: pricing15
+    why: "Single featured plan with detailed feature list — good for single-product"
+    layout: [centered]
+    content_density: standard
+    tone: [minimal]
+    goal: [convert]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: pricing20
+    why: "Pricing cards with expandable feature details per tier"
+    layout: [grid_cards]
+    content_density: rich
+    tone: [modern]
+    goal: [compare, convert]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [accordion]
+    items_count: few
+    complexity: medium
+
+  - id: pricing30
+    why: "Enterprise pricing with custom plan CTA — includes contact sales option"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [enterprise]
+    goal: [compare, convert, capture_leads]
+    cta_pattern: multi_action
+    media: [none]
+    interaction: [static]
+    items_count: moderate
+    complexity: medium
+```
+
+### Testimonial Section Picks
+
+```yaml
+testimonial_blocks:
+  - id: testimonial1
+    why: "Grid of quote cards with avatars — shows breadth of social proof"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [modern]
+    goal: [trust]
+    cta_pattern: none
+    media: [avatars]
+    interaction: [static]
+    items_count: moderate
+    complexity: low
+
+  - id: testimonial3
+    why: "Single large featured quote with photo — high-impact single testimonial"
+    layout: [centered]
+    content_density: minimal
+    tone: [elegant]
+    goal: [trust]
+    cta_pattern: none
+    media: [avatars]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: testimonial8
+    why: "Testimonial carousel — swipe through multiple quotes in compact space"
+    layout: [carousel]
+    content_density: standard
+    tone: [modern]
+    goal: [trust]
+    cta_pattern: none
+    media: [avatars]
+    interaction: [carousel]
+    items_count: many
+    complexity: medium
+
+  - id: testimonial10
+    why: "Masonry grid of testimonials — varied card heights for visual interest"
+    layout: [masonry]
+    content_density: standard
+    tone: [modern, playful]
+    goal: [trust]
+    cta_pattern: none
+    media: [avatars]
+    interaction: [static]
+    items_count: many
+    complexity: medium
+
+  - id: testimonial15
+    why: "Quote with star ratings — reviews-style social proof"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [modern]
+    goal: [trust]
+    cta_pattern: none
+    media: [avatars]
+    interaction: [static]
+    items_count: moderate
+    complexity: low
+
+  - id: testimonial20
+    why: "Video testimonials — embedded customer video reviews"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [modern, enterprise]
+    goal: [trust]
+    cta_pattern: none
+    media: [video, avatars]
+    interaction: [static]
+    items_count: few
+    complexity: medium
+
+  - id: testimonial25
+    why: "Logo bar + quote — combines partner logos with featured testimonial"
+    layout: [stacked]
+    content_density: standard
+    tone: [enterprise]
+    goal: [trust]
+    cta_pattern: none
+    media: [logos, avatars]
+    interaction: [static]
+    items_count: few
+    complexity: low
+```
+
+### CTA Section Picks
+
+```yaml
+cta_blocks:
+  - id: cta1
+    why: "Simple centered CTA — headline, subtext, and primary button"
+    layout: [centered]
+    content_density: minimal
+    tone: [minimal, modern]
+    goal: [convert]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: cta5
+    why: "CTA with background image/gradient — visually prominent section"
+    layout: [centered]
+    content_density: minimal
+    tone: [bold]
+    goal: [convert]
+    cta_pattern: primary_secondary
+    media: [photo]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: cta10
+    why: "CTA with email capture form inline — newsletter/waitlist signup"
+    layout: [centered]
+    content_density: standard
+    tone: [modern]
+    goal: [capture_leads]
+    cta_pattern: form_capture
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: medium
+
+  - id: cta15
+    why: "Split CTA with image — text on one side, visual on the other"
+    layout: [split_right_media]
+    content_density: standard
+    tone: [modern]
+    goal: [convert]
+    cta_pattern: primary_secondary
+    media: [screenshot]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: cta20
+    why: "Multi-action CTA — book demo, start trial, and contact sales options"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [enterprise]
+    goal: [convert]
+    cta_pattern: multi_action
+    media: [icons]
+    interaction: [static]
+    items_count: few
+    complexity: medium
+
+  - id: cta26
+    why: "CTA with social proof — includes testimonial snippet or user count"
+    layout: [centered]
+    content_density: standard
+    tone: [modern]
+    goal: [convert, trust]
+    cta_pattern: single_primary
+    media: [avatars]
+    interaction: [static]
+    items_count: few
+    complexity: low
+```
+
+### FAQ Section Picks
+
+```yaml
+faq_blocks:
+  - id: faq1
+    why: "Classic accordion FAQ — click to expand answers, compact layout"
+    layout: [stacked]
+    content_density: standard
+    tone: [minimal, modern]
+    goal: [support]
+    cta_pattern: none
+    media: [none]
+    interaction: [accordion]
+    items_count: moderate
+    complexity: low
+
+  - id: faq5
+    why: "Two-column FAQ grid — all answers visible, no accordion needed"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [modern]
+    goal: [support]
+    cta_pattern: none
+    media: [none]
+    interaction: [static]
+    items_count: moderate
+    complexity: low
+
+  - id: faq10
+    why: "FAQ with category sidebar — organized by topic with left navigation"
+    layout: [sidebar]
+    content_density: rich
+    tone: [enterprise]
+    goal: [support]
+    cta_pattern: none
+    media: [none]
+    interaction: [accordion]
+    items_count: many
+    complexity: medium
+
+  - id: faq14
+    why: "FAQ with contact CTA — questions section plus 'still need help?' prompt"
+    layout: [stacked]
+    content_density: standard
+    tone: [modern]
+    goal: [support, convert]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [accordion]
+    items_count: moderate
+    complexity: low
+```
+
+### Navbar Picks
+
+```yaml
+navbar_blocks:
+  - id: navbar1
+    why: "Simple navbar — logo, horizontal links, and CTA button"
+    layout: [centered]
+    content_density: minimal
+    tone: [minimal, modern]
+    goal: [navigate]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: navbar5
+    why: "Navbar with dropdown menus — standard multi-level navigation"
+    layout: [centered]
+    content_density: standard
+    tone: [modern]
+    goal: [navigate]
+    cta_pattern: single_primary
+    media: [none]
+    interaction: [hover]
+    items_count: moderate
+    complexity: medium
+
+  - id: navbar9
+    why: "Mega menu navbar — rich dropdown panels with icons and descriptions"
+    layout: [centered]
+    content_density: rich
+    tone: [enterprise]
+    goal: [navigate]
+    cta_pattern: single_primary
+    media: [icons]
+    interaction: [hover]
+    items_count: many
+    complexity: high
+
+  - id: navbar14
+    why: "Centered logo navbar — logo in the middle, links on both sides"
+    layout: [centered]
+    content_density: minimal
+    tone: [elegant]
+    goal: [navigate]
+    cta_pattern: none
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: navbar22
+    why: "App-style navbar — includes user avatar, notifications, and search"
+    layout: [centered]
+    content_density: standard
+    tone: [modern]
+    goal: [navigate]
+    cta_pattern: none
+    media: [avatars]
+    interaction: [hover]
+    items_count: moderate
+    complexity: medium
+```
+
+### Footer Picks
+
+```yaml
+footer_blocks:
+  - id: footer1
+    why: "Multi-column footer — logo, link groups (Product, Company, Resources), and social icons"
+    layout: [multi_column]
+    content_density: standard
+    tone: [modern]
+    goal: [navigate]
+    cta_pattern: link_list
+    media: [none]
+    interaction: [static]
+    items_count: many
+    complexity: low
+
+  - id: footer5
+    why: "Simple footer — single row with logo, few links, and social icons"
+    layout: [centered]
+    content_density: minimal
+    tone: [minimal]
+    goal: [navigate]
+    cta_pattern: link_list
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: footer10
+    why: "Footer with newsletter signup — email capture form alongside link columns"
+    layout: [multi_column]
+    content_density: standard
+    tone: [modern]
+    goal: [navigate, capture_leads]
+    cta_pattern: form_capture
+    media: [none]
+    interaction: [static]
+    items_count: many
+    complexity: medium
+
+  - id: footer15
+    why: "Large footer with CTA section — includes call-to-action banner above links"
+    layout: [stacked]
+    content_density: rich
+    tone: [enterprise]
+    goal: [navigate, convert]
+    cta_pattern: primary_secondary
+    media: [none]
+    interaction: [static]
+    items_count: many
+    complexity: medium
+
+  - id: footer25
+    why: "Minimal footer — copyright, legal links, and language selector only"
+    layout: [centered]
+    content_density: minimal
+    tone: [minimal]
+    goal: [navigate]
+    cta_pattern: none
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+```
+
+### Contact Section Picks
+
+```yaml
+contact_blocks:
+  - id: contact1
+    why: "Contact form with info sidebar — form on left, address/phone/email on right"
+    layout: [split_right_media]
+    content_density: standard
+    tone: [modern]
+    goal: [support, capture_leads]
+    cta_pattern: form_capture
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: medium
+
+  - id: contact5
+    why: "Centered contact form — clean, focused form with no sidebar"
+    layout: [centered]
+    content_density: minimal
+    tone: [minimal, modern]
+    goal: [capture_leads]
+    cta_pattern: form_capture
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: contact10
+    why: "Contact cards grid — email, phone, office location as separate cards"
+    layout: [grid_cards]
+    content_density: standard
+    tone: [modern]
+    goal: [support]
+    cta_pattern: multi_action
+    media: [icons]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: contact16
+    why: "Contact with embedded map — form alongside an interactive map"
+    layout: [split_left_media]
+    content_density: standard
+    tone: [enterprise]
+    goal: [support, capture_leads]
+    cta_pattern: form_capture
+    media: [illustration]
+    interaction: [static]
+    items_count: few
+    complexity: high
+```
+
+### Stats Section Picks
+
+```yaml
+stats_blocks:
+  - id: stats1
+    why: "Horizontal stats bar — bold numbers in a single row"
+    layout: [grid_cards]
+    content_density: minimal
+    tone: [bold, modern]
+    goal: [trust]
+    cta_pattern: none
+    media: [none]
+    interaction: [static]
+    items_count: few
+    complexity: low
+
+  - id: stats5
+    why: "Stats with icons and supporting descriptions"
+    layout: [grid_icons]
+    content_density: standard
+    tone: [modern]
+    goal: [trust, explain]
+    cta_pattern: none
+    media: [icons]
+    interaction: [static]
+    items_count: moderate
+    complexity: low
+
+  - id: stats10
+    why: "Stats integrated into a split section with image"
+    layout: [split_right_media]
+    content_density: standard
+    tone: [enterprise]
+    goal: [trust]
+    cta_pattern: none
+    media: [photo]
+    interaction: [static]
+    items_count: few
+    complexity: medium
+
+  - id: stats15
+    why: "Large counters with animated number reveal"
+    layout: [centered]
+    content_density: minimal
+    tone: [bold]
+    goal: [trust]
+    cta_pattern: none
+    media: [none]
+    interaction: [hover]
+    items_count: few
+    complexity: medium
+```
+
+---
+
+## Fallback Behavior
+
+When a section is not covered in this index (e.g., `blog`, `gallery`, `sidebar`):
+1. Recommend the default picks from `block-catalog.md`
+2. Ask the user about layout preference if multiple styles exist
+3. Note that the full catalog has more options to browse at https://shadcnblocks.com/explorer/blocks
+
+## Expanding This Index
+
+To add new tagged entries:
+1. Visit the block on shadcnblocks.com/block/{id}
+2. Note the description, layout pattern, and interactive elements
+3. Tag using the vocabulary above
+4. Add to the appropriate section with a `why` that distinguishes it from others

--- a/.claude/skills/shadcn-ui/references/component-catalog.md
+++ b/.claude/skills/shadcn-ui/references/component-catalog.md
@@ -1,0 +1,452 @@
+# ShadcnBlocks Component Catalog
+
+> 1,189 components across 60+ groups. Browse visually at https://shadcnblocks.com/explorer/components
+
+## Blocks vs Components
+
+- **Blocks** are full page sections (hero, pricing, footer) — self-contained layouts you compose into pages.
+- **Components** are smaller, reusable UI elements (buttons, inputs, accordions) — building blocks used inside blocks or on their own.
+
+All components are **free** and don't require a paid plan.
+
+## Install Syntax
+
+Components use a `type/variant-name` path:
+
+```bash
+npx shadcn add @shadcnblocks/<variant-name>
+```
+
+Component variant names follow the pattern `<type>-<style>-<number>` (e.g., `accordion-form-1`, `alert-error-3`, `button-icon-5`).
+
+## Archetypes
+
+| Archetype | Count | Description |
+|-----------|-------|-------------|
+| UI | 1,184 | General interface components |
+| Forms | 189 | Form inputs, fields, and controls |
+
+---
+
+## Component Groups
+
+### Form & Input Components
+
+#### Form (86 variants)
+Form layouts, multi-step forms, and form patterns.
+```bash
+npx shadcn add @shadcnblocks/form-signin-1
+```
+
+#### Field (38 variants)
+Labeled input fields with validation states, hints, and error messages.
+```bash
+npx shadcn add @shadcnblocks/field-standard-1
+```
+
+#### Input Group (39 variants)
+Input fields with prefixes, suffixes, icons, and addons.
+```bash
+npx shadcn add @shadcnblocks/input-group-standard-1
+```
+
+#### Input (24 variants)
+Standalone input elements with various styles and states.
+```bash
+npx shadcn add @shadcnblocks/input-standard-1
+```
+
+#### Textarea (13 variants)
+Multi-line text input areas with counters and auto-resize.
+```bash
+npx shadcn add @shadcnblocks/textarea-standard-1
+```
+
+#### Checkbox (12 variants)
+Checkbox inputs with labels, descriptions, and group layouts.
+```bash
+npx shadcn add @shadcnblocks/checkbox-standard-1
+```
+
+#### Radio Group (9 variants)
+Radio button groups with various layout styles.
+```bash
+npx shadcn add @shadcnblocks/radio-group-standard-1
+```
+
+#### Switch (19 variants)
+Toggle switch controls for boolean settings.
+```bash
+npx shadcn add @shadcnblocks/switch-standard-1
+```
+
+#### Slider (29 variants)
+Range sliders for numeric value selection.
+```bash
+npx shadcn add @shadcnblocks/slider-standard-1
+```
+
+#### Combobox (42 variants)
+Searchable select dropdowns with autocomplete.
+```bash
+npx shadcn add @shadcnblocks/combobox-standard-1
+```
+
+#### Date Picker (8 variants)
+Date selection inputs with calendar popups.
+```bash
+npx shadcn add @shadcnblocks/date-picker-standard-1
+```
+
+#### Input OTP (20 variants)
+One-time password and verification code inputs.
+```bash
+npx shadcn add @shadcnblocks/input-otp-standard-1
+```
+
+#### File Upload (44 variants)
+File upload dropzones, file pickers, and progress indicators.
+```bash
+npx shadcn add @shadcnblocks/file-upload-standard-1
+```
+
+#### Label (8 variants)
+Form labels with required indicators and helper text.
+```bash
+npx shadcn add @shadcnblocks/label-standard-1
+```
+
+#### Emoji Picker (6 variants)
+Emoji selection popover components.
+```bash
+npx shadcn add @shadcnblocks/emoji-picker-standard-1
+```
+
+---
+
+### Display & Feedback Components
+
+#### Alert (25 variants)
+Alert messages in error, info, success, and standard styles.
+```bash
+npx shadcn add @shadcnblocks/alert-error-1
+npx shadcn add @shadcnblocks/alert-info-1
+npx shadcn add @shadcnblocks/alert-success-1
+npx shadcn add @shadcnblocks/alert-standard-1
+```
+
+#### Alert Dialog (39 variants)
+Confirmation modals and destructive action dialogs.
+```bash
+npx shadcn add @shadcnblocks/alert-dialog-standard-1
+```
+
+#### Badge (20 variants)
+Status badges, tags, and labels.
+```bash
+npx shadcn add @shadcnblocks/badge-standard-1
+```
+
+#### Skeleton (30 variants)
+Loading placeholder skeletons for content.
+```bash
+npx shadcn add @shadcnblocks/skeleton-standard-1
+```
+
+#### Spinner (17 variants)
+Loading spinners and activity indicators.
+```bash
+npx shadcn add @shadcnblocks/spinner-standard-1
+```
+
+#### Progress (20 variants)
+Progress bars and completion indicators.
+```bash
+npx shadcn add @shadcnblocks/progress-standard-1
+```
+
+#### Empty (22 variants)
+Empty state illustrations and messages.
+```bash
+npx shadcn add @shadcnblocks/empty-standard-1
+```
+
+#### Sonner (24 variants)
+Toast notification components (uses Sonner library).
+```bash
+npx shadcn add @shadcnblocks/sonner-standard-1
+```
+
+#### Rating (2 variants)
+Star rating display and input components.
+```bash
+npx shadcn add @shadcnblocks/rating-standard-1
+```
+
+#### Price (2 variants)
+Price display with currency formatting.
+```bash
+npx shadcn add @shadcnblocks/price-standard-1
+```
+
+---
+
+### Navigation Components
+
+#### Navigation Menu (20 variants)
+Top-level navigation menus with dropdowns and mega menus.
+```bash
+npx shadcn add @shadcnblocks/navigation-menu-standard-1
+```
+
+#### Breadcrumb (14 variants)
+Breadcrumb navigation trails.
+```bash
+npx shadcn add @shadcnblocks/breadcrumb-standard-1
+```
+
+#### Pagination (19 variants)
+Page navigation controls for lists and tables.
+```bash
+npx shadcn add @shadcnblocks/pagination-standard-1
+```
+
+#### Tabs (11 variants)
+Tabbed content navigation.
+```bash
+npx shadcn add @shadcnblocks/tabs-standard-1
+```
+
+#### Menubar (10 variants)
+Application menu bars with nested menus.
+```bash
+npx shadcn add @shadcnblocks/menubar-standard-1
+```
+
+#### Command (21 variants)
+Command palette / search dialog components (Cmd+K style).
+```bash
+npx shadcn add @shadcnblocks/command-standard-1
+```
+
+#### Context Menu (27 variants)
+Right-click context menus.
+```bash
+npx shadcn add @shadcnblocks/context-menu-standard-1
+```
+
+#### Dropdown Menu (30 variants)
+Dropdown action menus triggered by buttons.
+```bash
+npx shadcn add @shadcnblocks/dropdown-menu-standard-1
+```
+
+---
+
+### Layout & Container Components
+
+#### Accordion (21 variants)
+Collapsible content sections in form, multi-level, standard, subtitle, and tabs styles.
+```bash
+npx shadcn add @shadcnblocks/accordion-standard-1
+npx shadcn add @shadcnblocks/accordion-form-1
+npx shadcn add @shadcnblocks/accordion-multi-level-1
+npx shadcn add @shadcnblocks/accordion-tabs-1
+```
+
+#### Card (4 variants)
+Content card containers with header, body, and footer.
+```bash
+npx shadcn add @shadcnblocks/card-standard-1
+```
+
+#### Collapsible (23 variants)
+Single collapsible sections.
+```bash
+npx shadcn add @shadcnblocks/collapsible-standard-1
+```
+
+#### Dialog (17 variants)
+Modal dialog windows.
+```bash
+npx shadcn add @shadcnblocks/dialog-standard-1
+```
+
+#### Drawer (22 variants)
+Slide-out drawer panels from edges.
+```bash
+npx shadcn add @shadcnblocks/drawer-standard-1
+```
+
+#### Sheet (29 variants)
+Side panel overlays for forms and details.
+```bash
+npx shadcn add @shadcnblocks/sheet-standard-1
+```
+
+#### Popover (15 variants)
+Floating content panels triggered by click.
+```bash
+npx shadcn add @shadcnblocks/popover-standard-1
+```
+
+#### Hover Card (20 variants)
+Content cards triggered by hover.
+```bash
+npx shadcn add @shadcnblocks/hover-card-standard-1
+```
+
+#### Tooltip (8 variants)
+Hover tooltip information displays.
+```bash
+npx shadcn add @shadcnblocks/tooltip-standard-1
+```
+
+#### Scroll Area (8 variants)
+Custom scrollbar containers.
+```bash
+npx shadcn add @shadcnblocks/scroll-area-standard-1
+```
+
+#### Separator (18 variants)
+Visual dividers between content sections.
+```bash
+npx shadcn add @shadcnblocks/separator-standard-1
+```
+
+#### Aspect Ratio (7 variants)
+Containers that maintain a fixed aspect ratio.
+```bash
+npx shadcn add @shadcnblocks/aspect-ratio-standard-1
+```
+
+#### Carousel (4 variants)
+Content carousels and sliders.
+```bash
+npx shadcn add @shadcnblocks/carousel-standard-1
+```
+
+---
+
+### Button & Action Components
+
+#### Button (35 variants)
+Button styles including primary, secondary, outline, ghost, icon, and loading states.
+```bash
+npx shadcn add @shadcnblocks/button-standard-1
+```
+
+#### Button Group (39 variants)
+Grouped button sets for related actions.
+```bash
+npx shadcn add @shadcnblocks/button-group-standard-1
+```
+
+#### Toggle (7 variants)
+Toggle buttons for on/off states.
+```bash
+npx shadcn add @shadcnblocks/toggle-standard-1
+```
+
+#### Toggle Group (7 variants)
+Groups of toggle buttons for multi-select.
+```bash
+npx shadcn add @shadcnblocks/toggle-group-standard-1
+```
+
+#### KBD (39 variants)
+Keyboard shortcut display components.
+```bash
+npx shadcn add @shadcnblocks/kbd-standard-1
+```
+
+#### Border Button (1 variant)
+Animated border button effect.
+```bash
+npx shadcn add @shadcnblocks/border-button-standard-1
+```
+
+---
+
+### Data Display Components
+
+#### Avatar (34 variants)
+User avatar images with fallbacks.
+```bash
+npx shadcn add @shadcnblocks/avatar-standard-1
+```
+
+#### Avatar Group (9 variants)
+Stacked or overlapping avatar collections.
+```bash
+npx shadcn add @shadcnblocks/avatar-group-standard-1
+```
+
+#### Chart (70 variants)
+Data visualization charts (line, bar, area, pie, radar, etc.).
+```bash
+npx shadcn add @shadcnblocks/chart-standard-1
+```
+
+#### Data Table (8 variants)
+Sortable, filterable data tables.
+```bash
+npx shadcn add @shadcnblocks/data-table-standard-1
+```
+
+#### Table (8 variants)
+Simple styled tables.
+```bash
+npx shadcn add @shadcnblocks/table-standard-1
+```
+
+#### Calendar (16 variants)
+Calendar date displays and pickers.
+```bash
+npx shadcn add @shadcnblocks/calendar-standard-1
+```
+
+#### Logo (3 variants)
+Brand logo display components.
+```bash
+npx shadcn add @shadcnblocks/logo-standard-1
+```
+
+#### Item (10 variants)
+Generic list item layouts.
+```bash
+npx shadcn add @shadcnblocks/item-standard-1
+```
+
+#### Scrollable Tabslist (1 variant)
+Horizontally scrollable tab lists for many tabs.
+```bash
+npx shadcn add @shadcnblocks/scrollable-tabslist-standard-1
+```
+
+---
+
+## Quick Reference: Choosing the Right Component
+
+| Need | Component Group | Example Variant |
+|------|----------------|-----------------|
+| Form layout | Form | `form-signin-1` |
+| Text input with label | Field | `field-standard-1` |
+| Input with icon/addon | Input Group | `input-group-standard-1` |
+| Searchable dropdown | Combobox | `combobox-standard-1` |
+| File uploads | File Upload | `file-upload-standard-1` |
+| Date selection | Date Picker | `date-picker-standard-1` |
+| Error/success message | Alert | `alert-error-1`, `alert-success-1` |
+| Confirmation dialog | Alert Dialog | `alert-dialog-standard-1` |
+| Loading state | Skeleton / Spinner | `skeleton-standard-1` |
+| Toast notification | Sonner | `sonner-standard-1` |
+| Empty state | Empty | `empty-standard-1` |
+| Modal window | Dialog | `dialog-standard-1` |
+| Side panel | Sheet / Drawer | `sheet-standard-1` |
+| Collapsible sections | Accordion | `accordion-standard-1` |
+| Data visualization | Chart | `chart-standard-1` |
+| Command palette | Command | `command-standard-1` |
+| Right-click menu | Context Menu | `context-menu-standard-1` |
+| Page navigation | Pagination | `pagination-standard-1` |
+| User avatar | Avatar | `avatar-standard-1` |
+| Keyboard shortcuts | KBD | `kbd-standard-1` |

--- a/.claude/skills/shadcn-ui/references/setup-guide.md
+++ b/.claude/skills/shadcn-ui/references/setup-guide.md
@@ -1,0 +1,101 @@
+# ShadcnBlocks Setup Guide
+
+## Prerequisites
+
+1. A React/Next.js project (or any framework supporting shadcn/ui)
+2. Tailwind CSS configured
+3. shadcn/ui initialized (`npx shadcn@latest init`)
+4. 1Password CLI (`op`) installed and authenticated
+
+## Step-by-Step Setup
+
+### 1. Initialize shadcn/ui (if not already done)
+
+```bash
+npx shadcn@latest init
+```
+
+Follow the prompts to configure:
+- TypeScript (recommended)
+- Style (default or new-york)
+- Base color
+- CSS variables
+- Tailwind configuration
+- Component alias paths
+
+This creates `components.json` in the project root.
+
+### 2. Obtain Your ShadcnBlocks API Key
+
+Get your API key from [shadcnblocks.com](https://shadcnblocks.com) (requires a paid plan).
+
+**Option A — Set directly:**
+```bash
+export SHADCNBLOCKS_API_KEY=<your-key>
+```
+
+**Option B — Use 1Password CLI:**
+If you store the key in 1Password, the scripts will retrieve it automatically. Set your reference path:
+```bash
+export OP_SHADCNBLOCKS_REF="op://<Your Vault>/<Your Item>/credential"
+```
+Or use the default path: `op://Platform Infra/ShadcnBlocks API Key/credential`
+
+### 3. Configure Environment Variable
+
+Add to your project's `.env`:
+```
+SHADCNBLOCKS_API_KEY=<your-key>
+```
+
+Ensure `.env` is in `.gitignore`.
+
+### 4. Add Registry to components.json
+
+Add the `@shadcnblocks` registry under the `registries` key:
+
+```json
+{
+  "registries": {
+    "@shadcnblocks": {
+      "url": "https://shadcnblocks.com/r/{name}",
+      "headers": {
+        "Authorization": "Bearer ${SHADCNBLOCKS_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+The `${SHADCNBLOCKS_API_KEY}` placeholder is resolved from the environment at install time.
+
+### 5. Automated Setup Alternative
+
+Run the setup script bundled with this skill:
+```bash
+bash scripts/setup-shadcnblocks.sh /path/to/project
+```
+
+This script handles steps 2-4 automatically using 1Password CLI.
+
+## Troubleshooting
+
+### Authentication Errors
+- Check that `.env` contains `SHADCNBLOCKS_API_KEY` with a valid key
+- If using 1Password: `bash scripts/get-api-key.sh` to test key retrieval
+- Verify the key works by running a test install
+
+### Registry Not Found
+- Ensure `registries` key exists in `components.json`
+- Verify the URL template includes `{name}` placeholder
+- Check JSON syntax
+
+### components.json Missing
+- Run `npx shadcn@latest init` to create it
+- Must be in the project root directory
+
+### 1Password Access (optional)
+- Sign in: `op signin`
+- Verify vault access: `op vault list`
+- Set custom reference: `export OP_SHADCNBLOCKS_REF="op://<Your Vault>/<Your Item>/credential"`
+- Or bypass 1Password entirely: `export SHADCNBLOCKS_API_KEY=<your-key>`

--- a/.claude/skills/shadcn-ui/scripts/get-api-key.sh
+++ b/.claude/skills/shadcn-ui/scripts/get-api-key.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Retrieve the ShadcnBlocks API key.
+#
+# Resolution order:
+#   1. SHADCNBLOCKS_API_KEY environment variable (if already set)
+#   2. 1Password CLI using OP_SHADCNBLOCKS_REF (custom reference path)
+#   3. 1Password CLI using the default reference path
+#
+# Usage: bash get-api-key.sh
+#
+# Environment variables:
+#   SHADCNBLOCKS_API_KEY      - Set this to skip 1Password lookup entirely
+#   OP_SHADCNBLOCKS_REF       - Custom 1Password reference path
+#                                (default: op://Platform Infra/ShadcnBlocks API Key/credential)
+
+set -euo pipefail
+
+# 1. Use existing env var if set
+if [ -n "${SHADCNBLOCKS_API_KEY:-}" ]; then
+  echo "$SHADCNBLOCKS_API_KEY"
+  exit 0
+fi
+
+# 2. Try 1Password CLI
+OP_REF="${OP_SHADCNBLOCKS_REF:-op://Platform Infra/ShadcnBlocks API Key/credential}"
+
+if ! command -v op &>/dev/null; then
+  echo "ERROR: Could not retrieve ShadcnBlocks API key." >&2
+  echo "Either set the SHADCNBLOCKS_API_KEY environment variable," >&2
+  echo "or install the 1Password CLI (op) and sign in." >&2
+  exit 1
+fi
+
+API_KEY=$(op read "$OP_REF" 2>/dev/null)
+
+if [ -z "$API_KEY" ]; then
+  echo "ERROR: Could not retrieve ShadcnBlocks API key from 1Password." >&2
+  echo "Reference: $OP_REF" >&2
+  echo "" >&2
+  echo "Options:" >&2
+  echo "  - Set SHADCNBLOCKS_API_KEY environment variable directly" >&2
+  echo "  - Set OP_SHADCNBLOCKS_REF to your 1Password reference path" >&2
+  echo "  - Ensure 'op' CLI is signed in: op signin" >&2
+  exit 1
+fi
+
+echo "$API_KEY"

--- a/.claude/skills/shadcn-ui/scripts/setup-shadcnblocks.sh
+++ b/.claude/skills/shadcn-ui/scripts/setup-shadcnblocks.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Setup script for ShadcnBlocks registry in a project.
+# Retrieves the API key and configures components.json.
+#
+# Usage: bash setup-shadcnblocks.sh [project-dir]
+#
+# The API key is resolved in this order:
+#   1. SHADCNBLOCKS_API_KEY environment variable
+#   2. 1Password CLI (customizable via OP_SHADCNBLOCKS_REF)
+#
+# Prerequisites:
+#   - components.json must already exist (run `npx shadcn@latest init` first)
+#   - jq must be installed
+#   - Either SHADCNBLOCKS_API_KEY is set, or 1Password CLI (op) is available
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="${1:-.}"
+COMPONENTS_JSON="$PROJECT_DIR/components.json"
+
+# Verify components.json exists
+if [ ! -f "$COMPONENTS_JSON" ]; then
+  echo "ERROR: $COMPONENTS_JSON not found."
+  echo "Run 'npx shadcn@latest init' first to create it."
+  exit 1
+fi
+
+# Retrieve API key using the helper script
+API_KEY=$("$SCRIPT_DIR/get-api-key.sh")
+
+# Add registry to components.json using jq
+# Uses env var placeholder so the actual key is never written to components.json
+if command -v jq &>/dev/null; then
+  TMP=$(mktemp)
+  jq '.registries["@shadcnblocks"] = {
+    "url": "https://shadcnblocks.com/r/{name}",
+    "headers": {
+      "Authorization": "Bearer ${SHADCNBLOCKS_API_KEY}"
+    }
+  }' "$COMPONENTS_JSON" > "$TMP" && mv "$TMP" "$COMPONENTS_JSON"
+  echo "ShadcnBlocks registry added to $COMPONENTS_JSON"
+else
+  echo "ERROR: jq is required to update components.json. Install with: brew install jq"
+  exit 1
+fi
+
+# Add SHADCNBLOCKS_API_KEY to .env
+ENV_FILE="$PROJECT_DIR/.env"
+if [ -f "$ENV_FILE" ]; then
+  if grep -q "SHADCNBLOCKS_API_KEY" "$ENV_FILE"; then
+    echo "SHADCNBLOCKS_API_KEY already set in $ENV_FILE"
+  else
+    echo "" >> "$ENV_FILE"
+    echo "SHADCNBLOCKS_API_KEY=$API_KEY" >> "$ENV_FILE"
+    echo "Added SHADCNBLOCKS_API_KEY to $ENV_FILE"
+  fi
+else
+  echo "SHADCNBLOCKS_API_KEY=$API_KEY" > "$ENV_FILE"
+  echo "Created $ENV_FILE with SHADCNBLOCKS_API_KEY"
+fi
+
+echo ""
+echo "Setup complete. Install blocks with:"
+echo "  npx shadcn add @shadcnblocks/<block-name>"

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ Thumbs.db
 *.sublime-project
 *.sublime-workspace
 
+# --- Claude Code ---
+.playwright-mcp/
+
 
 # --- Language Specific (Monorepo) ---
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "stitch": {
+      "command": "npx",
+      "args": ["-y", "@_davideast/stitch-mcp", "proxy"]
+    },
+    "shadcn": {
+      "command": "npx",
+      "args": ["-y", "shadcn@latest", "mcp"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,3 +164,36 @@ npm run lint:fix
 - AI Engine: `docker compose logs --tail=50 ai-engine` 또는 컨테이너 내부 `/health`로 확인합니다.
 
 ---
+
+## Claude Code 개발 도구 (선택)
+
+Claude Code 를 함께 사용하는 팀원을 위한 안내입니다. 사용하지 않으면 건너뛰어도 됩니다.
+
+### MCP 서버
+
+repo 루트의 `.mcp.json` 에 stitch / shadcn / playwright 3종이 등록되어 있어,
+Claude Code 가 이 디렉터리에서 실행되면 자동으로 연결됩니다. 별도 설치는 필요 없습니다.
+
+### Skills
+
+`.claude/skills/shadcn-ui/` 는 repo 에 vendor 되어 있어 자동으로 사용 가능합니다.
+stitch 관련 skill 묶음은 외부 플러그인이라 1회 설치가 필요합니다:
+
+```bash
+# Claude Code 안에서
+/plugin marketplace add https://github.com/gabelul/stitch-kit.git
+/plugin install stitch-kit@stitch-kit
+```
+
+### (선택) ShadcnBlocks 프리미엄 API
+
+shadcn-ui skill 의 프리미엄 블록 기능을 쓰려면 본인 API key 가 필요합니다.
+무료 컴포넌트는 키 없이도 동작합니다.
+
+```bash
+export SHADCNBLOCKS_API_KEY=...
+```
+
+또는 1Password CLI (`op`) 를 쓰는 경우 `OP_SHADCNBLOCKS_REF` 환경변수로 reference path 를 지정합니다.
+
+---


### PR DESCRIPTION
## 📝 작업 내용
프로젝트 레벨에 Claude Code MCP 서버 설정과 shadcn-ui skill 을 추가. 팀원이 repo 를 clone 하면 동일한 MCP 서버 (stitch / shadcn / playwright) 가 자동으로 연결되고, shadcn-ui skill 이 즉시 사용 가능해짐.

```
chore: register Claude Code MCP servers via .mcp.json
- stitch:     npx -y @_davideast/stitch-mcp proxy
- shadcn:     npx -y shadcn@latest mcp
- playwright: npx -y @playwright/mcp@latest

chore: vendor shadcn-ui skill under .claude/skills/
- SKILL.md + references/ (4 catalogs) + scripts/ (2 shell)
- 공개 마켓플레이스 미발견 → vendor 가 사실상 유일한 공유 방식
- scripts: SHADCNBLOCKS_API_KEY 환경변수 또는 1Password CLI 통해 조회 (하드코딩 secret 없음)

chore: stitch-kit 플러그인은 vendor 대신 CONTRIBUTING.md 안내
- 출처: https://github.com/gabelul/stitch-kit.git
- /plugin install stitch-kit@stitch-kit 한 번이면 35종 stitch-* skill 사용 가능

chore: ignore .playwright-mcp/ (playwright MCP 가 만드는 임시 스냅샷 폴더)
```

## 🔗 관련 이슈
없음 (개발 환경 셋업)

## 🗂️ 변경 범위
- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트
- [x] 로컬에서 정상 동작 확인 (`claude mcp list` → 3개 모두 ✓ Connected)
- [x] 하드코딩된 값 / 임시 주석 없음 (스크립트는 env / 1Password 만 참조)
- [x] PR 범위가 하나의 기능 단위로 잘려 있음 (Claude DX 셋업 한 묶음)

## 👀 리뷰어에게
- **vendor 정책 결정** — stitch 35종은 공개 플러그인 (`gabelul/stitch-kit`) 이라 README 안내로 대체. shadcn-ui 1종만 vendor (공개 출처 없음). 이 결정은 PR1 내에서만 의미가 있고, PR2 의 헤더 작업과는 독립적.
- **shadcn-ui scripts 안전성** — `scripts/get-api-key.sh` 와 `scripts/setup-shadcnblocks.sh` 는 SHADCNBLOCKS_API_KEY 를 env 또는 1Password CLI 로만 조회. 하드코딩된 토큰 없음.
- **vendor 시점 스냅샷** — 글로벌 `~/.claude/skills/shadcn-ui/` 의 PR1 시점 스냅샷이며, 이후 업스트림 변경은 수동 sync 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)