### PR TITLE
fix: prod compose deploy에서 ECR image를 사용하게 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,49 @@ on:
       - develop
 
 jobs:
-  deploy:
+  build-and-push:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push frontend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/tripkey-frontend:latest \
+            --build-arg VITE_API_BASE_URL=/api \
+            apps/frontend
+          docker push $ECR_REGISTRY/tripkey-frontend:latest
+
+      - name: Build and push backend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/tripkey-backend:latest apps/backend
+          docker push $ECR_REGISTRY/tripkey-backend:latest
+
+      - name: Build and push ai-engine
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/tripkey-ai-engine:latest apps/ai-engine
+          docker push $ECR_REGISTRY/tripkey-ai-engine:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -19,12 +59,19 @@ jobs:
 
       - name: Deploy via SSM
         run: |
-          aws ssm send-command \
+          COMMAND_ID=$(aws ssm send-command \
             --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
             --document-name "AWS-RunShellScript" \
-            --parameters 'commands=[
+            --parameters commands='[
+              "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
               "cd /home/ec2-user/tripkey-main",
               "git pull origin develop",
-              "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build"
+              "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com && docker compose -f docker-compose.yml -f docker-compose.prod.yml pull",
+              "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d"
             ]' \
-            --output text
+            --query "Command.CommandId" \
+            --output text)
+          
+          aws ssm wait command-executed \
+            --command-id $COMMAND_ID \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,10 +1,7 @@
 services:
   frontend:
-    build:
-      context: ./apps/frontend
-      dockerfile: Dockerfile
-      args:
-        VITE_API_BASE_URL: /api
+    image: ${ECR_REGISTRY}/tripkey-frontend:latest
+    build: !reset null
     env_file: !reset []
     ports: !override
       - "80:80"
@@ -27,6 +24,8 @@ services:
         max-file: "3"
 
   backend:
+    image: ${ECR_REGISTRY}/tripkey-backend:latest
+    build: !reset null
     ports: !reset []
     expose:
       - "8080"
@@ -56,6 +55,8 @@ services:
         max-file: "3"
 
   ai-engine:
+    image: ${ECR_REGISTRY}/tripkey-ai-engine:latest
+    build: !reset null
     ports: !reset []
     expose:
       - "8000"

--- a/infra/DEPLOY_RUNBOOK.md
+++ b/infra/DEPLOY_RUNBOOK.md
@@ -9,6 +9,7 @@ Supabase 관리형 PostgreSQL을 사용합니다.
 ## 사전 준비
 
 - 호스트에 Docker와 Docker Compose가 설치되어 있어야 합니다.
+- 호스트에서 ECR image pull 권한이 있는 AWS credentials 또는 instance role을 사용할 수 있어야 합니다.
 - Supabase schema가 이미 적용되어 있어야 합니다.
 - 호스트에 필요한 env 파일이 있어야 합니다.
   - `apps/backend/.env`
@@ -94,11 +95,15 @@ chmod 600 apps/backend/.env apps/ai-engine/.env
 실행 전 dev compose와 prod compose가 병합된 최종 설정을 확인합니다.
 
 ```bash
+export ECR_REGISTRY=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com
 docker compose -f docker-compose.yml -f docker-compose.prod.yml config
 ```
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+aws ecr get-login-password --region <AWS_REGION> \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 
 기본적으로 host port를 외부에 공개하는 컨테이너는 frontend뿐입니다.


### PR DESCRIPTION
## 변경 내용
- prod compose에서 ECR image를 사용하도록 변경
- EC2 deploy 단계에서 compose pull 후 up 하도록 변경
- 배포 런북을 ECR pull 방식으로 갱신

## 관련이슈
#91 

## 배경
GitHub Actions에서 ECR로 이미지를 push하고 있었지만, EC2의 prod compose는 ECR image를 사용하지 않아 실제 배포 경로가 어긋나 있었습니다.

## 확인
- `ECR_REGISTRY=example.com docker compose -f docker-compose.yml -f docker-compose.prod.yml config --no-interpolate`
- prod 병합 결과에서 `build:` 제거 및 `image:` 적용 확인