### PR TITLE
feat: preserve flight datetime and role in parse response

### DIFF
--- a/apps/ai-engine/app/prompts/core_parse.py
+++ b/apps/ai-engine/app/prompts/core_parse.py
@@ -78,6 +78,8 @@ def build_core_parse_prompt(req: ParseRequest) -> str:
 - If recommendation cards are generated, classification must be open_question and question_text/options must stay null.
 - Accommodation cards must be generated from the structured accommodation inputs above, not inferred from dump_text.
 - Flight cards must be generated from the structured flight inputs above, not inferred from dump_text.
+- Set flight_role to null unless it comes from the structured departure_flight or return_flight input.
+- For other transport flight cards mentioned in dump_text, preserve flight_datetime only when a clear datetime is explicitly present.
 - For each accommodation input, create exactly one accommodation card.
 - For each flight input provided, create exactly one transport card.
 
@@ -184,7 +186,9 @@ def build_core_parse_prompt(req: ParseRequest) -> str:
       "search_alias": "string | null",
       "check_in": "string | null",
       "check_out": "string | null",
-      "flight_number": "string | null"
+      "flight_number": "string | null",
+      "flight_datetime": "string | null",
+      "flight_role": "outbound" | "inbound" | null
     }}
   ],
   "alert_cards": [

--- a/apps/ai-engine/app/schemas/parse.py
+++ b/apps/ai-engine/app/schemas/parse.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from datetime import datetime
 from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -111,6 +112,15 @@ class CardResponse(BaseModel):
     flight_number: Optional[str] = None
     flight_datetime: Optional[str] = None
     flight_role: Optional[FlightRole] = None
+
+    @model_validator(mode="after")
+    def validate_flight_datetime(self) -> "CardResponse":
+        if self.flight_datetime:
+            try:
+                datetime.fromisoformat(self.flight_datetime.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError("flight_datetime must be an ISO datetime string.") from exc
+        return self
 
     @model_validator(mode="after")
     def validate_question_fields(self) -> "CardResponse":

--- a/apps/ai-engine/app/schemas/parse.py
+++ b/apps/ai-engine/app/schemas/parse.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from datetime import datetime
 from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -112,15 +111,6 @@ class CardResponse(BaseModel):
     flight_number: Optional[str] = None
     flight_datetime: Optional[str] = None
     flight_role: Optional[FlightRole] = None
-
-    @model_validator(mode="after")
-    def validate_flight_datetime(self) -> "CardResponse":
-        if self.flight_datetime:
-            try:
-                datetime.fromisoformat(self.flight_datetime.replace("Z", "+00:00"))
-            except ValueError as exc:
-                raise ValueError("flight_datetime must be an ISO datetime string.") from exc
-        return self
 
     @model_validator(mode="after")
     def validate_question_fields(self) -> "CardResponse":

--- a/apps/ai-engine/app/schemas/parse.py
+++ b/apps/ai-engine/app/schemas/parse.py
@@ -29,6 +29,11 @@ class PlacementStatus(str, Enum):
     BLOCKED = "blocked"
 
 
+class FlightRole(str, Enum):
+    OUTBOUND = "outbound"
+    INBOUND = "inbound"
+
+
 class AlertCategory(str, Enum):
     PRACTICAL = "practical"
     INSIGHT = "insight"
@@ -104,6 +109,8 @@ class CardResponse(BaseModel):
     check_in: Optional[str] = None
     check_out: Optional[str] = None
     flight_number: Optional[str] = None
+    flight_datetime: Optional[str] = None
+    flight_role: Optional[FlightRole] = None
 
     @model_validator(mode="after")
     def validate_question_fields(self) -> "CardResponse":

--- a/apps/ai-engine/app/services/core_parse.py
+++ b/apps/ai-engine/app/services/core_parse.py
@@ -24,6 +24,7 @@ from app.schemas.parse import (
     Classification,
     Coordinates,
     FlightInput,
+    FlightRole,
     ParseRequest,
     PlacementStatus,
 )
@@ -261,20 +262,33 @@ def _matches_flight_card(card: ParsedCard, flight: FlightInput) -> bool:
 
 
 def _apply_flight_constraints(cards: list[ParsedCard], req: ParseRequest) -> list[ParsedCard]:
-    flights = [flight for flight in [req.departure_flight, req.return_flight] if flight and flight.datetime]
+    flights = [
+        (req.departure_flight, FlightRole.OUTBOUND),
+        (req.return_flight, FlightRole.INBOUND),
+    ]
+    flights = [(flight, role) for flight, role in flights if flight and flight.datetime]
     if not flights:
         return cards
 
     updated_cards: list[ParsedCard] = []
     for card in cards:
         updated = card
-        if card.category == Category.TRANSPORT and not card.time_constraint:
-            for flight in flights:
+        if card.category == Category.TRANSPORT:
+            matched = False
+            for flight, role in flights:
                 if _matches_flight_card(card, flight):
+                    matched = True
+                    updates = {
+                        "flight_datetime": flight.datetime,
+                        "flight_role": role,
+                    }
                     formatted = _format_flight_time_constraint(flight.datetime or "")
-                    if formatted:
-                        updated = card.model_copy(update={"time_constraint": formatted})
+                    if formatted and not card.time_constraint:
+                        updates["time_constraint"] = formatted
+                    updated = card.model_copy(update=updates)
                     break
+            if not matched and card.flight_role:
+                updated = card.model_copy(update={"flight_role": None})
         updated_cards.append(updated)
     return updated_cards
 

--- a/apps/ai-engine/app/services/core_parse.py
+++ b/apps/ai-engine/app/services/core_parse.py
@@ -248,6 +248,16 @@ def _format_flight_time_constraint(value: str) -> str | None:
     return f"{parsed.strftime('%H:%M')} 출발"
 
 
+def _normalize_flight_datetime(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return value
+
+
 def _matches_flight_card(card: ParsedCard, flight: FlightInput) -> bool:
     if card.flight_number and flight.flight_number:
         return card.flight_number.strip().lower() == flight.flight_number.strip().lower()
@@ -267,28 +277,30 @@ def _apply_flight_constraints(cards: list[ParsedCard], req: ParseRequest) -> lis
         (req.return_flight, FlightRole.INBOUND),
     ]
     flights = [(flight, role) for flight, role in flights if flight and flight.datetime]
-    if not flights:
-        return cards
 
     updated_cards: list[ParsedCard] = []
     for card in cards:
         updated = card
         if card.category == Category.TRANSPORT:
+            if card.flight_datetime:
+                updated = card.model_copy(
+                    update={"flight_datetime": _normalize_flight_datetime(card.flight_datetime)}
+                )
             matched = False
             for flight, role in flights:
-                if _matches_flight_card(card, flight):
+                if _matches_flight_card(updated, flight):
                     matched = True
                     updates = {
-                        "flight_datetime": flight.datetime,
+                        "flight_datetime": _normalize_flight_datetime(flight.datetime),
                         "flight_role": role,
                     }
                     formatted = _format_flight_time_constraint(flight.datetime or "")
-                    if formatted and not card.time_constraint:
+                    if formatted and not updated.time_constraint:
                         updates["time_constraint"] = formatted
-                    updated = card.model_copy(update=updates)
+                    updated = updated.model_copy(update=updates)
                     break
-            if not matched and card.flight_role:
-                updated = card.model_copy(update={"flight_role": None})
+            if not matched and updated.flight_role:
+                updated = updated.model_copy(update={"flight_role": None})
         updated_cards.append(updated)
     return updated_cards
 

--- a/apps/ai-engine/tests/test_parse_service.py
+++ b/apps/ai-engine/tests/test_parse_service.py
@@ -292,6 +292,20 @@ def test_apply_flight_constraints_leaves_middle_flight_without_role_when_unmatch
     assert updated[0].flight_role is None
 
 
+def test_card_response_rejects_non_iso_flight_datetime() -> None:
+    with pytest.raises(ValueError, match="flight_datetime must be an ISO datetime string"):
+        ParsedCard(
+            name="KE703",
+            category=Category.TRANSPORT,
+            classification=Classification.CONFIRMED,
+            placement_status=PlacementStatus.READY_PARTIAL,
+            is_ai_generated=False,
+            allow_duplicate=True,
+            flight_number="KE703",
+            flight_datetime="7월 1일 오전 9시",
+        )
+
+
 def test_ensure_card_name_infers_from_question_text() -> None:
     raw = {
         "name": None,

--- a/apps/ai-engine/tests/test_parse_service.py
+++ b/apps/ai-engine/tests/test_parse_service.py
@@ -6,6 +6,7 @@ from app.schemas.parse import (
     Category,
     Classification,
     FlightInput,
+    FlightRole,
     ParseRequest,
     PlacementStatus,
 )
@@ -179,6 +180,116 @@ def test_apply_flight_constraints_sets_time_constraint() -> None:
     updated = core_parse._apply_flight_constraints(cards, req)
 
     assert updated[0].time_constraint == "09:00 출발"
+    assert updated[0].flight_datetime == "2026-07-01T09:00:00+09:00"
+    assert updated[0].flight_role == FlightRole.OUTBOUND
+
+
+def test_apply_flight_constraints_sets_inbound_role_for_return_flight() -> None:
+    cards = [
+        ParsedCard(
+            name="NRT → ICN",
+            category=Category.TRANSPORT,
+            classification=Classification.CONFIRMED,
+            placement_status=PlacementStatus.READY_PARTIAL,
+            is_ai_generated=False,
+            allow_duplicate=True,
+            flight_number="KE704",
+        )
+    ]
+    req = ParseRequest(
+        trip_id="trip-1",
+        dump_text="도쿄 여행",
+        destinations=["도쿄"],
+        travel_days=3,
+        companion_count=2,
+        return_flight=FlightInput(
+            departure_airport="NRT",
+            arrival_airport="ICN",
+            flight_number="KE704",
+            datetime="2026-07-03T18:30:00+09:00",
+        ),
+    )
+
+    updated = core_parse._apply_flight_constraints(cards, req)
+
+    assert updated[0].time_constraint == "18:30 출발"
+    assert updated[0].flight_datetime == "2026-07-03T18:30:00+09:00"
+    assert updated[0].flight_role == FlightRole.INBOUND
+
+
+def test_apply_flight_constraints_preserves_existing_time_constraint() -> None:
+    cards = [
+        ParsedCard(
+            name="ICN → NRT",
+            category=Category.TRANSPORT,
+            classification=Classification.CONFIRMED,
+            placement_status=PlacementStatus.READY_PARTIAL,
+            is_ai_generated=False,
+            allow_duplicate=True,
+            time_constraint="오전 출발",
+            flight_number="KE703",
+        )
+    ]
+    req = ParseRequest(
+        trip_id="trip-1",
+        dump_text="도쿄 여행",
+        destinations=["도쿄"],
+        travel_days=3,
+        companion_count=2,
+        departure_flight=FlightInput(
+            departure_airport="ICN",
+            arrival_airport="NRT",
+            flight_number="KE703",
+            datetime="2026-07-01T09:00:00+09:00",
+        ),
+    )
+
+    updated = core_parse._apply_flight_constraints(cards, req)
+
+    assert updated[0].time_constraint == "오전 출발"
+    assert updated[0].flight_datetime == "2026-07-01T09:00:00+09:00"
+    assert updated[0].flight_role == FlightRole.OUTBOUND
+
+
+def test_apply_flight_constraints_leaves_middle_flight_without_role_when_unmatched() -> None:
+    cards = [
+        ParsedCard(
+            name="ITM → CTS",
+            category=Category.TRANSPORT,
+            classification=Classification.CONFIRMED,
+            placement_status=PlacementStatus.READY_PARTIAL,
+            is_ai_generated=False,
+            allow_duplicate=True,
+            flight_number="JL200",
+            flight_datetime="2026-07-03T14:20:00+09:00",
+            flight_role=FlightRole.OUTBOUND,
+        )
+    ]
+    req = ParseRequest(
+        trip_id="trip-1",
+        dump_text="도쿄와 삿포로 여행",
+        destinations=["도쿄", "삿포로"],
+        travel_days=5,
+        companion_count=2,
+        departure_flight=FlightInput(
+            departure_airport="ICN",
+            arrival_airport="NRT",
+            flight_number="KE703",
+            datetime="2026-07-01T09:00:00+09:00",
+        ),
+        return_flight=FlightInput(
+            departure_airport="CTS",
+            arrival_airport="ICN",
+            flight_number="KE766",
+            datetime="2026-07-05T20:00:00+09:00",
+        ),
+    )
+
+    updated = core_parse._apply_flight_constraints(cards, req)
+
+    assert updated[0].time_constraint is None
+    assert updated[0].flight_datetime == "2026-07-03T14:20:00+09:00"
+    assert updated[0].flight_role is None
 
 
 def test_ensure_card_name_infers_from_question_text() -> None:

--- a/apps/ai-engine/tests/test_parse_service.py
+++ b/apps/ai-engine/tests/test_parse_service.py
@@ -292,8 +292,8 @@ def test_apply_flight_constraints_leaves_middle_flight_without_role_when_unmatch
     assert updated[0].flight_role is None
 
 
-def test_card_response_rejects_non_iso_flight_datetime() -> None:
-    with pytest.raises(ValueError, match="flight_datetime must be an ISO datetime string"):
+def test_apply_flight_constraints_nulls_non_iso_flight_datetime() -> None:
+    cards = [
         ParsedCard(
             name="KE703",
             category=Category.TRANSPORT,
@@ -304,6 +304,12 @@ def test_card_response_rejects_non_iso_flight_datetime() -> None:
             flight_number="KE703",
             flight_datetime="7월 1일 오전 9시",
         )
+    ]
+    req = _request()
+
+    updated = core_parse._apply_flight_constraints(cards, req)
+
+    assert updated[0].flight_datetime is None
 
 
 def test_ensure_card_name_infers_from_question_text() -> None:


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- AI 엔진 항공편 카드 응답에 `flight_datetime` / `flight_role` 메타를 추가하고, 출국/귀국 항공편과 중간 항공편을 구분할 수 있도록 후처리 로직을 보강했습니다.

## 🔗 관련 이슈

closes #105 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

### 항공편 메타 정책

- `departure_flight`에서 생성/매칭된 항공편 카드는 `flight_role = outbound`로 응답합니다.
- `return_flight`에서 생성/매칭된 항공편 카드는 `flight_role = inbound`로 응답합니다.
- `datetime` 원본 값은 `flight_datetime`으로 보존합니다.
- 기존 `time_constraint`는 표시용 보조 텍스트로 유지합니다.
- 중간 항공편/환승편처럼 dump text에서 추출된 일반 transport 항공편은 `flight_role = null`로 유지합니다.
- 단, dump text에서 시간이 명확히 추출된 경우 중간 항공편의 `flight_datetime`은 보존합니다.
- LLM이 이미 `time_constraint`를 채운 경우 해당 값을 보존하고, 비어 있는 경우에만 `flight_datetime` 기반 `"HH:mm 출발"` 보조 텍스트를 생성합니다.
- `flight_datetime`은 ISO datetime 문자열만 허용합니다.

### 실제 응답 확인

아래 dump로 실제 LLM 호출을 확인했습니다.

```text
7월 1일부터 5일까지 일본 여행.
첫날은 KE703으로 09:00에 인천에서 나리타로 가고, 도쿄에서 신주쿠와 시부야를 둘러볼 예정이야.
3일차에는 JL200 항공편으로 14:20에 오사카 이타미 공항에서 삿포로 신치토세 공항으로 이동해.
마지막 날은 KE766으로 20:00에 삿포로 신치토세에서 인천으로 돌아와.
삿포로에서는 오도리 공원과 스스키노를 가고 싶어.
```

핵심 응답:

```json
[
  {
    "name": "KE703",
    "category": "transport",
    "flight_number": "KE703",
    "flight_datetime": "2026-07-01T09:00:00+09:00",
    "flight_role": "outbound",
    "time_constraint": "09:00 출발"
  },
  {
    "name": "JL200",
    "category": "transport",
    "flight_number": "JL200",
    "flight_datetime": "2026-07-03T14:20:00+09:00",
    "flight_role": null,
    "time_constraint": null
  },
  {
    "name": "KE766",
    "category": "transport",
    "flight_number": "KE766",
    "flight_datetime": "2026-07-05T20:00:00+09:00",
    "flight_role": "inbound",
    "time_constraint": "20:00 출발"
  }
]
```

추가로, 주요 목적지는 도쿄/삿포로인데 중간 항공편에 오사카 이타미가 포함된 점에 대해 `alert_cards`도 생성되었습니다.

```json
{
  "id": "alert_001",
  "type": "discrepancy",
  "category": "practical",
  "scope": "trip",
  "message": "여행 주요 목적지는 도쿄와 삿포로로 파악되나, 3일차 이동 항공편에서 오사카 이타미 공항이 언급되었습니다. 오사카 방문 일정이 추가될 예정인가요?"
}
```

### 후속 작업 안내

현재 AI Engine 응답에는 `flight_datetime`, `flight_role`이 포함되지만, BE DTO / Entity / DB schema가 아직 해당 필드를 받지 않아 Supabase에는 저장되지 않습니다.

이는 이번 AI PR 범위에서는 정상이며, 후속 BE PR에서 아래 작업이 필요합니다.

- `AiPlaceCardDto`에 `flightDatetime`, `flightRole` 추가
- `PlaceCard` Entity에 `flightDatetime`, `flightRole` 추가
- Supabase `place_cards` schema에 컬럼 추가
- `CardDto` 응답 필드 추가
- Day View 슬롯 매핑을 `flight_role` 기준으로 변경
  - `outbound` → `start_time_card`
  - `inbound` → `end_time_card`
  - `null` → 일반 `cards[]`

### 검증

```bash
apps/ai-engine/.venv/bin/python -m pytest apps/ai-engine/tests
```

결과:

```text
15 passed
```

## 📸 스크린샷

없음