### PR TITLE
chore(be): add GET /v1/health endpoint

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/controller/HealthController.java
+++ b/apps/backend/src/main/java/com/tripkey/controller/HealthController.java
@@ -1,0 +1,17 @@
+package com.tripkey.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    public record HealthResponse(String status) {
+    }
+
+    @GetMapping("/health")
+    public ResponseEntity<HealthResponse> health() {
+        return ResponseEntity.ok(new HealthResponse("up"));
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/controller/HealthControllerTest.java
+++ b/apps/backend/src/test/java/com/tripkey/controller/HealthControllerTest.java
@@ -1,0 +1,21 @@
+package com.tripkey.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HealthControllerTest {
+
+    private final HealthController controller = new HealthController();
+
+    @Test
+    void healthReturns200WithStatusUp() {
+        ResponseEntity<HealthController.HealthResponse> response = controller.health();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().status()).isEqualTo("up");
+    }
+}


### PR DESCRIPTION
 ## 📝 작업 내용
                                                                                                  
   + `{"status": "up"}`.                                                                          
                                                                                                  
  - 신규 `HealthController` (record 기반 응답)                                                    
  - Spring Boot Actuator 의 `"UP"` 컨벤션 반영 (소문자로 표준화)                                  
  - 단위 테스트 1개                                             
                                                                                                  
  ## 🔗 관련 이슈                                                                                 
                                                                                                  
  closes #103                                                               
                                                                                                  
  ## 🗂️  변경 범위
                                                                                                  
  - [ ] Frontend (apps/frontend)
  - [x] Backend (apps/backend)                                                                    
  - [ ] AI Engine (apps/ai-engine)
  - [ ] 공통 / 설정 / 문서                                                                        
                                                                                                  
  ## ✅ 작업 체크리스트                                                                           
                                                                                                  
  - [x] 로컬에서 정상 동작 확인했나요?                                                            
  - [x] 기존 기능이 깨지지 않았나요?                                                              
  - [x] 하드코딩된 값이나 임시 주석은 없나요?
  - [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?                                              
                                                                                                  
  ## 🧪 테스트                                                                                    
                                                                                                  
  ```bash                                                                                         
  cd apps/backend && ./gradlew test --tests com.tripkey.controller.HealthControllerTest
                                                                                       
  수동 확인:                                                                                      
  curl http://localhost:8080/v1/health                                                            
  # → {"status": "up"}                                                                            
                                            