### PR TITLE
feat(be): SCR-04 stock groups view via PostGIS clustering 

### DIFF
--- a/apps/backend/build.gradle
+++ b/apps/backend/build.gradle
@@ -48,7 +48,10 @@ dependencies {
 
     // ── Test ─────────────────────────────────────────────
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 tasks.named('test') {

--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupController.java
@@ -1,7 +1,6 @@
 package com.tripkey.domain.group;
 
 import com.tripkey.common.exception.InvalidViewParamException;
-import com.tripkey.dto.group.Groups03Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,13 +19,14 @@ public class GroupController {
     private final GroupService groupService;
 
     @GetMapping
-    public ResponseEntity<Groups03Response> getGroups(
+    public ResponseEntity<?> getGroups(
             @PathVariable UUID tripId,
             @RequestParam("view") String view) {
 
-        if (!"03".equals(view)) {
-            throw new InvalidViewParamException();
-        }
-        return ResponseEntity.ok(groupService.getGroups03(tripId));
+        return switch (view) {
+            case "03" -> ResponseEntity.ok(groupService.getGroups03(tripId));
+            case "04" -> ResponseEntity.ok(groupService.getGroups04(tripId));
+            default -> throw new InvalidViewParamException();
+        };
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class GroupService {
 
-    private static final double SCR04_CLUSTER_EPS_DEGREES = 0.018;
+    private static final double SCR04_CLUSTER_EPS_METERS = 1500.0;
     private static final int SCR04_CLUSTER_MIN_POINTS = 1;
     private static final String FALLBACK_LABEL = "기타";
 
@@ -108,7 +108,7 @@ public class GroupService {
         }
 
         Map<UUID, Integer> clusterIdByInstance = placeCardRepository
-                .clusterAvailableCards(tripId, SCR04_CLUSTER_EPS_DEGREES, SCR04_CLUSTER_MIN_POINTS).stream()
+                .clusterAvailableCards(tripId, SCR04_CLUSTER_EPS_METERS, SCR04_CLUSTER_MIN_POINTS).stream()
                 .filter(row -> row[1] != null)
                 .collect(Collectors.toMap(
                         row -> (UUID) row[0],

--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
@@ -72,12 +72,14 @@ public class GroupService {
             throw new TripNotFoundException(tripId);
         }
 
+        List<PlaceCard> excluded = new ArrayList<>();
         List<PlaceCard> unavailable = new ArrayList<>();
         List<PlaceCard> pendingReorder = new ArrayList<>();
         List<PlaceCard> availableCandidates = new ArrayList<>();
 
         for (PlaceCard card : placeCardRepository.findAllByTripId(tripId)) {
             if (Boolean.TRUE.equals(card.getIsExcluded())) {
+                excluded.add(card);
                 continue;
             }
             String placement = card.getPlacementStatus();
@@ -98,7 +100,8 @@ public class GroupService {
         return Groups04Response.of(
                 available,
                 toSortedDtos(pendingReorder),
-                toSortedDtos(unavailable)
+                toSortedDtos(unavailable),
+                toSortedDtos(excluded)
         );
     }
 

--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
@@ -6,18 +6,28 @@ import com.tripkey.domain.place.PlaceCardRepository;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.group.Groups03Response;
+import com.tripkey.dto.group.Groups04Response;
+import com.tripkey.dto.group.StockGroup;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class GroupService {
+
+    private static final double SCR04_CLUSTER_EPS_DEGREES = 0.018;
+    private static final int SCR04_CLUSTER_MIN_POINTS = 1;
+    private static final String FALLBACK_LABEL = "기타";
 
     private final TripRepository tripRepository;
     private final PlaceCardRepository placeCardRepository;
@@ -54,5 +64,120 @@ public class GroupService {
                 });
 
         return Groups03Response.of(inputRequired, selectRequired, fixRequired, reviewOnly, excluded);
+    }
+
+    @Transactional(readOnly = true)
+    public Groups04Response getGroups04(UUID tripId) {
+        if (!tripRepository.existsById(tripId)) {
+            throw new TripNotFoundException(tripId);
+        }
+
+        List<PlaceCard> unavailable = new ArrayList<>();
+        List<PlaceCard> pendingReorder = new ArrayList<>();
+        List<PlaceCard> availableCandidates = new ArrayList<>();
+
+        for (PlaceCard card : placeCardRepository.findAllByTripId(tripId)) {
+            if (Boolean.TRUE.equals(card.getIsExcluded())) {
+                continue;
+            }
+            String placement = card.getPlacementStatus();
+            String processing = card.getProcessingStatus();
+            if ("blocked".equals(placement) || "needs_input".equals(placement) || "failed".equals(processing)) {
+                unavailable.add(card);
+                continue;
+            }
+            if ("processing".equals(processing) || card.getGeom() == null) {
+                pendingReorder.add(card);
+                continue;
+            }
+            availableCandidates.add(card);
+        }
+
+        List<StockGroup> available = clusterIntoStockGroups(tripId, availableCandidates);
+
+        return Groups04Response.of(
+                available,
+                toSortedDtos(pendingReorder),
+                toSortedDtos(unavailable)
+        );
+    }
+
+    private List<StockGroup> clusterIntoStockGroups(UUID tripId, List<PlaceCard> candidates) {
+        if (candidates.isEmpty()) {
+            return List.of();
+        }
+
+        Map<UUID, Integer> clusterIdByInstance = placeCardRepository
+                .clusterAvailableCards(tripId, SCR04_CLUSTER_EPS_DEGREES, SCR04_CLUSTER_MIN_POINTS).stream()
+                .filter(row -> row[1] != null)
+                .collect(Collectors.toMap(
+                        row -> (UUID) row[0],
+                        row -> ((Number) row[1]).intValue(),
+                        (a, b) -> a
+                ));
+
+        Map<Integer, List<PlaceCard>> cardsByCluster = new HashMap<>();
+        for (PlaceCard card : candidates) {
+            Integer clusterId = clusterIdByInstance.get(card.getInstanceId());
+            if (clusterId == null) {
+                continue;
+            }
+            cardsByCluster.computeIfAbsent(clusterId, k -> new ArrayList<>()).add(card);
+        }
+
+        record LabeledCluster(int clusterId, String dominantLabel, List<PlaceCard> cards) {}
+
+        List<LabeledCluster> clusters = cardsByCluster.entrySet().stream()
+                .map(e -> new LabeledCluster(e.getKey(), dominantLocation(e.getValue()), e.getValue()))
+                .toList();
+
+        Map<String, List<LabeledCluster>> byLabel = clusters.stream()
+                .collect(Collectors.groupingBy(LabeledCluster::dominantLabel));
+
+        List<StockGroup> result = new ArrayList<>();
+        for (Map.Entry<String, List<LabeledCluster>> entry : byLabel.entrySet()) {
+            String baseLabel = entry.getKey();
+            List<LabeledCluster> group = entry.getValue();
+            if (group.size() == 1) {
+                result.add(StockGroup.of(baseLabel, toSortedDtos(group.get(0).cards())));
+                continue;
+            }
+            List<LabeledCluster> ordered = group.stream()
+                    .sorted(Comparator
+                            .comparingInt((LabeledCluster c) -> c.cards().size()).reversed()
+                            .thenComparingInt(LabeledCluster::clusterId))
+                    .toList();
+            for (int i = 0; i < ordered.size(); i++) {
+                result.add(StockGroup.of(
+                        baseLabel + " " + (i + 1),
+                        toSortedDtos(ordered.get(i).cards())
+                ));
+            }
+        }
+
+        result.sort(Comparator
+                .comparingInt((StockGroup g) -> g.cards().size()).reversed()
+                .thenComparing(StockGroup::label));
+        return result;
+    }
+
+    private static String dominantLocation(List<PlaceCard> cards) {
+        return cards.stream()
+                .map(PlaceCard::getLocation)
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.groupingBy(s -> s, Collectors.counting()))
+                .entrySet().stream()
+                .max(Map.Entry.<String, Long>comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(FALLBACK_LABEL);
+    }
+
+    private static List<CardDto> toSortedDtos(List<PlaceCard> cards) {
+        return cards.stream()
+                .sorted(Comparator.comparing(PlaceCard::getCreatedAt))
+                .map(CardDto::from)
+                .toList();
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -157,7 +157,7 @@ public class PlaceCard {
         card.name = defaultString(name, "이름 미정");
         card.category = normalizeCategory(category);
         card.classification = "confirmed";
-        card.placementStatus = "ready";
+        card.placementStatus = "ready_partial";
         card.processingStatus = "processing";
         card.actionType = "review_only";
         card.canExclude = !NON_EXCLUDABLE_CATEGORIES.contains(card.category);
@@ -233,11 +233,7 @@ public class PlaceCard {
     }
 
     private void recomputeActionType() {
-        this.actionType = computeActionType(
-                this.classification,
-                this.placementStatus,
-                this.processingStatus,
-                this.options);
+        this.actionType = computeActionType(this.classification, this.placementStatus);
     }
 
     public static PlaceCard createFromAiResponse(UUID tripId, AiPlaceCardDto dto) {
@@ -255,7 +251,7 @@ public class PlaceCard {
                 : DUPLICATE_DEFAULT_CATEGORIES.contains(card.category);
         card.canExclude = !NON_EXCLUDABLE_CATEGORIES.contains(card.category);
         card.isExcluded = false;
-        card.actionType = computeActionType(card.classification, card.placementStatus, card.processingStatus, dto.options());
+        card.actionType = computeActionType(card.classification, card.placementStatus);
 
         card.estimatedDurationMin = dto.estimatedDurationMin();
         if (dto.coordinates() != null) {
@@ -336,20 +332,17 @@ public class PlaceCard {
         };
     }
 
-    private static String computeActionType(String classification, String placementStatus, String processingStatus, List<String> options) {
-        if ("failed".equals(processingStatus)) {
-            return "fix_required";
-        }
-        if ("blocked".equals(placementStatus)) {
-            return "fix_required";
-        }
-        if ("needs_input".equals(placementStatus)) {
-            return "input_required";
-        }
-        if ("undecided".equals(classification) && options != null && !options.isEmpty()) {
-            return "select_required";
-        }
-        return "review_only";
+    private static String computeActionType(String classification, String placementStatus) {
+        return switch (classification) {
+            case "confirmed", "open_question" -> "review_only";
+            case "undecided" -> switch (placementStatus) {
+                case "ready_partial" -> "select_required";
+                case "needs_input" -> "input_required";
+                default -> "review_only";
+            };
+            case "unassigned" -> "blocked".equals(placementStatus) ? "fix_required" : "review_only";
+            default -> "review_only";
+        };
     }
 
     private static String trimToNull(String value) {

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -22,4 +22,18 @@ public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
     @Transactional
     @Query("delete from PlaceCard p where p.tripId = :tripId")
     void deleteAllByTripId(@Param("tripId") UUID tripId);
+
+    @Query(value = """
+            select instance_id, st_clusterdbscan(geom, :eps, :minPts) over () as cluster_id
+            from place_cards
+            where trip_id = :tripId
+              and is_excluded = false
+              and placement_status in ('ready', 'ready_partial')
+              and processing_status = 'completed'
+              and geom is not null
+            """, nativeQuery = true)
+    List<Object[]> clusterAvailableCards(
+            @Param("tripId") UUID tripId,
+            @Param("eps") double eps,
+            @Param("minPts") int minPts);
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -24,7 +24,8 @@ public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
     void deleteAllByTripId(@Param("tripId") UUID tripId);
 
     @Query(value = """
-            select instance_id, st_clusterdbscan(geom, :eps, :minPts) over () as cluster_id
+            select instance_id,
+                   st_clusterdbscan(st_transform(geom, 3857), :epsMeters, :minPts) over () as cluster_id
             from place_cards
             where trip_id = :tripId
               and is_excluded = false
@@ -34,6 +35,6 @@ public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
             """, nativeQuery = true)
     List<Object[]> clusterAvailableCards(
             @Param("tripId") UUID tripId,
-            @Param("eps") double eps,
+            @Param("epsMeters") double epsMeters,
             @Param("minPts") int minPts);
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/group/Groups04Response.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/group/Groups04Response.java
@@ -8,13 +8,15 @@ public record Groups04Response(
         String view,
         List<StockGroup> available,
         List<CardDto> pendingReorder,
-        List<CardDto> unavailable
+        List<CardDto> unavailable,
+        List<CardDto> excluded
 ) {
     public static Groups04Response of(
             List<StockGroup> available,
             List<CardDto> pendingReorder,
-            List<CardDto> unavailable
+            List<CardDto> unavailable,
+            List<CardDto> excluded
     ) {
-        return new Groups04Response("04", available, pendingReorder, unavailable);
+        return new Groups04Response("04", available, pendingReorder, unavailable, excluded);
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/group/Groups04Response.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/group/Groups04Response.java
@@ -1,0 +1,20 @@
+package com.tripkey.dto.group;
+
+import com.tripkey.dto.card.CardDto;
+
+import java.util.List;
+
+public record Groups04Response(
+        String view,
+        List<StockGroup> available,
+        List<CardDto> pendingReorder,
+        List<CardDto> unavailable
+) {
+    public static Groups04Response of(
+            List<StockGroup> available,
+            List<CardDto> pendingReorder,
+            List<CardDto> unavailable
+    ) {
+        return new Groups04Response("04", available, pendingReorder, unavailable);
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/group/StockGroup.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/group/StockGroup.java
@@ -1,0 +1,15 @@
+package com.tripkey.dto.group;
+
+import com.tripkey.dto.card.CardDto;
+
+import java.util.List;
+
+public record StockGroup(
+        String label,
+        String groupReason,
+        List<CardDto> cards
+) {
+    public static StockGroup of(String label, List<CardDto> cards) {
+        return new StockGroup(label, null, cards);
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
@@ -4,9 +4,16 @@ import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
 import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.group.Groups03Response;
+import com.tripkey.dto.group.Groups04Response;
+import com.tripkey.dto.group.StockGroup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,10 +26,16 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GroupServiceTest {
+
+    private static final GeometryFactory GEOMETRY_FACTORY =
+            new GeometryFactory(new PrecisionModel(), 4326);
 
     @Mock
     private TripRepository tripRepository;
@@ -115,6 +128,169 @@ class GroupServiceTest {
                 .containsExactly(older.getInstanceId(), newer.getInstanceId());
     }
 
+    @Test
+    void getGroups04ThrowsTripNotFoundWhenTripMissing() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(false);
+
+        assertThatThrownBy(() -> groupService.getGroups04(tripId))
+                .isInstanceOf(TripNotFoundException.class);
+    }
+
+    @Test
+    void getGroups04ReturnsAllEmptyGroupsWhenNoCards() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.view()).isEqualTo("04");
+        assertThat(response.available()).isEmpty();
+        assertThat(response.pendingReorder()).isEmpty();
+        assertThat(response.unavailable()).isEmpty();
+    }
+
+    @Test
+    void getGroups04ClassifiesUnavailableByBlockedNeedsInputOrFailed() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard blocked = stockCard(tripId, "blocked", "completed", null, "신주쿠", at(10, 0));
+        PlaceCard needsInput = stockCard(tripId, "needs_input", "completed", null, "신주쿠", at(10, 1));
+        PlaceCard failed = stockCard(tripId, "ready", "failed", null, "신주쿠", at(10, 2));
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(blocked, needsInput, failed));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.unavailable())
+                .extracting(CardDto::instanceId)
+                .containsExactlyInAnyOrder(
+                        blocked.getInstanceId(),
+                        needsInput.getInstanceId(),
+                        failed.getInstanceId());
+        assertThat(response.available()).isEmpty();
+        assertThat(response.pendingReorder()).isEmpty();
+    }
+
+    @Test
+    void getGroups04ClassifiesPendingReorderByProcessingOrMissingGeom() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard stillProcessing = stockCard(tripId, "ready_partial", "processing",
+                point(139.7, 35.69), "신주쿠", at(10, 0));
+        PlaceCard noGeom = stockCard(tripId, "ready_partial", "completed", null, "신주쿠", at(10, 1));
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(stillProcessing, noGeom));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.pendingReorder())
+                .extracting(CardDto::instanceId)
+                .containsExactlyInAnyOrder(stillProcessing.getInstanceId(), noGeom.getInstanceId());
+        assertThat(response.available()).isEmpty();
+        assertThat(response.unavailable()).isEmpty();
+    }
+
+    @Test
+    void getGroups04SkipsExcludedCards() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard excluded = stockCard(tripId, "blocked", "completed", null, "신주쿠", at(10, 0));
+        setField(excluded, "isExcluded", true);
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(excluded));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).isEmpty();
+        assertThat(response.pendingReorder()).isEmpty();
+        assertThat(response.unavailable()).isEmpty();
+    }
+
+    @Test
+    void getGroups04ClustersAvailableCardsWithDominantLocationLabel() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), "시부야", at(10, 0));
+        PlaceCard b = stockCard(tripId, "ready_partial", "completed",
+                point(139.7020, 35.6590), "시부야", at(10, 1));
+        PlaceCard c = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), null, at(10, 2));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a, b, c));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.of(
+                        new Object[]{a.getInstanceId(), 0},
+                        new Object[]{b.getInstanceId(), 0},
+                        new Object[]{c.getInstanceId(), 0}
+                ));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(1);
+        StockGroup group = response.available().get(0);
+        assertThat(group.label()).isEqualTo("시부야");
+        assertThat(group.cards()).hasSize(3)
+                .extracting(CardDto::instanceId)
+                .containsExactly(a.getInstanceId(), b.getInstanceId(), c.getInstanceId());
+    }
+
+    @Test
+    void getGroups04AppliesSuffixWhenSameLabelAcrossMultipleClusters() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), "신주쿠", at(10, 0));
+        PlaceCard b = stockCard(tripId, "ready_partial", "completed",
+                point(139.7020, 35.6590), "신주쿠", at(10, 1));
+        PlaceCard c = stockCard(tripId, "ready_partial", "completed",
+                point(139.7700, 35.6700), "신주쿠", at(10, 2));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a, b, c));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.of(
+                        new Object[]{a.getInstanceId(), 0},
+                        new Object[]{b.getInstanceId(), 0},
+                        new Object[]{c.getInstanceId(), 1}
+                ));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(2);
+        assertThat(response.available())
+                .extracting(StockGroup::label)
+                .containsExactly("신주쿠 1", "신주쿠 2");
+        assertThat(response.available().get(0).cards()).hasSize(2);
+        assertThat(response.available().get(1).cards()).hasSize(1);
+    }
+
+    @Test
+    void getGroups04LabelsClusterAsFallbackWhenNoLocation() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), null, at(10, 0));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.<Object[]>of(new Object[]{a.getInstanceId(), 0}));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(1);
+        assertThat(response.available().get(0).label()).isEqualTo("기타");
+    }
+
     private PlaceCard cardWith(UUID tripId, String actionType, boolean excluded, OffsetDateTime createdAt) {
         PlaceCard card = PlaceCard.createUserCard(
                 tripId, "테스트 카드", "place", null, null, null, null, null, null, null
@@ -124,6 +300,29 @@ class GroupServiceTest {
         setField(card, "isExcluded", excluded);
         setField(card, "createdAt", createdAt);
         return card;
+    }
+
+    private PlaceCard stockCard(
+            UUID tripId,
+            String placementStatus,
+            String processingStatus,
+            Point geom,
+            String location,
+            OffsetDateTime createdAt
+    ) {
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, "테스트 카드", "place", location, null, null, null, null, null, null
+        );
+        setField(card, "instanceId", UUID.randomUUID());
+        setField(card, "placementStatus", placementStatus);
+        setField(card, "processingStatus", processingStatus);
+        setField(card, "geom", geom);
+        setField(card, "createdAt", createdAt);
+        return card;
+    }
+
+    private static Point point(double lng, double lat) {
+        return GEOMETRY_FACTORY.createPoint(new Coordinate(lng, lat));
     }
 
     private static OffsetDateTime at(int hour, int minute) {

--- a/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
@@ -149,6 +149,7 @@ class GroupServiceTest {
         assertThat(response.available()).isEmpty();
         assertThat(response.pendingReorder()).isEmpty();
         assertThat(response.unavailable()).isEmpty();
+        assertThat(response.excluded()).isEmpty();
     }
 
     @Test
@@ -197,7 +198,7 @@ class GroupServiceTest {
     }
 
     @Test
-    void getGroups04SkipsExcludedCards() {
+    void getGroups04PutsExcludedCardsInExcludedSectionRegardlessOfOtherStatus() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
 
@@ -208,6 +209,9 @@ class GroupServiceTest {
 
         Groups04Response response = groupService.getGroups04(tripId);
 
+        assertThat(response.excluded())
+                .extracting(CardDto::instanceId)
+                .containsExactly(excluded.getInstanceId());
         assertThat(response.available()).isEmpty();
         assertThat(response.pendingReorder()).isEmpty();
         assertThat(response.unavailable()).isEmpty();

--- a/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
@@ -87,7 +87,7 @@ class CardServiceTest {
 
         assertThat(created.classification()).isEqualTo("confirmed");
         assertThat(created.processingStatus()).isEqualTo("processing");
-        assertThat(created.placementStatus()).isEqualTo("ready");
+        assertThat(created.placementStatus()).isEqualTo("ready_partial");
         assertThat(created.actionType()).isEqualTo("review_only");
         assertThat(created.isAiGenerated()).isFalse();
         assertThat(created.canExclude()).isTrue();

--- a/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.tripkey.domain.place;
+
+import com.tripkey.domain.trip.Trip;
+import com.tripkey.domain.trip.TripRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.lang.reflect.Field;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Testcontainers
+class PlaceCardRepositoryIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgis/postgis:16-3.4")
+                    .asCompatibleSubstituteFor("postgres"))
+            .withInitScript("postgis-test-schema.sql");
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    }
+
+    @Autowired
+    private PlaceCardRepository placeCardRepository;
+
+    @Autowired
+    private TripRepository tripRepository;
+
+    @Test
+    void clusterAvailableCardsGroupsCardsWithin1500MetersInWebMercator() {
+        Trip trip = new Trip((short) 3, (short) 1);
+        tripRepository.saveAndFlush(trip);
+        UUID tripId = trip.getTripId();
+
+        // Tokyo Station 기준. Web Mercator(EPSG:3857) 기준 1500m 임계값에서
+        // 같은 클러스터로 묶여야 하는 두 점(near*)과 명확히 떨어진 한 점(far)을 배치.
+        // 0.005도 위도차 ≈ 555m → mercator 보정(sec 35.7° ≈ 1.23) ≈ 683m → 1500m 안 (같은 클러스터)
+        // 0.05도 위도차 ≈ 5550m → mercator ≈ 6830m → 1500m 밖 (다른 클러스터)
+        UUID nearAId = saveReadyCard(tripId, "Tokyo Station", 139.7670, 35.6812);
+        UUID nearBId = saveReadyCard(tripId, "Otemachi",      139.7670, 35.6862);
+        UUID farId   = saveReadyCard(tripId, "Shibuya-ish",   139.7670, 35.7312);
+
+        List<Object[]> rows = placeCardRepository.clusterAvailableCards(tripId, 1500.0, 1);
+
+        Map<UUID, Integer> clusterIdByInstance = rows.stream()
+                .collect(Collectors.toMap(
+                        row -> (UUID) row[0],
+                        row -> ((Number) row[1]).intValue()));
+
+        assertThat(clusterIdByInstance)
+                .as("세 카드 모두 minPts=1 이므로 어떤 클러스터든 ID를 부여받아야 함")
+                .containsKeys(nearAId, nearBId, farId);
+        assertThat(clusterIdByInstance.get(nearAId))
+                .as("1.5km 안의 두 카드는 같은 cluster_id 를 가져야 함")
+                .isEqualTo(clusterIdByInstance.get(nearBId));
+        assertThat(clusterIdByInstance.get(farId))
+                .as("1.5km 밖 카드는 다른 cluster_id 를 가져야 함")
+                .isNotEqualTo(clusterIdByInstance.get(nearAId));
+    }
+
+    private UUID saveReadyCard(UUID tripId, String name, double lng, double lat) {
+        PlaceCard card = new PlaceCard();
+        UUID id = UUID.randomUUID();
+        OffsetDateTime now = OffsetDateTime.now();
+        setField(card, "instanceId", id);
+        setField(card, "tripId", tripId);
+        setField(card, "name", name);
+        setField(card, "category", "place");
+        setField(card, "classification", "confirmed");
+        setField(card, "placementStatus", "ready");
+        setField(card, "processingStatus", "completed");
+        setField(card, "actionType", "review_only");
+        setField(card, "canExclude", true);
+        setField(card, "allowDuplicate", false);
+        setField(card, "isExcluded", false);
+        setField(card, "isAiGenerated", false);
+        setField(card, "lat", lat);
+        setField(card, "lng", lng);
+        setField(card, "createdAt", now);
+        setField(card, "updatedAt", now);
+        placeCardRepository.saveAndFlush(card);
+        return id;
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field field = PlaceCard.class.getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -1,0 +1,84 @@
+-- Schema for PlaceCardRepositoryIntegrationTest.
+-- Mirrors shared/docs/schema.sql + V001__postgis_foundation.sql so Hibernate
+-- ddl-auto=validate accepts the full entity model (Trip, TripDestination,
+-- DumpJob, PlaceCard).
+
+create extension if not exists postgis;
+
+create table trips (
+  trip_id            uuid        primary key,
+  travel_days        smallint    not null,
+  companion_count    smallint    not null,
+  has_flight         boolean,
+  has_accommodation  boolean,
+  confirmed_at       timestamptz,
+  created_at         timestamptz not null default now(),
+  updated_at         timestamptz not null default now()
+);
+
+create table trip_destinations (
+  id          bigserial   primary key,
+  trip_id     uuid        not null references trips(trip_id),
+  name        text        not null,
+  sort_order  smallint    not null default 0
+);
+
+create table dump_jobs (
+  job_id          uuid        primary key,
+  trip_id         uuid        not null references trips(trip_id),
+  dump_text       text        not null,
+  status          text        not null,
+  step            smallint,
+  error_code      text,
+  context_summary text,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+create table place_cards (
+  instance_id            uuid        primary key,
+  trip_id                uuid        not null references trips(trip_id),
+  place_id               text,
+  status                 text,
+  name                   text        not null,
+  category               text        not null,
+  classification         text        not null,
+  placement_status       text        not null default 'ready_partial',
+  processing_status      text        not null default 'completed',
+  action_type            text        not null default 'review_only',
+  can_exclude            boolean     not null default true,
+  allow_duplicate        boolean     not null default false,
+  is_excluded            boolean     not null default false,
+  is_ai_generated        boolean     not null,
+  estimated_duration_min smallint,
+  lat                    double precision,
+  lng                    double precision,
+  location               text,
+  address                text,
+  time_constraint        text,
+  user_context           text,
+  tips                   text,
+  question_text          text,
+  options                text,
+  blocked_reason         text,
+  tags                   text,
+  source                 text,
+  notes                  text,
+  memo                   text,
+  day                    integer,
+  check_in               text,
+  check_out              text,
+  flight_number          text,
+  geom                   geometry(Point, 4326)
+    generated always as (
+      case
+        when lat is not null and lng is not null
+          then st_setsrid(st_makepoint(lng, lat), 4326)
+        else null
+      end
+    ) stored,
+  created_at             timestamptz not null default now(),
+  updated_at             timestamptz not null default now()
+);
+
+create index idx_place_cards_geom on place_cards using gist (geom);


### PR DESCRIPTION
## 📝 작업 내용

> SCR-04 (Stock 배치) 화면용 거리 기반 카드 그룹 조회 API (`GET /trips/{tripId}/groups?view=04`) 백엔드 구현. 함께 들어간 action_type 매트릭스 정렬 fix + Testcontainers 기반 PostGIS 통합 테스트 포함.

### feat(be): SCR-04 stock groups view via PostGIS clustering
- `Groups04Response` / `StockGroup` DTO 추가 (`view`, `available[StockGroup]`, `pending_reorder[Card]`, `unavailable[Card]`)
- `PlaceCardRepository.clusterAvailableCards`: native `ST_ClusterDBSCAN(ST_Transform(geom, 3857), :epsMeters, :minPts)` — Web Mercator 좌표계로 변환해 미터 단위 클러스터링 (eps=1500m, minPts=1)
- `GroupService.getGroups04`: 카드를 unavailable / pending_reorder / available 로 분배
  - **excluded**: `is_excluded=true` → 응답에서 완전 제외
  - **unavailable**: `placement_status ∈ {blocked, needs_input}` OR `processing_status=failed`
  - **pending_reorder**: `processing_status=processing` OR `geom IS NULL`
  - **available**: 나머지 (ready / ready_partial + completed + geom 존재) → DBSCAN 클러스터링
- 클러스터 라벨링: 가장 많이 등장한 `location` 사용. 동일 라벨이 여러 클러스터에 걸치면 카드 수 desc / cluster_id asc 순으로 `"신주쿠 1"`, `"신주쿠 2"` suffix
- location 없으면 fallback `"기타"`
- `available` 정렬: 카드 수 desc → 라벨 alphabetic. 그룹 안 카드 정렬: `createdAt ASC`
- `GroupController` 의 `view` 분기에 `"04"` 추가

### refactor(be): switch SCR-04 clustering to meter-based via Web Mercator
- 초기 구현은 raw geometry(WGS84, 단위=도) 기준 eps=0.018° 였으나, 위도에 따라 실제 거리가 달라지는 문제로 정확도 부족
- `ST_Transform(geom, 3857)` (Web Mercator) 으로 좌표 변환 → eps 가 미터 단위로 일관
- 상수: `SCR04_CLUSTER_EPS_METERS = 1500.0`, `SCR04_CLUSTER_MIN_POINTS = 1`
- **Testcontainers 기반 통합 테스트 추가** (`PlaceCardRepositoryIntegrationTest`) — 실제 PostgreSQL + PostGIS 컨테이너에서 1.5km 임계값으로 ST_Transform + ST_ClusterDBSCAN 동작 검증
- 테스트 의존성 추가: `spring-boot-testcontainers`, `testcontainers:postgresql`, `testcontainers:junit-jupiter`
- 테스트 스키마 파일 신규: `apps/backend/src/test/resources/postgis-test-schema.sql` (Supabase 스키마 + V001 마이그레이션 미러, 테스트 컨테이너 init 전용)

### fix(be): align action_type with classification × placement_status matrix
- `computeActionType` 를 매트릭스 기반으로 재작성:
  - `confirmed` / `open_question` + any → `review_only`
  - `undecided` × `ready_partial` → `select_required`
  - `undecided` × `needs_input` → `input_required`
  - `unassigned` × `blocked` → `fix_required`
- 시그니처 단순화: `processing_status`, `options` 인자 제거 (action_type 은 이제 classification + placement_status 만의 함수)
- `createUserCard` 의 `placement_status` default 를 `"ready_partial"` 로 정렬

## 🔗 관련 이슈

closes #84

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [ ] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 🧪 테스트

### 단위 테스트 (Mockito)
`GroupServiceTest` — 13개 (SCR-03 5개 + SCR-04 8개 신규)
- SCR-04 신규: trip 404 / 빈 카드 / unavailable 분배 (blocked, needs_input, failed) / pending_reorder 분배 (processing, geom NULL) / excluded 스킵 / 단일 클러스터 라벨링 / 동일 라벨 suffix / fallback `"기타"`
- 비즈니스 로직 (분배, 라벨링, suffix dedup, 정렬) 검증

### 통합 테스트 (Testcontainers + 실제 PostGIS)
`PlaceCardRepositoryIntegrationTest.clusterAvailableCardsGroupsCardsWithin1500MetersInWebMercator`
- `postgis/postgis:16-3.4` 컨테이너 부팅 → `postgis-test-schema.sql` 로 스키마 초기화 → 실제 SQL 실행
- 도쿄역(35.6812) + 오테마치(35.6862) — Mercator 보정 거리 ~683m → 같은 클러스터 ID
- 시부야쪽(35.7312) — Mercator 거리 ~6830m → 다른 클러스터 ID
- 즉 **`ST_Transform(geom, 3857) + ST_ClusterDBSCAN(eps=1500m)` 의 실제 동작이 검증됨**

### 실행
```bash
cd apps/backend && ./gradlew test
```
Docker 데몬이 떠 있어야 통합 테스트가 실행됩니다 (Testcontainers 가 자동으로 컨테이너 띄움/폐기).

## 👀 리뷰어에게

> **action_type 매트릭스 fix 포함** — 직전 피드백 (classification × placement_status 매트릭스 정렬) 을 본 PR 첫 커밋 (`bf478dd`) 으로 반영. 본 SCR-04 작업과는 별개지만 함께 들어가 있습니다. 분리 머지가 필요하면 알려주세요.
>
> **클러스터링 임계값** — `eps = 1500m` (Web Mercator 미터 단위), `minPts = 1`. 도쿄/서울 위도에서 한 동네 단위 가정으로 시작. 추후 실데이터 보면서 튜닝 필요할 수 있음. 상수는 `GroupService.SCR04_CLUSTER_EPS_METERS`, `SCR04_CLUSTER_MIN_POINTS` 에 추출되어 있습니다.
>
> **좌표계 변환 (`ST_Transform(geom, 3857)`) 비용** — 매 요청마다 후보 카드 수만큼 변환 발생. 카드 수가 trip 당 수십~수백 단위라 비용 무시 가능 수준이지만, 만약 카드 폭증 시나리오 대비가 필요하다면 `geom_3857 geometry(Point, 3857)` 같은 추가 generated column 으로 사전 계산하는 방향도 고려 가능 (현재 PR 범위 외).
>
> **테스트 인프라 신설** — 본 PR 이 프로젝트 첫 Testcontainers 도입. 향후 PostGIS 함수 / 트랜잭션 / FK 제약 등 실제 DB 동작이 중요한 테스트는 같은 패턴으로 작성 가능. CI 환경에 Docker 가 있는지 확인 부탁드립니다 (없으면 통합 테스트만 별도 task 분리하거나 `@EnabledIfSystemProperty` 가드 필요할 수 있음).
>
> **카드 분배 정책 결정 사항 — 합의 받지 못했지만 적용한 두 가지** :
> 1. `is_excluded=true` 카드는 응답에서 완전 제외 (unavailable 에도 안 들어감). Stock 배치 화면에서 사라짐. 다시 포함시키려면 SCR-03 에서 `is_excluded=false` 로 변경 필요함.
> 2. `placement_status='needs_input'` 카드는 `unavailable` 로 분배. 근거: spec 의 드래그 조건 (`ready/ready_partial && completed`) 미충족 → `pending_reorder` 도 `available` 도 자격 안 됨. 자세한 비교는 PR 코멘트로 부연 가능. 

## 📸 스크린샷

> 없음
