### PR TITLE
Feat/Non-blocking Enrichment 실행 경계 / API 계약 / BE 자동 트리거 1차 구현 

### DIFF
--- a/apps/ai-engine/app/api/non_blocking_enrichment.py
+++ b/apps/ai-engine/app/api/non_blocking_enrichment.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, status
+
+from app.schemas.non_blocking_enrichment import NonBlockingEnrichmentRequest, NonBlockingEnrichmentResponse
+from app.services.non_blocking_enrichment import enrich_card_non_blocking
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/internal/ai/enrich", tags=["enrichment"])
+
+
+@router.post(
+    "/non-blocking/card",
+    response_model=NonBlockingEnrichmentResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Card-level non-blocking enrichment",
+)
+async def non_blocking_card_endpoint(req: NonBlockingEnrichmentRequest) -> NonBlockingEnrichmentResponse:
+    try:
+        return await enrich_card_non_blocking(req)
+    except Exception as exc:
+        logger.exception("Non-blocking enrichment failed | trip_id=%s", req.trip_id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Non-blocking enrichment failed.",
+        ) from exc

--- a/apps/ai-engine/app/main.py
+++ b/apps/ai-engine/app/main.py
@@ -5,6 +5,7 @@ import logging
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
+from app.api.non_blocking_enrichment import router as non_blocking_enrichment_router
 from app.api.parse import router as parse_router
 
 load_dotenv()
@@ -13,6 +14,7 @@ logging.basicConfig(level=logging.INFO)
 
 app = FastAPI(title="TripKey AI Engine")
 app.include_router(parse_router)
+app.include_router(non_blocking_enrichment_router)
 
 
 @app.get("/health")

--- a/apps/ai-engine/app/schemas/non_blocking_enrichment.py
+++ b/apps/ai-engine/app/schemas/non_blocking_enrichment.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.parse import AlertCardResponse, Category, Classification, Coordinates, FlightRole, PlacementStatus
+
+
+class EnrichmentCardSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    instance_id: Optional[str] = None
+    name: str
+    category: Category
+    classification: Classification
+    placement_status: PlacementStatus
+
+    estimated_duration_min: Optional[int] = None
+    place_id: Optional[str] = None
+    coordinates: Optional[Coordinates] = None
+    location: Optional[str] = None
+    address: Optional[str] = None
+    time_constraint: Optional[str] = None
+    user_context: Optional[str] = None
+    tips: Optional[str] = None
+    tags: Optional[list[str]] = None
+    check_in: Optional[str] = None
+    check_out: Optional[str] = None
+    flight_number: Optional[str] = None
+    flight_datetime: Optional[str] = None
+    flight_role: Optional[FlightRole] = None
+
+
+class NonBlockingEnrichmentRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    trip_id: str
+    destinations: list[str] = Field(default_factory=list)
+    travel_days: Optional[int] = None
+    companion_count: Optional[int] = None
+    card: EnrichmentCardSnapshot
+
+
+class EnrichmentPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    value: Any
+    apply_mode: Literal["auto", "suggestion"]
+    confidence: Literal["high", "medium", "low"]
+    reason: str
+
+
+class NonBlockingEnrichmentResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    card_instance_id: Optional[str] = None
+    patches: list[EnrichmentPatch] = Field(default_factory=list)
+    alert_cards: list[AlertCardResponse] = Field(default_factory=list)

--- a/apps/ai-engine/app/services/non_blocking_enrichment.py
+++ b/apps/ai-engine/app/services/non_blocking_enrichment.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from app.schemas.non_blocking_enrichment import (
+    EnrichmentPatch,
+    NonBlockingEnrichmentRequest,
+    NonBlockingEnrichmentResponse,
+)
+from app.schemas.parse import AlertCardResponse, AlertCategory, Category, FlightRole
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _insight_alert(alert_type: str, message: str) -> AlertCardResponse:
+    return AlertCardResponse(
+        id=str(uuid.uuid4()),
+        type=alert_type,
+        category=AlertCategory.INSIGHT,
+        scope="trip",
+        day=None,
+        message=message,
+        related_instance_ids=None,
+    )
+
+
+def _build_transport_alerts(req: NonBlockingEnrichmentRequest) -> list[AlertCardResponse]:
+    card = req.card
+    if card.category != Category.TRANSPORT:
+        return []
+
+    departure_time = _parse_iso_datetime(card.flight_datetime)
+    if not departure_time:
+        return []
+
+    alerts: list[AlertCardResponse] = []
+    hour = departure_time.hour
+    if card.flight_role == FlightRole.OUTBOUND and hour >= 18:
+        alerts.append(
+            _insight_alert(
+                "late_arrival_notice",
+                f"{card.name} 출발 시간이 저녁이라 첫날 일정은 가볍게 잡는 편이 좋아요.",
+            )
+        )
+    elif card.flight_role == FlightRole.INBOUND and hour < 12:
+        alerts.append(
+            _insight_alert(
+                "early_return_notice",
+                f"{card.name} 출발 시간이 오전이라 마지막 날 이동 시간을 먼저 확보하는 편이 좋아요.",
+            )
+        )
+
+    return alerts
+
+
+def _build_patch_suggestions(req: NonBlockingEnrichmentRequest) -> list[EnrichmentPatch]:
+    card = req.card
+    patches: list[EnrichmentPatch] = []
+
+    if card.category in {Category.PLACE, Category.ACTIVITY, Category.FOOD} and not card.tips:
+        patches.append(
+            EnrichmentPatch(
+                field="tips",
+                value="방문 전 운영시간과 휴무일을 한 번 확인해보세요.",
+                apply_mode="suggestion",
+                confidence="medium",
+                reason="운영시간은 여행 당일 변동될 수 있어 검토용 제안으로만 제공합니다.",
+            )
+        )
+
+    return patches
+
+
+async def enrich_card_non_blocking(req: NonBlockingEnrichmentRequest) -> NonBlockingEnrichmentResponse:
+    return NonBlockingEnrichmentResponse(
+        card_instance_id=req.card.instance_id,
+        patches=_build_patch_suggestions(req),
+        alert_cards=_build_transport_alerts(req),
+    )

--- a/apps/ai-engine/tests/test_non_blocking_enrichment.py
+++ b/apps/ai-engine/tests/test_non_blocking_enrichment.py
@@ -1,0 +1,88 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.schemas.non_blocking_enrichment import EnrichmentCardSnapshot, NonBlockingEnrichmentRequest
+from app.schemas.parse import Category, Classification, FlightRole, PlacementStatus
+from app.services.non_blocking_enrichment import enrich_card_non_blocking
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_enrichment_generates_trip_scope_insight_alert() -> None:
+    req = NonBlockingEnrichmentRequest(
+        trip_id="trip-1",
+        destinations=["도쿄"],
+        travel_days=3,
+        companion_count=2,
+        card=EnrichmentCardSnapshot(
+            instance_id="card-1",
+            name="ICN → NRT",
+            category=Category.TRANSPORT,
+            classification=Classification.CONFIRMED,
+            placement_status=PlacementStatus.READY,
+            flight_datetime="2026-07-01T19:00:00+09:00",
+            flight_role=FlightRole.OUTBOUND,
+        ),
+    )
+
+    result = await enrich_card_non_blocking(req)
+
+    assert result.card_instance_id == "card-1"
+    assert len(result.alert_cards) == 1
+    alert = result.alert_cards[0]
+    assert alert.category.value == "insight"
+    assert alert.scope == "trip"
+    assert alert.day is None
+    assert alert.related_instance_ids is None
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_enrichment_keeps_name_change_as_suggestion_only() -> None:
+    req = NonBlockingEnrichmentRequest(
+        trip_id="trip-1",
+        destinations=["오사카"],
+        card=EnrichmentCardSnapshot(
+            instance_id="card-1",
+            name="도톤보리",
+            category=Category.PLACE,
+            classification=Classification.CONFIRMED,
+            placement_status=PlacementStatus.READY_PARTIAL,
+        ),
+    )
+
+    result = await enrich_card_non_blocking(req)
+
+    assert result.alert_cards == []
+    assert result.patches[0].field == "tips"
+    assert result.patches[0].apply_mode == "suggestion"
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_enrichment_endpoint() -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/internal/ai/enrich/non-blocking/card",
+            json={
+                "trip_id": "trip-1",
+                "destinations": ["도쿄"],
+                "travel_days": 3,
+                "companion_count": 2,
+                "card": {
+                    "instance_id": "card-1",
+                    "name": "NRT → ICN",
+                    "category": "transport",
+                    "classification": "confirmed",
+                    "placement_status": "ready",
+                    "flight_datetime": "2026-07-03T09:00:00+09:00",
+                    "flight_role": "inbound",
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["card_instance_id"] == "card-1"
+    assert body["alert_cards"][0]["category"] == "insight"
+    assert body["alert_cards"][0]["scope"] == "trip"
+    assert body["alert_cards"][0]["day"] is None
+    assert body["alert_cards"][0]["related_instance_ids"] is None

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
@@ -28,6 +28,7 @@ public class DumpAsyncProcessor {
     private final TripDestinationRepository tripDestinationRepository;
     private final PlaceCardRepository placeCardRepository;
     private final AiEngineClient aiEngineClient;
+    private final NonBlockingEnrichmentProcessor nonBlockingEnrichmentProcessor;
 
     @Async("dumpTaskExecutor")
     @Transactional
@@ -78,7 +79,7 @@ public class DumpAsyncProcessor {
                 return;
             }
 
-            placeCardRepository.saveAll(cards);
+            List<PlaceCard> savedCards = placeCardRepository.saveAll(cards);
 
             if (response.alertCards() != null && !response.alertCards().isEmpty()) {
                 log.info("Received {} alert cards for trip={} (parse_version={})",
@@ -88,10 +89,19 @@ public class DumpAsyncProcessor {
 
             job.complete(response.contextSummary());
             dumpJobRepository.save(job);
+            triggerNonBlockingEnrichment(savedCards, destinations, trip);
         } catch (Exception e) {
             log.error("Failed to parse dump job. jobId={}", jobId, e);
             job.fail("PARSE_FAILED");
             dumpJobRepository.save(job);
+        }
+    }
+
+    private void triggerNonBlockingEnrichment(List<PlaceCard> cards, List<String> destinations, Trip trip) {
+        try {
+            nonBlockingEnrichmentProcessor.trigger(cards, destinations, trip);
+        } catch (Exception e) {
+            log.warn("Failed to submit non-blocking enrichment. trip={}", trip.getTripId(), e);
         }
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
@@ -1,0 +1,45 @@
+package com.tripkey.domain.dump;
+
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.trip.Trip;
+import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
+import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NonBlockingEnrichmentProcessor {
+
+    private final AiEngineClient aiEngineClient;
+
+    @Async("dumpTaskExecutor")
+    public void trigger(List<PlaceCard> cards, List<String> destinations, Trip trip) {
+        for (PlaceCard card : cards) {
+            try {
+                AiNonBlockingEnrichmentRequest request = AiNonBlockingEnrichmentRequest.from(
+                        card,
+                        destinations,
+                        trip.getTravelDays(),
+                        trip.getCompanionCount()
+                );
+                AiNonBlockingEnrichmentResponse response = aiEngineClient.enrichCardNonBlocking(request);
+                int alertCount = response.alertCards() == null ? 0 : response.alertCards().size();
+                int patchCount = response.patches() == null ? 0 : response.patches().size();
+                if (alertCount > 0 || patchCount > 0) {
+                    log.info("Non-blocking enrichment completed. trip={} card={} alerts={} patches={}",
+                            card.getTripId(), card.getInstanceId(), alertCount, patchCount);
+                }
+            } catch (Exception e) {
+                log.warn("Non-blocking enrichment failed. trip={} card={}",
+                        card.getTripId(), card.getInstanceId(), e);
+            }
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
@@ -2,6 +2,8 @@ package com.tripkey.infra.aiengine;
 
 import com.tripkey.infra.aiengine.dto.AiParseRequest;
 import com.tripkey.infra.aiengine.dto.AiParseResponse;
+import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
+import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -30,6 +32,25 @@ public class AiEngineClient {
             return response;
         } catch (WebClientResponseException | WebClientRequestException e) {
             throw new IllegalStateException("Failed to call ai-engine parse endpoint", e);
+        }
+    }
+
+    public AiNonBlockingEnrichmentResponse enrichCardNonBlocking(AiNonBlockingEnrichmentRequest request) {
+        try {
+            AiNonBlockingEnrichmentResponse response = aiEngineWebClient.post()
+                    .uri("/internal/ai/enrich/non-blocking/card")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(AiNonBlockingEnrichmentResponse.class)
+                    .block();
+
+            if (response == null) {
+                throw new IllegalStateException("ai-engine returned an empty enrichment response body");
+            }
+
+            return response;
+        } catch (WebClientResponseException | WebClientRequestException e) {
+            throw new IllegalStateException("Failed to call ai-engine non-blocking enrichment endpoint", e);
         }
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiNonBlockingEnrichmentRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiNonBlockingEnrichmentRequest.java
@@ -1,0 +1,119 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tripkey.domain.place.PlaceCard;
+
+import java.util.List;
+import java.util.UUID;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AiNonBlockingEnrichmentRequest(
+        @JsonProperty("trip_id")
+        UUID tripId,
+
+        List<String> destinations,
+
+        @JsonProperty("travel_days")
+        Short travelDays,
+
+        @JsonProperty("companion_count")
+        Short companionCount,
+
+        CardSnapshot card
+) {
+
+    public static AiNonBlockingEnrichmentRequest from(
+            PlaceCard card,
+            List<String> destinations,
+            Short travelDays,
+            Short companionCount
+    ) {
+        return new AiNonBlockingEnrichmentRequest(
+                card.getTripId(),
+                destinations,
+                travelDays,
+                companionCount,
+                CardSnapshot.from(card)
+        );
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record CardSnapshot(
+            @JsonProperty("instance_id")
+            UUID instanceId,
+
+            String name,
+
+            String category,
+
+            String classification,
+
+            @JsonProperty("placement_status")
+            String placementStatus,
+
+            @JsonProperty("estimated_duration_min")
+            Short estimatedDurationMin,
+
+            @JsonProperty("place_id")
+            String placeId,
+
+            Coordinates coordinates,
+
+            String location,
+
+            String address,
+
+            @JsonProperty("time_constraint")
+            String timeConstraint,
+
+            @JsonProperty("user_context")
+            String userContext,
+
+            String tips,
+
+            List<String> tags,
+
+            @JsonProperty("check_in")
+            String checkIn,
+
+            @JsonProperty("check_out")
+            String checkOut,
+
+            // TODO[#flight-fields]: Add flight_datetime and flight_role after the BE flight schema/DTO change lands.
+            @JsonProperty("flight_number")
+            String flightNumber
+    ) {
+        public static CardSnapshot from(PlaceCard card) {
+            Coordinates coordinates = (card.getLat() != null && card.getLng() != null)
+                    ? new Coordinates(card.getLat(), card.getLng())
+                    : null;
+
+            return new CardSnapshot(
+                    card.getInstanceId(),
+                    card.getName(),
+                    card.getCategory(),
+                    card.getClassification(),
+                    card.getPlacementStatus(),
+                    card.getEstimatedDurationMin(),
+                    card.getPlaceId(),
+                    coordinates,
+                    card.getLocation(),
+                    card.getAddress(),
+                    card.getTimeConstraint(),
+                    card.getUserContext(),
+                    card.getTips(),
+                    card.getTags(),
+                    card.getCheckIn(),
+                    card.getCheckOut(),
+                    card.getFlightNumber()
+            );
+        }
+    }
+
+    public record Coordinates(
+            Double lat,
+            Double lng
+    ) {
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiNonBlockingEnrichmentResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiNonBlockingEnrichmentResponse.java
@@ -1,0 +1,27 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.UUID;
+
+public record AiNonBlockingEnrichmentResponse(
+        @JsonProperty("card_instance_id")
+        UUID cardInstanceId,
+
+        List<Patch> patches,
+
+        @JsonProperty("alert_cards")
+        List<AiParseResponse.AlertCard> alertCards
+) {
+
+    public record Patch(
+            String field,
+            Object value,
+            @JsonProperty("apply_mode")
+            String applyMode,
+            String confidence,
+            String reason
+    ) {
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiPlaceCardDto.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiPlaceCardDto.java
@@ -1,9 +1,13 @@
 package com.tripkey.infra.aiengine.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+// AI Engine may return v3.3 flight fields before the BE flight DTO/entity work lands.
+// Keep unknown fields non-breaking here; the owning BE flight change will map them explicitly.
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record AiPlaceCardDto(
         @JsonProperty("place_id")
         String placeId,

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +41,9 @@ class DumpAsyncProcessorTest {
 
     @Mock
     private AiEngineClient aiEngineClient;
+
+    @Mock
+    private NonBlockingEnrichmentProcessor nonBlockingEnrichmentProcessor;
 
     @InjectMocks
     private DumpAsyncProcessor dumpAsyncProcessor;
@@ -87,15 +91,71 @@ class DumpAsyncProcessorTest {
         when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
         when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(tripId)).thenReturn(List.of(destination));
         when(aiEngineClient.parseDump(any())).thenReturn(response);
+        when(placeCardRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         dumpAsyncProcessor.process(job.getJobId());
 
         verify(placeCardRepository).deleteAllByTripId(tripId);
         verify(placeCardRepository).saveAll(any());
+        verify(nonBlockingEnrichmentProcessor).trigger(any(), any(), any());
 
         assertThat(job.getStatus()).isEqualTo("completed");
         assertThat(job.getStep()).isEqualTo((short) 3);
         assertThat(job.getContextSummary()).isEqualTo("오사카 시내 중심 동선");
+        assertThat(job.getErrorCode()).isNull();
+    }
+
+    @Test
+    void processCompletesWhenNonBlockingEnrichmentSubmissionFails() {
+        UUID tripId = UUID.randomUUID();
+        DumpJob job = DumpJob.create(tripId, "오사카 3박4일 여행입니다.");
+        Trip trip = new Trip((short) 4, (short) 2);
+        TripDestination destination = new TripDestination(trip, "오사카", (short) 0);
+
+        AiPlaceCardDto card = new AiPlaceCardDto(
+                "place-1",
+                "도톤보리",
+                "place",
+                "confirmed",
+                "ready_partial",
+                false,
+                false,
+                (short) 90,
+                null,
+                "오사카 중앙구",
+                null,
+                null,
+                "야간 방문 추천",
+                null,
+                null,
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null
+        );
+
+        AiParseResponse response = new AiParseResponse(
+                List.of(card),
+                "오사카 시내 중심 동선",
+                List.of(),
+                "3.2.0"
+        );
+
+        when(dumpJobRepository.findById(job.getJobId())).thenReturn(Optional.of(job));
+        when(dumpJobRepository.save(any(DumpJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
+        when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(tripId)).thenReturn(List.of(destination));
+        when(aiEngineClient.parseDump(any())).thenReturn(response);
+        when(placeCardRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        doThrow(new IllegalStateException("executor rejected"))
+                .when(nonBlockingEnrichmentProcessor).trigger(any(), any(), any());
+
+        dumpAsyncProcessor.process(job.getJobId());
+
+        verify(nonBlockingEnrichmentProcessor).trigger(any(), any(), any());
+        assertThat(job.getStatus()).isEqualTo("completed");
         assertThat(job.getErrorCode()).isNull();
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
@@ -1,0 +1,63 @@
+package com.tripkey.domain.dump;
+
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.trip.Trip;
+import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NonBlockingEnrichmentProcessorTest {
+
+    @Mock
+    private AiEngineClient aiEngineClient;
+
+    @InjectMocks
+    private NonBlockingEnrichmentProcessor nonBlockingEnrichmentProcessor;
+
+    @Test
+    void triggerSwallowsCardLevelEnrichmentFailure() {
+        PlaceCard card = PlaceCard.createFromAiResponse(
+                UUID.randomUUID(),
+                new AiPlaceCardDto(
+                        null,
+                        "도톤보리",
+                        "place",
+                        "confirmed",
+                        "ready_partial",
+                        false,
+                        false,
+                        (short) 90,
+                        null,
+                        "오사카",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                ),
+                "ai_parse"
+        );
+        Trip trip = new Trip((short) 3, (short) 2);
+        when(aiEngineClient.enrichCardNonBlocking(any())).thenThrow(new IllegalStateException("timeout"));
+
+        assertDoesNotThrow(() -> nonBlockingEnrichmentProcessor.trigger(List.of(card), List.of("오사카"), trip));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

> Core Parse + Blocking Enrichment 완료 후 BE가 카드별 Non-blocking Enrichment를 비동기로 트리거하도록 연결했습니다.

- AI Engine에 카드 단위 Non-blocking Enrichment endpoint 추가
- BE에서 parse 결과 카드 저장 및 job 완료 후 카드별 enrichment 자동 트리거
- Non-blocking 실패가 parse job 실패로 전파되지 않도록 처리
- 현재 MVP에서는 enrichment 결과를 저장하지 않고 로그로만 확인
- BE flight 필드 작업과 충돌하지 않도록 AI parse DTO의 unknown field 방어 처리 추가

## 🔗 관련 이슈

refs #107 
refs #73 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- Non-blocking Enrichment는 현재 저장/merge까지 하지 않고, 실행 경계와 API 계약만 추가했습니다.
- 실제 동작 확인은 BE 로그로 합니다.
  - 예: `Non-blocking enrichment completed. trip=... card=... alerts=0 patches=1`
- `patches`는 자동 적용이 아니라 suggestion 계약입니다.
- `alert_cards`/`patches` persistence, FE 노출, retry/status 관리는 후속 작업으로 분리했습니다.
- BE flight schema/DTO 작업은 다른 작업과 충돌 가능성이 있어 포함하지 않았습니다.
  - 대신 `AiPlaceCardDto`에 `@JsonIgnoreProperties(ignoreUnknown = true)`를 추가해 AI Engine v3.3 flight 필드가 먼저 내려와도 BE가 깨지지 않게 했습니다.

검증:

```bash
cd apps/ai-engine
.venv/bin/python -m pytest tests/test_non_blocking_enrichment.py tests/test_parse_service.py
```

```bash
cd apps/backend
./gradlew test --tests com.tripkey.domain.dump.DumpAsyncProcessorTest --tests com.tripkey.domain.dump.NonBlockingEnrichmentProcessorTest --tests com.tripkey.common.json.JsonNamingStrategyTest
```

Docker dev 환경에서 실제 dump submit 후 non-blocking 로그 확인 완료.

## 📸 스크린샷

UI 변경 없음