### PR TITLE
feat(be): SCR-04 stock groups reorder trigger backed by pending_reord

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
@@ -67,7 +67,7 @@ public class DumpAsyncProcessor {
             List<PlaceCard> cards = response.cards() == null
                     ? List.of()
                     : response.cards().stream()
-                    .map(card -> PlaceCard.createFromAiResponse(job.getTripId(), card))
+                    .map(card -> PlaceCard.createFromAiResponse(job.getTripId(), card, "ai_parse"))
                     .toList();
 
             placeCardRepository.deleteAllByTripId(job.getTripId());

--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupController.java
@@ -1,10 +1,12 @@
 package com.tripkey.domain.group;
 
 import com.tripkey.common.exception.InvalidViewParamException;
+import com.tripkey.dto.group.Groups04Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,5 +30,10 @@ public class GroupController {
             case "04" -> ResponseEntity.ok(groupService.getGroups04(tripId));
             default -> throw new InvalidViewParamException();
         };
+    }
+
+    @PostMapping("/reorder")
+    public ResponseEntity<Groups04Response> reorderGroups(@PathVariable UUID tripId) {
+        return ResponseEntity.ok(groupService.reorderGroups(tripId));
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
@@ -66,6 +66,15 @@ public class GroupService {
         return Groups03Response.of(inputRequired, selectRequired, fixRequired, reviewOnly, excluded);
     }
 
+    @Transactional
+    public Groups04Response reorderGroups(UUID tripId) {
+        if (!tripRepository.existsById(tripId)) {
+            throw new TripNotFoundException(tripId);
+        }
+        placeCardRepository.markAllReordered(tripId);
+        return getGroups04(tripId);
+    }
+
     @Transactional(readOnly = true)
     public Groups04Response getGroups04(UUID tripId) {
         if (!tripRepository.existsById(tripId)) {
@@ -88,8 +97,12 @@ public class GroupService {
                 unavailable.add(card);
                 continue;
             }
-            if ("processing".equals(processing) || card.getGeom() == null) {
+            if ("processing".equals(processing) || Boolean.TRUE.equals(card.getPendingReorder())) {
                 pendingReorder.add(card);
+                continue;
+            }
+            if (card.getGeom() == null) {
+                unavailable.add(card);
                 continue;
             }
             availableCandidates.add(card);

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -72,6 +72,9 @@ public class PlaceCard {
     @Column(name = "is_ai_generated", nullable = false)
     private Boolean isAiGenerated;
 
+    @Column(name = "pending_reorder", nullable = false)
+    private Boolean pendingReorder;
+
     @Column(name = "estimated_duration_min")
     private Short estimatedDurationMin;
 
@@ -164,6 +167,7 @@ public class PlaceCard {
         card.allowDuplicate = DUPLICATE_DEFAULT_CATEGORIES.contains(card.category);
         card.isExcluded = false;
         card.isAiGenerated = false;
+        card.pendingReorder = true;
         card.estimatedDurationMin = estimatedDurationMin;
         card.location = trimToNull(location);
         card.timeConstraint = trimToNull(timeConstraint);
@@ -251,6 +255,7 @@ public class PlaceCard {
                 : DUPLICATE_DEFAULT_CATEGORIES.contains(card.category);
         card.canExclude = !NON_EXCLUDABLE_CATEGORIES.contains(card.category);
         card.isExcluded = false;
+        card.pendingReorder = false;
         card.actionType = computeActionType(card.classification, card.placementStatus);
 
         card.estimatedDurationMin = dto.estimatedDurationMin();

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -240,7 +240,7 @@ public class PlaceCard {
         this.actionType = computeActionType(this.classification, this.placementStatus);
     }
 
-    public static PlaceCard createFromAiResponse(UUID tripId, AiPlaceCardDto dto) {
+    public static PlaceCard createFromAiResponse(UUID tripId, AiPlaceCardDto dto, String source) {
         PlaceCard card = new PlaceCard();
         card.tripId = tripId;
         card.placeId = trimToNull(dto.placeId());
@@ -255,7 +255,8 @@ public class PlaceCard {
                 : DUPLICATE_DEFAULT_CATEGORIES.contains(card.category);
         card.canExclude = !NON_EXCLUDABLE_CATEGORIES.contains(card.category);
         card.isExcluded = false;
-        card.pendingReorder = false;
+        card.source = source;
+        card.pendingReorder = "ai_recommend".equals(source);
         card.actionType = computeActionType(card.classification, card.placementStatus);
 
         card.estimatedDurationMin = dto.estimatedDurationMin();
@@ -272,7 +273,6 @@ public class PlaceCard {
         card.options = dto.options();
         card.blockedReason = trimToNull(dto.blockedReason());
         card.tags = dto.tags();
-        card.source = "ai_parse";
         card.checkIn = trimToNull(dto.checkIn());
         card.checkOut = trimToNull(dto.checkOut());
         card.flightNumber = trimToNull(dto.flightNumber());

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -23,6 +23,11 @@ public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
     @Query("delete from PlaceCard p where p.tripId = :tripId")
     void deleteAllByTripId(@Param("tripId") UUID tripId);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("update PlaceCard p set p.pendingReorder = false where p.tripId = :tripId and p.pendingReorder = true")
+    int markAllReordered(@Param("tripId") UUID tripId);
+
     @Query(value = """
             select instance_id,
                    st_clusterdbscan(st_transform(geom, 3857), :epsMeters, :minPts) over () as cluster_id

--- a/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -177,24 +178,44 @@ class GroupServiceTest {
     }
 
     @Test
-    void getGroups04ClassifiesPendingReorderByProcessingOrMissingGeom() {
+    void getGroups04ClassifiesPendingReorderByProcessingOrPendingFlag() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
 
         PlaceCard stillProcessing = stockCard(tripId, "ready_partial", "processing",
                 point(139.7, 35.69), "신주쿠", at(10, 0));
-        PlaceCard noGeom = stockCard(tripId, "ready_partial", "completed", null, "신주쿠", at(10, 1));
+        PlaceCard pendingFlag = stockCard(tripId, "ready_partial", "completed",
+                point(139.7, 35.69), "신주쿠", at(10, 1));
+        setField(pendingFlag, "pendingReorder", true);
 
         when(placeCardRepository.findAllByTripId(tripId))
-                .thenReturn(List.of(stillProcessing, noGeom));
+                .thenReturn(List.of(stillProcessing, pendingFlag));
 
         Groups04Response response = groupService.getGroups04(tripId);
 
         assertThat(response.pendingReorder())
                 .extracting(CardDto::instanceId)
-                .containsExactlyInAnyOrder(stillProcessing.getInstanceId(), noGeom.getInstanceId());
+                .containsExactlyInAnyOrder(stillProcessing.getInstanceId(), pendingFlag.getInstanceId());
         assertThat(response.available()).isEmpty();
         assertThat(response.unavailable()).isEmpty();
+    }
+
+    @Test
+    void getGroups04PutsCardsWithoutGeomIntoUnavailableWhenAlreadyReordered() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard noGeom = stockCard(tripId, "ready_partial", "completed", null, "신주쿠", at(10, 0));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(noGeom));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.unavailable())
+                .extracting(CardDto::instanceId)
+                .containsExactly(noGeom.getInstanceId());
+        assertThat(response.pendingReorder()).isEmpty();
+        assertThat(response.available()).isEmpty();
     }
 
     @Test
@@ -295,6 +316,60 @@ class GroupServiceTest {
         assertThat(response.available().get(0).label()).isEqualTo("기타");
     }
 
+    @Test
+    void reorderGroupsThrowsTripNotFoundWhenTripMissing() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(false);
+
+        assertThatThrownBy(() -> groupService.reorderGroups(tripId))
+                .isInstanceOf(TripNotFoundException.class);
+    }
+
+    @Test
+    void reorderGroupsMarksAllPendingAndReturnsRefreshedGroups04() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.markAllReordered(tripId)).thenReturn(2);
+
+        // markAllReordered 호출 후 상태 시뮬레이션 — pending_reorder=false (stockCard 기본값) 인 카드 두 장
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), "시부야", at(10, 0));
+        PlaceCard b = stockCard(tripId, "ready_partial", "completed",
+                point(139.7020, 35.6590), "시부야", at(10, 1));
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a, b));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.of(
+                        new Object[]{a.getInstanceId(), 0},
+                        new Object[]{b.getInstanceId(), 0}
+                ));
+
+        Groups04Response response = groupService.reorderGroups(tripId);
+
+        verify(placeCardRepository).markAllReordered(tripId);
+        assertThat(response.view()).isEqualTo("04");
+        assertThat(response.available()).hasSize(1);
+        assertThat(response.available().get(0).label()).isEqualTo("시부야");
+        assertThat(response.available().get(0).cards()).hasSize(2);
+        assertThat(response.pendingReorder()).isEmpty();
+    }
+
+    @Test
+    void reorderGroupsIsIdempotent() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.markAllReordered(tripId)).thenReturn(0);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+
+        Groups04Response first = groupService.reorderGroups(tripId);
+        Groups04Response second = groupService.reorderGroups(tripId);
+
+        verify(placeCardRepository, org.mockito.Mockito.times(2)).markAllReordered(tripId);
+        assertThat(first.view()).isEqualTo("04");
+        assertThat(second.view()).isEqualTo("04");
+        assertThat(first.available()).isEmpty();
+        assertThat(second.available()).isEmpty();
+    }
+
     private PlaceCard cardWith(UUID tripId, String actionType, boolean excluded, OffsetDateTime createdAt) {
         PlaceCard card = PlaceCard.createUserCard(
                 tripId, "테스트 카드", "place", null, null, null, null, null, null, null
@@ -322,6 +397,9 @@ class GroupServiceTest {
         setField(card, "processingStatus", processingStatus);
         setField(card, "geom", geom);
         setField(card, "createdAt", createdAt);
+        // 대부분의 SCR-04 시나리오는 "재정렬이 끝난 카드" 가정 → 기본 pending_reorder=false.
+        // pending_reorder=true 동작을 검증해야 하는 테스트는 setField 로 명시 override.
+        setField(card, "pendingReorder", false);
         return card;
     }
 

--- a/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
@@ -261,6 +261,6 @@ class CardServiceTest {
                 null,
                 null
         );
-        return PlaceCard.createFromAiResponse(tripId, dto);
+        return PlaceCard.createFromAiResponse(tripId, dto, "ai_parse");
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
@@ -96,6 +96,7 @@ class PlaceCardRepositoryIntegrationTest {
         setField(card, "allowDuplicate", false);
         setField(card, "isExcluded", false);
         setField(card, "isAiGenerated", false);
+        setField(card, "pendingReorder", false);
         setField(card, "lat", lat);
         setField(card, "lng", lng);
         setField(card, "createdAt", now);

--- a/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardTest.java
@@ -36,7 +36,7 @@ class PlaceCardTest {
                 null
         );
 
-        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto);
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
 
         assertThat(card.getCategory()).isEqualTo("food");
         assertThat(card.getClassification()).isEqualTo("confirmed");
@@ -76,7 +76,7 @@ class PlaceCardTest {
                 null
         );
 
-        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto);
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
 
         assertThat(card.getCategory()).isEqualTo("place");
         assertThat(card.getClassification()).isEqualTo("undecided");
@@ -113,7 +113,7 @@ class PlaceCardTest {
                 null                                     // flight_number
         );
 
-        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto);
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
 
         assertThat(card.getActionType()).isEqualTo("select_required");
         assertThat(card.getOptions()).containsExactly("라멘", "스시", "야키토리");
@@ -145,7 +145,7 @@ class PlaceCardTest {
                 null                                        // flight_number
         );
 
-        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto);
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
 
         assertThat(card.getPlacementStatus()).isEqualTo("blocked");
         assertThat(card.getActionType()).isEqualTo("fix_required");
@@ -178,11 +178,55 @@ class PlaceCardTest {
                 "KE723"
         );
 
-        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto);
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
 
         assertThat(card.getCategory()).isEqualTo("transport");
         assertThat(card.getCanExclude()).isFalse();
         assertThat(card.getAllowDuplicate()).isTrue();
         assertThat(card.getFlightNumber()).isEqualTo("KE723");
+    }
+
+    @Test
+    void createFromAiResponseWithAiParseSourceMarksPendingReorderFalse() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                "place-1",
+                "도톤보리",
+                "food",
+                "confirmed",
+                "ready_partial",
+                false,
+                false,
+                (short) 90,
+                null, null, null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
+
+        assertThat(card.getSource()).isEqualTo("ai_parse");
+        assertThat(card.getPendingReorder())
+                .as("ai_parse 카드는 즉시 클러스터에 합류해야 하므로 false")
+                .isFalse();
+    }
+
+    @Test
+    void createFromAiResponseWithAiRecommendSourceMarksPendingReorderTrue() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                "place-1",
+                "도톤보리",
+                "food",
+                "confirmed",
+                "ready_partial",
+                false,
+                false,
+                (short) 90,
+                null, null, null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_recommend");
+
+        assertThat(card.getSource()).isEqualTo("ai_recommend");
+        assertThat(card.getPendingReorder())
+                .as("ai_recommend 카드는 사용자가 인지하도록 pending_reorder=true 로 분류")
+                .isTrue();
     }
 }

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -50,6 +50,7 @@ create table place_cards (
   allow_duplicate        boolean     not null default false,
   is_excluded            boolean     not null default false,
   is_ai_generated        boolean     not null,
+  pending_reorder        boolean     not null default true,
   estimated_duration_min smallint,
   lat                    double precision,
   lng                    double precision,

--- a/shared/docs/migrations/V002__place_cards_pending_reorder.sql
+++ b/shared/docs/migrations/V002__place_cards_pending_reorder.sql
@@ -1,0 +1,38 @@
+-- TripKey migration: place_cards.pending_reorder column
+-- Date: 2026-05-06
+-- Scope: SCR-04 Stock 그룹 재정렬 트리거(POST /trips/{trip_id}/groups/reorder) 의 정확한 의미를
+--        지원하기 위한 카드별 "재정렬 대기 중" 플래그를 추가한다.
+--
+-- 적용 대상: Supabase (dev / production 모두)
+-- 적용 방법: Supabase SQL Editor 에서 본 파일 전체 실행
+-- 동기 산출물: shared/docs/schema.sql 가 본 마이그레이션 적용 후 상태와 일치해야 함
+--
+-- 정책:
+-- - 컬럼 default = true (새로 만들어진 카드는 일단 pending_reorder 그룹에 들어감)
+-- - AI 파싱(SCR-02) 으로 만들어진 기존 카드들은 사용자가 명시적으로 재정렬을 누른 적 없지만
+--   대량 일괄 추가된 결과이므로 false 로 백필하여 첫 SCR-04 진입 시 즉시 클러스터링되게 한다.
+-- - SCR-04 진입 후 새로 추가되는 카드 (POST /cards) 는 default true 를 그대로 둬 pending_reorder 에
+--   머무르고, 사용자가 "재정렬" 버튼을 눌러야 available 클러스터로 편입된다.
+
+-- 1. pending_reorder 컬럼 추가 (default true, NOT NULL)
+alter table public.place_cards
+  add column if not exists pending_reorder boolean not null default true;
+
+-- 2. 기존 AI 파싱 카드 백필 — 첫 SCR-04 진입에서 즉시 클러스터에 포함되도록
+update public.place_cards
+   set pending_reorder = false
+ where source = 'ai_parse';
+
+-- ─────────────────────────────────────────────
+-- 검증 (적용 후 Supabase SQL Editor 에서 실행하여 확인)
+-- ─────────────────────────────────────────────
+-- 1) 컬럼 추가 확인
+--    select column_name, data_type, is_nullable, column_default
+--      from information_schema.columns
+--     where table_name = 'place_cards' and column_name = 'pending_reorder';
+--
+-- 2) 백필 결과 확인 (source 별 분포)
+--    select source, pending_reorder, count(*)
+--      from public.place_cards
+--     group by source, pending_reorder
+--     order by source, pending_reorder;

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -59,6 +59,7 @@ create table if not exists public.place_cards (
   allow_duplicate        boolean     not null default false,       -- Day 보드 중복 배치 허용 (숙소/교통은 true 기본)
   is_excluded            boolean     not null default false,       -- 사용자가 제외한 카드 여부
   is_ai_generated        boolean     not null,                     -- AI가 자체적으로 추가한 추천 카드 여부 (INSERT 시 명시 필요)
+  pending_reorder        boolean     not null default true,        -- SCR-04 재정렬 대기 여부 (true=pending_reorder 그룹, false=available 클러스터 후보)
 
   -- 위치 / 메타
   estimated_duration_min smallint,                                 -- 예상 체류시간 (분)


### PR DESCRIPTION
## 📝 작업 내용

> SCR-04 (Stock 배치) 화면의 "재정렬" 버튼이 호출하는 `POST /trips/{tripId}/groups/reorder` 엔드포인트 구현. 카드별 `pending_reorder` 플래그를 도입해 spec 의 "pending_reorder → available 편입" 동작을 실제로 수행하도록 한다.

### 변경 핵심

**스키마 (V002 마이그레이션)**
- `place_cards.pending_reorder boolean not null default true` 컬럼 추가
- 기존 `source = 'ai_parse'` 카드는 백필로 `false` 처리 → 첫 SCR-04 진입 시 자동 클러스터링

**카테고리 분배 로직 변경 (`GroupService.getGroups04`)**
1. `is_excluded=true` → `excluded`
2. `placement_status ∈ {blocked, needs_input}` 또는 `processing_status=failed` → `unavailable`
3. `processing_status=processing` 또는 `pending_reorder=true` → `pending_reorder`
4. `geom IS NULL` → `unavailable` (재정렬 끝났는데 좌표 없는 카드)
5. 그 외 → `available` (DBSCAN 클러스터링)

**재정렬 엔드포인트 (`POST /trips/{tripId}/groups/reorder`)**
- `GroupService.reorderGroups`: trip 검증 → `placeCardRepository.markAllReordered` 호출 (UPDATE) → 갱신된 `Groups04Response` 반환
- 멱등성: 재호출 시 이미 false 인 카드는 변경 없음

**팩토리 메서드 정합**
- `createUserCard` → `pendingReorder = true` (사용자가 새로 추가한 카드는 재정렬 대기)
- `createFromAiResponse` → `pendingReorder = false` (AI 가 이미 분류한 결과)

**테스트**
- `GroupServiceTest`: stockCard 헬퍼 default `pending_reorder=false`. 옵션 C 카테고리 분배 테스트 갱신 + reorder 동작 테스트 3개 추가 (404, mark + 갱신, 멱등성)
- `PlaceCardRepositoryIntegrationTest`: 실제 PostgreSQL+PostGIS 컨테이너에서 클러스터링 통합 테스트 — `pendingReorder=false` 명시 추가

## 🔗 관련 이슈

closes #93

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서 (V002 마이그레이션 + schema.sql)

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 🧪 테스트

### 단위 테스트 (Mockito)
`GroupServiceTest` — SCR-04 / SCR-04 reorder 관련 신규/갱신:
- 빈 카드 → 모든 그룹 비어있음
- excluded > 다른 분류 우선순위
- unavailable 분배 (blocked / needs_input / failed)
- pending_reorder 분배 (processing OR pending_reorder=true)
- 재정렬 후 geom NULL 카드 → unavailable
- 클러스터링 + 라벨링 + suffix dedup + fallback "기타"
- **신규 reorder 테스트 3개:**
  - `reorderGroupsThrowsTripNotFoundWhenTripMissing` (404)
  - `reorderGroupsMarksAllPendingAndReturnsRefreshedGroups04` (markAllReordered 호출 + 갱신된 응답)
  - `reorderGroupsIsIdempotent` (반복 호출 시 동일 결과)

### 통합 테스트 (Testcontainers + 실제 PostGIS)
`PlaceCardRepositoryIntegrationTest.clusterAvailableCardsGroupsCardsWithin1500MetersInWebMercator`
- pendingReorder=false 카드만 사용하므로 reorder 흐름과는 직접 검증 영역 다름. 다만 테스트 데이터 builder 가 새 컬럼을 NOT NULL 정합으로 채우는지 회귀 확인용.

### 실행
```bash
cd apps/backend && ./gradlew test
```
Docker 데몬 필요 (Testcontainers PostGIS 컨테이너 띄움/폐기).

## 📦 V002 마이그레이션 적용 안내 — 머지 전 필수

본 PR 머지 전에 **dev Supabase 에 V002 적용** 필요 (`ddl-auto: validate` 가 새 컬럼 부재로 부팅 실패하기 때문).

`shared/docs/migrations/V002__place_cards_pending_reorder.sql` 의 SQL 을 Supabase SQL Editor 에서 실행 후, 다음 검증 쿼리 두 개 통과 확인:

```sql
-- 1) 컬럼 추가 확인
select column_name, data_type, is_nullable, column_default
  from information_schema.columns
 where table_name = 'place_cards' and column_name = 'pending_reorder';
-- 기대: 1행 (boolean | NO | true)

-- 2) 백필 결과 확인
select source, pending_reorder, count(*)
  from public.place_cards
 group by source, pending_reorder
 order by source;
-- 기대: ai_parse 카드는 false, 그 외는 true
```

**(작성자 확인) dev Supabase 에 적용 + 검증 통과 완료.**

## 👀 리뷰어에게

리뷰 요청 사항을 4개 항목으로 정리했습니다. 각 항목 하단에 **확인이 필요한 질문** 을 명시했으니 짚어주시면 감사하겠습니다.

### 1. 왜 새 컬럼을 도입했나 (옵션 C)

이전 SCR-04 PR (#96) 에서 `pending_reorder` 그룹 분류 기준은 `processing OR geom IS NULL` 휴리스틱이었습니다. 하지만 spec 은 **"재정렬 버튼 클릭 → pending_reorder → available 편입"** 을 명시하는데, 휴리스틱 기준만으로는 사용자가 버튼을 눌러도 카드 상태가 바뀔 게 없었습니다 (= 사실상 no-op).

본 PR 은 카드별 `pending_reorder` 플래그를 도입해 spec 의 동작을 그대로 구현합니다.

→ **확인:** 옵션 C (DB 컬럼 추가) 방향이 맞나요? 아니면 더 가벼운 대안이 있나요?

### 2. `pending_reorder` 초기값 — `createUserCard` 와 `createFromAiResponse` 가 다릅니다

| 메서드 | 초기값 | 호출 시점 | 이유 |
|---|---|---|---|
| `createFromAiResponse` | **false** | SCR-02 dump 일괄 파싱 | "이미 AI 가 분류해준 결과" → 사용자 첫 SCR-04 진입에서 즉시 클러스터에 보임 |
| `createUserCard` | **true** | 사용자 수동 추가 (`POST /cards`) | "방금 추가한 카드" → "새로 정리된 카드" 그룹에 표시 후 사용자가 재정렬 트리거 |

비대칭이 자연스러운 일반 케이스 (사용자가 SCR-04 화면에서 "+카드 추가" 누르는 시나리오) 에서는 의도대로 동작합니다.

다만 다음 두 케이스에서는 불확실:

- **케이스 A — AI 가 SCR-03/04 에서 자동 추천 카드를 만드는 경우** (`source='ai_recommend'`): 현재 코드는 `createFromAiResponse` 경로로 들어가 `pending_reorder=false` 가 됨 → 사용자 모르게 클러스터에 합류. "새로 정리된 카드" 로 표시하는 게 더 자연스러울 수 있음.
- **케이스 B — Dump 비동기 처리 중 사용자가 SCR-04 로 미리 진입한 경우**: 처리가 끝날 때마다 새 AI 카드 (`createFromAiResponse`) 가 생성됨 → 사용자가 보고 있는 클러스터에 카드가 갑자기 끼어듦.

→ **확인:** 위 두 케이스에서 `createFromAiResponse` 의 기본값을 `true` 로 바꿔야 할까요? 아니면 `source` 별 분기가 필요할까요?

### 3. 백필 정책

V002 마이그레이션은 기존 `source='ai_parse'` 카드만 `pending_reorder=false` 로 백필합니다. 다른 source (`manual`, `ai_recommend`) 는 default `true` 유지.

이유: 운영 중인 dev DB 의 AI 파싱 카드 ~수십 장이 모두 `true` 가 되면 첫 SCR-04 진입에서 available 이 비어있고 pending_reorder 만 가득한 어색한 UX 가 됨.

→ **확인:** 이 백필 정책 OK 신가요?

### 4. 카테고리 우선순위 (코드 1줄 결정)

`getGroups04` 의 분배 순서:
```
1. is_excluded=true                                  → excluded
2. blocked / needs_input / failed                    → unavailable
3. processing OR pending_reorder=true                → pending_reorder
4. geom IS NULL (재정렬 끝났는데 좌표 없음)         → unavailable
5. else                                              → available
```

3번이 4번보다 위에 있어, processing 중인 카드는 좌표가 없어도 `pending_reorder` 에 머무릅니다 (FE 가 "처리 중" UX 표기 가능). 재정렬이 끝났는데도 좌표 없는 카드만 `unavailable` 로 떨어집니다.

→ **확인:** 이 우선순위로 진행해도 될까요? 4번 케이스 (재정렬 후 좌표 NULL) 가 실제로 발생할 수 있는지도 의견 주시면 감사하겠습니다.

### 5. API 명세서 갱신 — 본 PR 포함 vs 별도 PR
                                                                                                  
본 PR 은 코드만 변경했고 명세서는 손대지 않았습니다. 다만 "`pending_reorder` 정의가 카드별 컬럼
기반" 같은 구현 노트를 명세서에 추가하면 FE / AI 팀이 동작 파악하기 쉬울 것 같습니다.

## 📸 스크린샷

> 없음 (BE 전용)
