### PR TITLE
chore: stabilize EC2 compose deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,21 @@ jobs:
             --query "Command.CommandId" \
             --output text)
 
+          print_ssm_output() {
+            echo "---- SSM stdout ----"
+            aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+              --query "StandardOutputContent" \
+              --output text || true
+            echo "---- SSM stderr ----"
+            aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+              --query "StandardErrorContent" \
+              --output text || true
+          }
+
           for i in {1..60}; do
             STATUS=$(aws ssm get-command-invocation \
               --command-id $COMMAND_ID \
@@ -80,9 +95,11 @@ jobs:
               exit 0
             elif [ "$STATUS" = "Failed" ]; then
               echo "Deploy failed"
+              print_ssm_output
               exit 1
             fi
             sleep 10
           done
           echo "Timeout"
+          print_ssm_output
           exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,7 @@ jobs:
               "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
               "cd /home/ec2-user/tripkey-main",
               "git pull origin fix/cd-remove-build-flag",
+              "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d",
               "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d"
             ]' \
             --query "Command.CommandId" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to EC2
 on:
   push:
     branches:
-      - fix/cd-remove-build-flag
+      - develop
 
 jobs:
   build-and-push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,49 @@ on:
       - develop
 
 jobs:
-  deploy:
+  build-and-push:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push frontend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/tripkey-frontend:latest \
+            --build-arg VITE_API_BASE_URL=/api \
+            apps/frontend
+          docker push $ECR_REGISTRY/tripkey-frontend:latest
+
+      - name: Build and push backend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/tripkey-backend:latest apps/backend
+          docker push $ECR_REGISTRY/tripkey-backend:latest
+
+      - name: Build and push ai-engine
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/tripkey-ai-engine:latest apps/ai-engine
+          docker push $ECR_REGISTRY/tripkey-ai-engine:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -19,12 +59,19 @@ jobs:
 
       - name: Deploy via SSM
         run: |
-          aws ssm send-command \
+          COMMAND_ID=$(aws ssm send-command \
             --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
             --document-name "AWS-RunShellScript" \
-            --parameters 'commands=[
+            --parameters commands='[
+              "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
               "cd /home/ec2-user/tripkey-main",
               "git pull origin develop",
-              "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build"
+              "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com && docker compose -f docker-compose.yml -f docker-compose.prod.yml pull",
+              "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d"
             ]' \
-            --output text
+            --query "Command.CommandId" \
+            --output text)
+          
+          aws ssm wait command-executed \
+            --command-id $COMMAND_ID \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,10 +63,7 @@ jobs:
             --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
             --document-name "AWS-RunShellScript" \
             --parameters commands='[
-              "sudo -u ec2-user -H bash -lc '\''aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com'\''",
-              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && git pull origin fix/cd-remove-build-flag'\''",
-              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com docker compose -f docker-compose.yml -f docker-compose.prod.yml pull'\''",
-              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d'\''"
+              "sudo -u ec2-user -H bash /home/ec2-user/tripkey-main/infra/deploy.sh"
             ]' \
             --query "Command.CommandId" \
             --output text)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to EC2
 on:
   push:
     branches:
-      - develop
+      - fix/cd-remove-build-flag
 
 jobs:
   build-and-push:
@@ -65,7 +65,7 @@ jobs:
             --parameters commands='[
               "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
               "cd /home/ec2-user/tripkey-main",
-              "git pull origin develop",
+              "git pull origin fix/cd-remove-build-flag",
               "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com && docker compose -f docker-compose.yml -f docker-compose.prod.yml pull",
               "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d"
             ]' \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
             --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
             --document-name "AWS-RunShellScript" \
             --parameters commands='[
-              "git config --global --add safe.directory /home/ec2-user/tripkey-main",
+              "export HOME=/root && git config --global --add safe.directory /home/ec2-user/tripkey-main",
               "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
               "cd /home/ec2-user/tripkey-main",
               "git pull origin fix/cd-remove-build-flag",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,7 @@ jobs:
             --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
             --document-name "AWS-RunShellScript" \
             --parameters commands='[
+              "git config --global --add safe.directory /home/ec2-user/tripkey-main",
               "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
               "cd /home/ec2-user/tripkey-main",
               "git pull origin fix/cd-remove-build-flag",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
             --query "Command.CommandId" \
             --output text)
 
-          for i in {1..30}; do
+          for i in {1..60}; do
             STATUS=$(aws ssm get-command-invocation \
               --command-id $COMMAND_ID \
               --instance-id ${{ secrets.EC2_INSTANCE_ID }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,8 +65,8 @@ jobs:
             --parameters commands='[
               "sudo -u ec2-user -H bash -lc '\''aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com'\''",
               "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && git pull origin fix/cd-remove-build-flag'\''",
-              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && docker compose -f docker-compose.yml -f docker-compose.prod.yml pull'\''",
-              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d'\''"
+              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com docker compose -f docker-compose.yml -f docker-compose.prod.yml pull'\''",
+              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d'\''"
             ]' \
             --query "Command.CommandId" \
             --output text)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,12 +63,10 @@ jobs:
             --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
             --document-name "AWS-RunShellScript" \
             --parameters commands='[
-              "export HOME=/root && git config --global --add safe.directory /home/ec2-user/tripkey-main",
-              "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
-              "cd /home/ec2-user/tripkey-main",
-              "git pull origin fix/cd-remove-build-flag",
-              "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d pull",
-              "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d"
+              "sudo -u ec2-user -H bash -lc '\''aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com'\''",
+              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && git pull origin fix/cd-remove-build-flag'\''",
+              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && docker compose -f docker-compose.yml -f docker-compose.prod.yml pull'\''",
+              "sudo -u ec2-user -H bash -lc '\''cd /home/ec2-user/tripkey-main && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d'\''"
             ]' \
             --query "Command.CommandId" \
             --output text)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,12 +66,26 @@ jobs:
               "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
               "cd /home/ec2-user/tripkey-main",
               "git pull origin fix/cd-remove-build-flag",
-              "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com && docker compose -f docker-compose.yml -f docker-compose.prod.yml pull",
-              "export ECR_REGISTRY=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d"
+              "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d"
             ]' \
             --query "Command.CommandId" \
             --output text)
-          
-          aws ssm wait command-executed \
-            --command-id $COMMAND_ID \
-            --instance-id ${{ secrets.EC2_INSTANCE_ID }}
+
+          for i in {1..30}; do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id $COMMAND_ID \
+              --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+              --query "Status" \
+              --output text)
+            echo "Status: $STATUS"
+            if [ "$STATUS" = "Success" ]; then
+              echo "Deploy succeeded"
+              exit 0
+            elif [ "$STATUS" = "Failed" ]; then
+              echo "Deploy failed"
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "Timeout"
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
               "aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com",
               "cd /home/ec2-user/tripkey-main",
               "git pull origin fix/cd-remove-build-flag",
-              "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d",
+              "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d pull",
               "docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d"
             ]' \
             --query "Command.CommandId" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,15 +126,15 @@ cp apps/ai-engine/.env.example apps/ai-engine/.env
 ### 전체 서비스 실행
 
 ```bash
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
 
 ### 개별 서비스 실행
 
 ```bash
-docker compose up frontend
-docker compose up backend
-docker compose up ai-engine
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up frontend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up backend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up ai-engine
 ```
 
 ### 개별 앱 로컬 실행
@@ -161,7 +161,7 @@ npm run lint:fix
 
 - Frontend: `http://localhost:3000`
 - Backend: `http://localhost:8080` 접속 시 404가 보여도 서버가 떠 있으면 정상입니다.
-- AI Engine: `docker compose logs --tail=50 ai-engine` 또는 컨테이너 내부 `/health`로 확인합니다.
+- AI Engine: `docker compose -f docker-compose.yml -f docker-compose.dev.yml logs --tail=50 ai-engine` 또는 컨테이너 내부 `/health`로 확인합니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ SUPABASE_SERVICE_ROLE_KEY=
 
 ```bash
 # 전체 실행 (권장)
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 
 # 개별 실행
 cd apps/frontend && npm install && npm run dev     # http://localhost:3000
@@ -103,7 +103,7 @@ cd apps/ai-engine && uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 
 - Frontend: `http://localhost:3000`
 - Backend: `http://localhost:8080` 접속 시 404가 보여도 서버가 떠 있으면 정상입니다.
-- AI Engine: `docker compose logs --tail=50 ai-engine` 또는 컨테이너 내부에서 `/health`로 확인할 수 있습니다.
+- AI Engine: `docker compose -f docker-compose.yml -f docker-compose.dev.yml logs --tail=50 ai-engine` 또는 컨테이너 내부에서 `/health`로 확인할 수 있습니다.
 
 ---
 

--- a/apps/backend/build.gradle
+++ b/apps/backend/build.gradle
@@ -1,8 +1,18 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:3.5.13'
+    }
+}
+
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
 }
+
+apply plugin: 'org.springframework.boot'
 
 group = 'com.tripkey'
 version = '0.0.1-SNAPSHOT'

--- a/apps/backend/build.gradle
+++ b/apps/backend/build.gradle
@@ -1,18 +1,8 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'org.springframework.boot:spring-boot-gradle-plugin:3.5.13'
-    }
-}
-
 plugins {
     id 'java'
+    id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
 }
-
-apply plugin: 'org.springframework.boot'
 
 group = 'com.tripkey'
 version = '0.0.1-SNAPSHOT'

--- a/apps/backend/settings.gradle
+++ b/apps/backend/settings.gradle
@@ -1,2 +1,9 @@
 // settings.gradle
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = 'tripkey-backend'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,39 @@
+services:
+  frontend:
+    build:
+      context: ./apps/frontend
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3000:3000"
+    env_file:
+      - ./apps/frontend/.env
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+      WATCHPACK_POLLING: "true"
+    volumes:
+      - ./apps/frontend:/app
+      - /app/node_modules
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: ./apps/backend
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./apps/backend/.env
+    restart: unless-stopped
+
+  ai-engine:
+    build:
+      context: ./apps/ai-engine
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    env_file:
+      - ./apps/ai-engine/.env
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    volumes:
+      - ./apps/ai-engine:/app
+    restart: unless-stopped

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,10 +1,7 @@
 services:
   frontend:
-    build:
-      context: ./apps/frontend
-      dockerfile: Dockerfile
-      args:
-        VITE_API_BASE_URL: /api
+    image: ${ECR_REGISTRY}/tripkey-frontend:latest
+    build: !reset null
     env_file: !reset []
     ports: !override
       - "80:80"
@@ -27,6 +24,8 @@ services:
         max-file: "3"
 
   backend:
+    image: ${ECR_REGISTRY}/tripkey-backend:latest
+    build: !reset null
     ports: !reset []
     expose:
       - "8080"
@@ -56,6 +55,8 @@ services:
         max-file: "3"
 
   ai-engine:
+    image: ${ECR_REGISTRY}/tripkey-ai-engine:latest
+    build: !reset null
     ports: !reset []
     expose:
       - "8000"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,12 +1,8 @@
 services:
   frontend:
     image: ${ECR_REGISTRY}/tripkey-frontend:latest
-    build: !reset null
-    env_file: !reset []
-    ports: !override
+    ports:
       - "80:80"
-    volumes: !reset []
-    environment: !reset []
     depends_on:
       backend:
         condition: service_started
@@ -25,10 +21,10 @@ services:
 
   backend:
     image: ${ECR_REGISTRY}/tripkey-backend:latest
-    build: !reset null
-    ports: !reset []
     expose:
       - "8080"
+    env_file:
+      - ./apps/backend/.env
     environment:
       SPRING_PROFILES_ACTIVE: prod
       AI_ENGINE_URL: http://tripkey-ai-engine:8000
@@ -56,11 +52,10 @@ services:
 
   ai-engine:
     image: ${ECR_REGISTRY}/tripkey-ai-engine:latest
-    build: !reset null
-    ports: !reset []
     expose:
       - "8000"
-    volumes: !reset []
+    env_file:
+      - ./apps/ai-engine/.env
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers ${AI_ENGINE_WORKERS:-2}
     restart: unless-stopped
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,94 +1,25 @@
-# ────────────────────────────────────────────
-# TripKey — docker-compose (로컬 개발용)
-#
-# 사전 준비:
-#   각 앱 .env.example → .env 복사 후 값 채우기
-#   cp apps/frontend/.env.example apps/frontend/.env
-#   cp apps/backend/.env.example apps/backend/.env
-#   cp apps/ai-engine/.env.example apps/ai-engine/.env
-#
-# 실행:
-#   docker-compose up --build
-#
-# 개별 실행:
-#   docker-compose up frontend
-#   docker-compose up backend
-#   docker-compose up ai-engine
-# ────────────────────────────────────────────
-
 services:
-
-  # ── Frontend (React + Vite dev server) ────────
   frontend:
-    build:
-      context: ./apps/frontend
-      dockerfile: Dockerfile.dev
     container_name: tripkey-frontend
-    ports:
-      - "3000:3000" # 로컬 3000 → Vite dev server 3000
-    env_file:
-      - ./apps/frontend/.env
-    environment:
-      CHOKIDAR_USEPOLLING: "true"
-      WATCHPACK_POLLING: "true"
-    volumes:
-      - ./apps/frontend:/app
-      - /app/node_modules
     depends_on:
       - backend
     networks:
       - tripkey-network
-    restart: unless-stopped
 
-  # ── Backend (Java Spring Boot) ──────────────
   backend:
-    build:
-      context: ./apps/backend
-      dockerfile: Dockerfile
     container_name: tripkey-backend
-    ports:
-      - "8080:8080"
-    env_file:
-      - ./apps/backend/.env
     environment:
-      # AI Engine 내부 통신 주소 (컨테이너 이름으로 호출)
       AI_ENGINE_URL: http://tripkey-ai-engine:8000
-      # Supabase는 외부 서비스 — .env에서 주입
-      # SUPABASE_URL: ${SUPABASE_URL}
-      # SUPABASE_KEY: ${SUPABASE_KEY}
     depends_on:
       - ai-engine
     networks:
       - tripkey-network
-    restart: unless-stopped
 
-  # ── AI Engine (Python FastAPI) ──────────────
   ai-engine:
-    build:
-      context: ./apps/ai-engine
-      dockerfile: Dockerfile
     container_name: tripkey-ai-engine
-    ports:
-      - "8000:8000" # 로컬 8000 → FastAPI 8000 (개발용, 프로덕션에서는 외부 노출 여부 결정)
-    # expose:
-    #   - "8000" # 내부 통신용 포트 (외부 노출은 backend → ai-engine 통신만)
-    env_file:
-      - ./apps/ai-engine/.env
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
-    volumes:
-      - ./apps/ai-engine:/app
     networks:
       - tripkey-network
-    restart: unless-stopped
 
 networks:
   tripkey-network:
     driver: bridge
-
-# ────────────────────────────────────────────
-# TODO (팀 논의 후 결정)
-# - AWS 배포 시 별도 docker-compose.prod.yml 작성
-# - ai-engine 포트 프로덕션 외부 노출 여부 결정
-# - 헬스체크 (healthcheck) 추가 여부
-# - 로그 드라이버 설정 (awslogs 등)
-# ────────────────────────────────────────────

--- a/infra/DEPLOY_RUNBOOK.md
+++ b/infra/DEPLOY_RUNBOOK.md
@@ -92,7 +92,7 @@ chmod 600 apps/backend/.env apps/ai-engine/.env
 
 ## 실행
 
-실행 전 dev compose와 prod compose가 병합된 최종 설정을 확인합니다.
+실행 전 base compose와 prod compose가 병합된 최종 설정을 확인합니다.
 
 ```bash
 export ECR_REGISTRY=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com

--- a/infra/DEPLOY_RUNBOOK.md
+++ b/infra/DEPLOY_RUNBOOK.md
@@ -4,7 +4,7 @@
 
 이 문서는 AWS EC2 같은 단일 호스트에서 Docker Compose로 TripKey production
 구성을 배포하는 절차를 다룹니다. 데이터베이스는 별도 RDS가 아니라 현재 사용 중인
-Supabase 관리형 PostgreSQL을 사용합니다..
+Supabase 관리형 PostgreSQL을 사용합니다.
 
 ## 사전 준비
 

--- a/infra/DEPLOY_RUNBOOK.md
+++ b/infra/DEPLOY_RUNBOOK.md
@@ -4,7 +4,7 @@
 
 이 문서는 AWS EC2 같은 단일 호스트에서 Docker Compose로 TripKey production
 구성을 배포하는 절차를 다룹니다. 데이터베이스는 별도 RDS가 아니라 현재 사용 중인
-Supabase 관리형 PostgreSQL을 사용합니다.
+Supabase 관리형 PostgreSQL을 사용합니다..
 
 ## 사전 준비
 

--- a/infra/DEPLOY_RUNBOOK.md
+++ b/infra/DEPLOY_RUNBOOK.md
@@ -9,6 +9,7 @@ Supabase 관리형 PostgreSQL을 사용합니다.
 ## 사전 준비
 
 - 호스트에 Docker와 Docker Compose가 설치되어 있어야 합니다.
+- 호스트에서 ECR image pull 권한이 있는 AWS credentials 또는 instance role을 사용할 수 있어야 합니다.
 - Supabase schema가 이미 적용되어 있어야 합니다.
 - 호스트에 필요한 env 파일이 있어야 합니다.
   - `apps/backend/.env`
@@ -94,11 +95,15 @@ chmod 600 apps/backend/.env apps/ai-engine/.env
 실행 전 dev compose와 prod compose가 병합된 최종 설정을 확인합니다.
 
 ```bash
+export ECR_REGISTRY=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com
 docker compose -f docker-compose.yml -f docker-compose.prod.yml config
 ```
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+aws ecr get-login-password --region <AWS_REGION> \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 
 기본적으로 host port를 외부에 공개하는 컨테이너는 frontend뿐입니다.

--- a/infra/DEPLOY_RUNBOOK.md
+++ b/infra/DEPLOY_RUNBOOK.md
@@ -81,13 +81,24 @@ GOOGLE_MAPS_API_KEY=
 AI_ENGINE_WORKERS=2
 ```
 
+## Deploy 필수 Env
+
+`infra/deploy.sh`는 repository root의 `.env`에서 배포 설정을 읽습니다.
+
+```env
+ECR_REGISTRY=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com
+AWS_REGION=ap-northeast-2
+DEPLOY_BRANCH=develop
+```
+
 EC2 호스트에서 직접 파일을 만들거나, 팀에서 사용하는 secret 관리 경로를 통해
 복사합니다. 파일 위치 예시는 다음과 같습니다.
 
 ```bash
+vi .env
 vi apps/backend/.env
 vi apps/ai-engine/.env
-chmod 600 apps/backend/.env apps/ai-engine/.env
+chmod 600 .env apps/backend/.env apps/ai-engine/.env
 ```
 
 ## 실행
@@ -95,15 +106,11 @@ chmod 600 apps/backend/.env apps/ai-engine/.env
 실행 전 base compose와 prod compose가 병합된 최종 설정을 확인합니다.
 
 ```bash
-export ECR_REGISTRY=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com
 docker compose -f docker-compose.yml -f docker-compose.prod.yml config
 ```
 
 ```bash
-aws ecr get-login-password --region <AWS_REGION> \
-  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
-docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
-docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+./infra/deploy.sh
 ```
 
 기본적으로 host port를 외부에 공개하는 컨테이너는 frontend뿐입니다.

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -6,11 +6,14 @@ COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.prod.yml)
 
 cd "$APP_DIR"
 
+echo "Deploy directory: $APP_DIR"
+
 if [ ! -f .env ]; then
   echo "Missing required .env file: $APP_DIR/.env" >&2
   exit 1
 fi
 
+echo "Loading deploy environment"
 set -a
 source .env
 set +a
@@ -20,10 +23,15 @@ set +a
 AWS_REGION="${AWS_REGION:-ap-northeast-2}"
 DEPLOY_BRANCH="${DEPLOY_BRANCH:-fix/cd-remove-build-flag}"
 
+echo "Logging in to ECR: $ECR_REGISTRY"
 aws ecr get-login-password --region "$AWS_REGION" \
   | docker login --username AWS --password-stdin "$ECR_REGISTRY"
 
+echo "Pulling branch: $DEPLOY_BRANCH"
 git pull origin "$DEPLOY_BRANCH"
 
+echo "Pulling compose images"
 ECR_REGISTRY="$ECR_REGISTRY" docker compose "${COMPOSE_FILES[@]}" pull
+
+echo "Starting compose services"
 ECR_REGISTRY="$ECR_REGISTRY" docker compose "${COMPOSE_FILES[@]}" up -d

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -21,7 +21,7 @@ set +a
 : "${ECR_REGISTRY:?ECR_REGISTRY is required in $APP_DIR/.env}"
 
 AWS_REGION="${AWS_REGION:-ap-northeast-2}"
-DEPLOY_BRANCH="${DEPLOY_BRANCH:-fix/cd-remove-build-flag}"
+DEPLOY_BRANCH="fix/cd-remove-build-flag"
 
 echo "Logging in to ECR: $ECR_REGISTRY"
 aws ecr get-login-password --region "$AWS_REGION" \

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -21,14 +21,14 @@ set +a
 : "${ECR_REGISTRY:?ECR_REGISTRY is required in $APP_DIR/.env}"
 
 AWS_REGION="${AWS_REGION:-ap-northeast-2}"
-DEPLOY_BRANCH="fix/cd-remove-build-flag"
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-develop}"
 
 echo "Logging in to ECR: $ECR_REGISTRY"
 aws ecr get-login-password --region "$AWS_REGION" \
   | docker login --username AWS --password-stdin "$ECR_REGISTRY"
 
-# echo "Pulling branch: $DEPLOY_BRANCH"
-git pull origin "${DEPLOY_BRANCH:-fix/cd-remove-build-flag}"
+echo "Pulling branch: $DEPLOY_BRANCH"
+git pull origin "$DEPLOY_BRANCH"
 
 echo "Pulling compose images"
 ECR_REGISTRY="$ECR_REGISTRY" docker compose "${COMPOSE_FILES[@]}" pull

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_DIR="/home/ec2-user/tripkey-main"
+COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.prod.yml)
+
+cd "$APP_DIR"
+
+if [ ! -f .env ]; then
+  echo "Missing required .env file: $APP_DIR/.env" >&2
+  exit 1
+fi
+
+set -a
+source .env
+set +a
+
+: "${ECR_REGISTRY:?ECR_REGISTRY is required in $APP_DIR/.env}"
+
+AWS_REGION="${AWS_REGION:-ap-northeast-2}"
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-fix/cd-remove-build-flag}"
+
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+git pull origin "$DEPLOY_BRANCH"
+
+ECR_REGISTRY="$ECR_REGISTRY" docker compose "${COMPOSE_FILES[@]}" pull
+ECR_REGISTRY="$ECR_REGISTRY" docker compose "${COMPOSE_FILES[@]}" up -d

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -27,8 +27,8 @@ echo "Logging in to ECR: $ECR_REGISTRY"
 aws ecr get-login-password --region "$AWS_REGION" \
   | docker login --username AWS --password-stdin "$ECR_REGISTRY"
 
-echo "Pulling branch: $DEPLOY_BRANCH"
-git pull origin "$DEPLOY_BRANCH"
+# echo "Pulling branch: $DEPLOY_BRANCH"
+git pull origin "${DEPLOY_BRANCH:-fix/cd-remove-build-flag}"
 
 echo "Pulling compose images"
 ECR_REGISTRY="$ECR_REGISTRY" docker compose "${COMPOSE_FILES[@]}" pull


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- EC2 배포 workflow를 정리하고, Docker Compose 운영 배포 구성을 안정화했습니다.
- 로컬 Gradle 캐시가 없는 GitHub Actions Docker 빌드 환경에서도 Spring Boot Gradle plugin을 안정적으로 해석할 수 있도록 `settings.gradle`에 plugin repository 설정을 추가했습니다.
- SSM 배포 명령을 `infra/deploy.sh`로 분리해 workflow quoting 복잡도를 줄였습니다.
- `docker-compose.yml`을 공통 base로 정리하고 dev/prod compose 설정을 분리했습니다.
- SSM 실패 시 stdout/stderr를 Actions 로그에 출력하도록 개선했습니다.

## 🔗 관련 이슈

closes #91 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.
> 없으면 "없음"으로 남겨주세요.

- GitHub Actions의 clean Docker build 환경에서 Spring Boot Gradle plugin 해석이 실패하던 문제를 해결하기 위해 `settings.gradle`에 `pluginManagement.repositories`를 추가했습니다. Gradle plugin 해석 경로 변경이 적절한지 확인 부탁드립니다.
- `docker-compose.yml`, `docker-compose.dev.yml`, `docker-compose.prod.yml` 분리 구조로 바꿨습니다. 따라서
-  로컬 빌드 방식을 `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build` 로 진행해야합니다.
상세 내용은 README.md, CONTRIBUTING.md에 작성 되어있습니다.
- EC2 배포는 `infra/deploy.sh`를 통해 실행되며, root `.env`의 `ECR_REGISTRY`, `AWS_REGION`, `DEPLOY_BRANCH` 값을 사용합니다.
- deploy workflow는 PR merge로 `develop`에 push가 발생하면 실행됩니다.

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.

없음
