### PR TITLE
feat(be): SCR-04 Day View Model lookup endpoint

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
@@ -54,6 +54,12 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse("INVALID_VIEW_PARAM", e.getMessage()));
     }
 
+    @ExceptionHandler(InvalidDayParamException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidDayParam(InvalidDayParamException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("INVALID_DAY_PARAM", e.getMessage()));
+    }
+
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ErrorResponse> handleMissingParam(MissingServletRequestParameterException e) {
         if ("view".equals(e.getParameterName())) {

--- a/apps/backend/src/main/java/com/tripkey/common/exception/InvalidDayParamException.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/InvalidDayParamException.java
@@ -1,0 +1,8 @@
+package com.tripkey.common.exception;
+
+public class InvalidDayParamException extends RuntimeException {
+
+    public InvalidDayParamException() {
+        super("day_number 는 1 이상이어야 해요");
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/group/DayController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/DayController.java
@@ -1,0 +1,26 @@
+package com.tripkey.domain.group;
+
+import com.tripkey.dto.group.DayViewModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/trips/{tripId}/days")
+@RequiredArgsConstructor
+public class DayController {
+
+    private final DayViewService dayViewService;
+
+    @GetMapping("/{dayNumber}")
+    public ResponseEntity<DayViewModel> getDayViewModel(
+            @PathVariable UUID tripId,
+            @PathVariable int dayNumber) {
+        return ResponseEntity.ok(dayViewService.getDayViewModel(tripId, dayNumber));
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/group/DayViewService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/DayViewService.java
@@ -1,0 +1,70 @@
+package com.tripkey.domain.group;
+
+import com.tripkey.common.exception.InvalidDayParamException;
+import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.card.CardDto;
+import com.tripkey.dto.group.DayViewModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DayViewService {
+
+    private final TripRepository tripRepository;
+    private final PlaceCardRepository placeCardRepository;
+
+    @Transactional(readOnly = true)
+    public DayViewModel getDayViewModel(UUID tripId, int dayNumber) {
+        if (dayNumber < 1) {
+            throw new InvalidDayParamException();
+        }
+        if (!tripRepository.existsById(tripId)) {
+            throw new TripNotFoundException(tripId);
+        }
+
+        List<PlaceCard> cardsForDay = placeCardRepository.findAllByTripIdAndDay(tripId, dayNumber).stream()
+                .sorted(Comparator.comparing(PlaceCard::getCreatedAt))
+                .toList();
+
+        int maxDay = placeCardRepository.findMaxDayByTripId(tripId);
+
+        PlaceCard startTimeCard = null;
+        PlaceCard endTimeCard = null;
+        List<PlaceCard> otherCards = new ArrayList<>();
+
+        for (PlaceCard card : cardsForDay) {
+            boolean isFlightCard = "transport".equals(card.getCategory())
+                    && card.getFlightNumber() != null
+                    && !card.getFlightNumber().isBlank();
+
+            if (isFlightCard) {
+                if (dayNumber == 1 && startTimeCard == null) {
+                    startTimeCard = card;
+                    continue;
+                }
+                if (dayNumber == maxDay && endTimeCard == null) {
+                    endTimeCard = card;
+                    continue;
+                }
+            }
+            otherCards.add(card);
+        }
+
+        return DayViewModel.of(
+                dayNumber,
+                startTimeCard != null ? CardDto.from(startTimeCard) : null,
+                endTimeCard != null ? CardDto.from(endTimeCard) : null,
+                otherCards.stream().map(CardDto::from).toList()
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -14,9 +14,14 @@ public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
 
     List<PlaceCard> findAllByTripId(UUID tripId);
 
+    List<PlaceCard> findAllByTripIdAndDay(UUID tripId, Integer day);
+
     Optional<PlaceCard> findByInstanceIdAndTripId(UUID instanceId, UUID tripId);
 
     boolean existsByTripIdAndCategoryAndFlightNumber(UUID tripId, String category, String flightNumber);
+
+    @Query("select coalesce(max(p.day), 0) from PlaceCard p where p.tripId = :tripId")
+    int findMaxDayByTripId(@Param("tripId") UUID tripId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional

--- a/apps/backend/src/main/java/com/tripkey/dto/group/DayViewModel.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/group/DayViewModel.java
@@ -1,0 +1,18 @@
+package com.tripkey.dto.group;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.tripkey.dto.card.CardDto;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public record DayViewModel(
+        String dayId,
+        CardDto startTimeCard,
+        CardDto endTimeCard,
+        List<CardDto> cards
+) {
+    public static DayViewModel of(int dayNumber, CardDto startTimeCard, CardDto endTimeCard, List<CardDto> cards) {
+        return new DayViewModel("day" + dayNumber, startTimeCard, endTimeCard, cards);
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/group/DayViewServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/DayViewServiceTest.java
@@ -1,0 +1,228 @@
+package com.tripkey.domain.group;
+
+import com.tripkey.common.exception.InvalidDayParamException;
+import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.card.CardDto;
+import com.tripkey.dto.group.DayViewModel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DayViewServiceTest {
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private PlaceCardRepository placeCardRepository;
+
+    @InjectMocks
+    private DayViewService dayViewService;
+
+    @Test
+    void getDayViewModelThrowsInvalidDayParamWhenDayIsZero() {
+        assertThatThrownBy(() -> dayViewService.getDayViewModel(UUID.randomUUID(), 0))
+                .isInstanceOf(InvalidDayParamException.class);
+    }
+
+    @Test
+    void getDayViewModelThrowsInvalidDayParamWhenDayIsNegative() {
+        assertThatThrownBy(() -> dayViewService.getDayViewModel(UUID.randomUUID(), -1))
+                .isInstanceOf(InvalidDayParamException.class);
+    }
+
+    @Test
+    void getDayViewModelThrowsTripNotFoundWhenTripMissing() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(false);
+
+        assertThatThrownBy(() -> dayViewService.getDayViewModel(tripId, 1))
+                .isInstanceOf(TripNotFoundException.class);
+    }
+
+    @Test
+    void getDayViewModelReturnsEmptyDayViewWhenNoCardsForDay() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 3)).thenReturn(List.of());
+        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(0);
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 3);
+
+        assertThat(response.dayId()).isEqualTo("day3");
+        assertThat(response.startTimeCard()).isNull();
+        assertThat(response.endTimeCard()).isNull();
+        assertThat(response.cards()).isEmpty();
+    }
+
+    @Test
+    void getDayViewModelAssignsArrivalFlightToStartTimeCardOnDayOne() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard arrivalFlight = dayCard(tripId, "transport", "KE723", 1, at(8, 0));
+        PlaceCard restaurant = dayCard(tripId, "food", null, 1, at(12, 0));
+
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 1))
+                .thenReturn(List.of(restaurant, arrivalFlight));
+        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(5);
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 1);
+
+        assertThat(response.dayId()).isEqualTo("day1");
+        assertThat(response.startTimeCard()).isNotNull();
+        assertThat(response.startTimeCard().instanceId()).isEqualTo(arrivalFlight.getInstanceId());
+        assertThat(response.endTimeCard()).isNull();
+        assertThat(response.cards())
+                .extracting(CardDto::instanceId)
+                .containsExactly(restaurant.getInstanceId());
+    }
+
+    @Test
+    void getDayViewModelAssignsDepartureFlightToEndTimeCardOnMaxDay() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard hotelCheckout = dayCard(tripId, "accommodation", null, 5, at(10, 0));
+        PlaceCard departureFlight = dayCard(tripId, "transport", "KE726", 5, at(20, 0));
+
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 5))
+                .thenReturn(List.of(hotelCheckout, departureFlight));
+        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(5);
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 5);
+
+        assertThat(response.dayId()).isEqualTo("day5");
+        assertThat(response.startTimeCard()).isNull();
+        assertThat(response.endTimeCard()).isNotNull();
+        assertThat(response.endTimeCard().instanceId()).isEqualTo(departureFlight.getInstanceId());
+        assertThat(response.cards())
+                .extracting(CardDto::instanceId)
+                .containsExactly(hotelCheckout.getInstanceId());
+    }
+
+    @Test
+    void getDayViewModelAssignsBothFlightsForSingleDayTrip() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard arrivalFlight = dayCard(tripId, "transport", "KE723", 1, at(8, 0));
+        PlaceCard lunch = dayCard(tripId, "food", null, 1, at(12, 0));
+        PlaceCard departureFlight = dayCard(tripId, "transport", "KE726", 1, at(20, 0));
+
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 1))
+                .thenReturn(List.of(arrivalFlight, lunch, departureFlight));
+        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(1);
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 1);
+
+        assertThat(response.startTimeCard()).isNotNull();
+        assertThat(response.startTimeCard().instanceId()).isEqualTo(arrivalFlight.getInstanceId());
+        assertThat(response.endTimeCard()).isNotNull();
+        assertThat(response.endTimeCard().instanceId()).isEqualTo(departureFlight.getInstanceId());
+        assertThat(response.cards())
+                .extracting(CardDto::instanceId)
+                .containsExactly(lunch.getInstanceId());
+    }
+
+    @Test
+    void getDayViewModelKeepsMiddleDayFlightInCardsArray() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        // 3일차 국내선 환승편 — start/end 슬롯에 들어가지 않고 cards[] 에 표시
+        PlaceCard middleFlight = dayCard(tripId, "transport", "JL101", 3, at(14, 0));
+
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 3))
+                .thenReturn(List.of(middleFlight));
+        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(5);
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 3);
+
+        assertThat(response.startTimeCard()).isNull();
+        assertThat(response.endTimeCard()).isNull();
+        assertThat(response.cards())
+                .extracting(CardDto::instanceId)
+                .containsExactly(middleFlight.getInstanceId());
+    }
+
+    @Test
+    void getDayViewModelTreatsTransportWithoutFlightNumberAsRegularCard() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        // transport 카테고리지만 flight_number 없음 (예: 지하철 / 버스)
+        PlaceCard subway = dayCard(tripId, "transport", null, 1, at(9, 0));
+
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 1))
+                .thenReturn(List.of(subway));
+        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(3);
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 1);
+
+        assertThat(response.startTimeCard()).isNull();
+        assertThat(response.endTimeCard()).isNull();
+        assertThat(response.cards())
+                .extracting(CardDto::instanceId)
+                .containsExactly(subway.getInstanceId());
+    }
+
+    @Test
+    void getDayViewModelSortsCardsByCreatedAtAsc() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard later = dayCard(tripId, "place", null, 2, at(14, 0));
+        PlaceCard earlier = dayCard(tripId, "place", null, 2, at(10, 0));
+
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 2))
+                .thenReturn(List.of(later, earlier));
+        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(5);
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 2);
+
+        assertThat(response.cards())
+                .extracting(CardDto::instanceId)
+                .containsExactly(earlier.getInstanceId(), later.getInstanceId());
+    }
+
+    private PlaceCard dayCard(UUID tripId, String category, String flightNumber, int day, OffsetDateTime createdAt) {
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, "테스트 카드", category, null, null, null, null, null, null, flightNumber
+        );
+        setField(card, "instanceId", UUID.randomUUID());
+        setField(card, "day", day);
+        setField(card, "createdAt", createdAt);
+        return card;
+    }
+
+    private static OffsetDateTime at(int hour, int minute) {
+        return OffsetDateTime.of(2026, 5, 7, hour, minute, 0, 0, ZoneOffset.UTC);
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field field = PlaceCard.class.getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

> SCR-04 Day 보드의 특정 Day 데이터를 반환하는 `GET /trips/{tripId}/days/{dayNumber}` 엔드포인트 구현. 항공편 고정 슬롯(start/end) + 일반 카드 배열로 구성된 Day View Model 반환.

### 변경 핵심

**DTO**
- `DayViewModel` (record): `day_id`, `start_time_card`, `end_time_card`, `cards`
- 응답 키는 Jackson SNAKE_CASE 정책으로 변환

**Service — `DayViewService.getDayViewModel`**
- `dayNumber < 1` → 400 (`INVALID_DAY_PARAM`)
- trip 미존재 → 404
- 카드 카테고리 분배:
  - `category='transport'` AND `flight_number` 존재 AND `dayNumber=1` → `start_time_card`
  - `category='transport'` AND `flight_number` 존재 AND `dayNumber=MAX(day)` → `end_time_card`
  - 그 외 (숙소, 음식, 중간 day 항공편, flight_number 없는 transport 등) → `cards[]`
- 정렬: `cards[]` 는 `createdAt ASC` (SCR-03/04 와 통일)

**Controller — 신규 `DayController`**
- `GET /trips/{tripId}/days/{dayNumber}`

**Repository — `PlaceCardRepository` 확장**
- `findAllByTripIdAndDay(tripId, day)` (메서드 명 derived query)
- `findMaxDayByTripId(tripId)` (`COALESCE(MAX(day), 0)`)

**예외 — 신규 `InvalidDayParamException`**
- `GlobalExceptionHandler` 매핑: 400 / `INVALID_DAY_PARAM`

**테스트 — `DayViewServiceTest` (10개)**
- 잘못된 day (0, 음수)
- trip 미존재 (404)
- 빈 day (모든 슬롯 null + 빈 cards)
- day 1 도착 항공편 → start
- 마지막 day 출발 항공편 → end
- 단일 day 여행 (day=1=MAX) — 항공편 2개 → start + end
- 중간 day 항공편 → cards[] 잔류
- transport 인데 flight_number 없는 카드 → cards[] (지하철/버스 등)
- `createdAt` ASC 정렬

## 🔗 관련 이슈

closes #100

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 🧪 테스트

### 단위 테스트
`DayViewServiceTest` — 10개 (전부 신규)

### 실행
```bash
cd apps/backend && ./gradlew test
```

### 수동 확인 (옵션)
브랜치 체크아웃 + `bootRun` 후:
```bash
curl http://localhost:8080/v1/trips/{tripId}/days/1 | jq
curl http://localhost:8080/v1/trips/{tripId}/days/0 | jq   # 400 INVALID_DAY_PARAM
curl http://localhost:8080/v1/trips/{nonExistentId}/days/1 | jq  # 404 TRIP_NOT_FOUND
```

## 👀 리뷰어에게

리뷰 요청 사항을 4개 항목으로 정리했습니다. 각 항목 하단에 **확인이 필요한 질문** 을 명시했으니 짚어주시면 감사하겠습니다.

### 1. 400 에러 처리 — 스펙과 다르게 구현했습니다

스펙 (`api명세서.md` 747~761줄) 은 `GET /days/{day_number}` 의 400 응답으로 `CONFIRM_EMPTY_DAYS` / `CONFIRM_ALL_EXCLUDED` 를 명시합니다.

본 PR 은 이를 따르지 않고 `INVALID_DAY_PARAM` (day < 1) 만 차단합니다. 이유:

- read-only 엔드포인트가 빈 데이터에 400 을 던지면 SCR-04 첫 진입 시 (사용자가 카드 미배치) 매번 에러가 떠 UX 가 깨짐
- 스펙의 에러 코드 접두사가 `CONFIRM_*` → 원래 의도가 verify/confirm 의 BE 방어용으로 보임 (read endpoint 에 복붙된 가능성)

→ **확인:** 스펙대로 `CONFIRM_*` 검증을 days GET 에도 추가해야 할까요? 아니면 스펙 자체를 days GET 에서는 빈 응답을 허용하도록 수정해야 할까요?

### 2. 항공편 식별 정책 — `category='transport'` + `flight_number` 보유

| 조건 | 분배 |
|---|---|
| `category='transport'` + `flight_number != null` + `dayNumber == 1` | `start_time_card` (도착 항공편) |
| `category='transport'` + `flight_number != null` + `dayNumber == MAX(day)` | `end_time_card` (출발 항공편) |
| 그 외 transport (지하철 / 버스 / 중간 day 항공편) | `cards[]` |

스펙은 "도착 항공편" / "출발 항공편" 만 명시하고 식별 기준이 없어 위와 같이 결정했습니다.

→ **확인:** 이 식별 기준 OK 신가요? 만약 사용자가 항공편 카드를 day=1 이 아닌 곳에 배치한 경우 (예: day=2 의 환승편) → 현재는 `cards[]` 로 떨어집니다. 이게 의도와 맞나요?

### 3. 단일 day 여행 케이스 (`dayNumber == 1 == MAX(day)`)

day 1 == MAX day 인 시나리오에서 항공편 2개 카드가 있으면:
- 첫 번째 (`createdAt` 빠른 카드) → `start_time_card`
- 두 번째 → `end_time_card`

**한계:** 시간 메타가 부족해서 "도착이 진짜 먼저인가?" 는 보장 못 합니다. createdAt 으로 추정.

→ **확인:** 이 정도 추정으로 OK 신가요? 아니면 `time_constraint` 텍스트 파싱 같은 추가 작업이 필요할까요?

### 4. 컨트롤러 분리 — `GroupController` 가 아닌 `DayController` 신설

스펙은 `tags: [groups]` 로 묶어 관리하지만, 본 PR 은 별도 `DayController` 를 만들었습니다. 이유:
- URL 리소스 경로가 `/groups` 와 다름 (`/days/{dayNumber}`)
- 향후 추가 (PATCH `/days/{dayNumber}`, etc.) 에서 분리가 유리

→ **확인:** 컨트롤러 분리 OK 신가요? 아니면 `GroupController` 안으로 흡수할까요?

## 📸 스크린샷

> 없음 (BE 전용)
