### PR TITLE
Fix/109 places destination mismatch

### DIFF
--- a/apps/ai-engine/app/services/core_parse.py
+++ b/apps/ai-engine/app/services/core_parse.py
@@ -51,6 +51,15 @@ PLACES_ELIGIBLE_CATEGORIES = {
     Category.FOOD,
     Category.TRANSPORT,
 }
+DESTINATION_ADDRESS_HINTS = {
+    "도쿄": {"도쿄", "tokyo", "japan", "日本", "東京都"},
+    "동경": {"동경", "tokyo", "japan", "日本", "東京都"},
+    "오사카": {"오사카", "osaka", "japan", "日本", "大阪"},
+    "교토": {"교토", "kyoto", "japan", "日本", "京都"},
+    "삿포로": {"삿포로", "sapporo", "japan", "日本", "札幌"},
+    "후쿠오카": {"후쿠오카", "fukuoka", "japan", "日本", "福岡"},
+    "나고야": {"나고야", "nagoya", "japan", "日本", "名古屋"},
+}
 
 gemini_blocked_until = 0.0
 
@@ -313,10 +322,11 @@ def _query_candidates(card: ParsedCard, req: ParseRequest) -> list[str]:
     name = card.name.strip()
 
     candidates = [
-        f"{name} {location}".strip(),
+        f"{name} {location}".strip() if location else "",
         f"{name} {primary_destination}".strip(),
         f"{alias} {location}".strip() if alias else "",
         f"{alias} {primary_destination}".strip() if alias else "",
+        name,
     ]
 
     deduped: list[str] = []
@@ -329,6 +339,33 @@ def _query_candidates(card: ParsedCard, req: ParseRequest) -> list[str]:
         deduped.append(candidate)
         seen.add(candidate)
     return deduped
+
+
+def _destination_hints(destinations: list[str]) -> set[str]:
+    hints: set[str] = set()
+    for destination in destinations:
+        normalized = destination.strip().lower()
+        if not normalized:
+            continue
+        hints.add(normalized)
+        hints.update(hint.lower() for hint in DESTINATION_ADDRESS_HINTS.get(destination.strip(), set()))
+    return hints
+
+
+def _place_matches_destination_context(place: dict, req: ParseRequest) -> bool:
+    hints = _destination_hints(req.destinations)
+    if not hints:
+        return True
+
+    address_parts = [
+        place.get("formattedAddress"),
+        place.get("shortFormattedAddress"),
+    ]
+    address_text = " ".join(part for part in address_parts if isinstance(part, str)).lower()
+    if not address_text:
+        return True
+
+    return any(hint in address_text for hint in hints)
 
 
 def _uses_search_alias(card: ParsedCard, query: str) -> bool:
@@ -414,20 +451,24 @@ async def _enrich_card(card: ParsedCard, req: ParseRequest, api_key: str) -> Par
             display_name = ((place.get("displayName") or {}).get("text") or "").strip()
             formatted_address = (place.get("formattedAddress") or "").strip()
             name_matched = _is_name_match(card, display_name)
+            destination_matched = _place_matches_destination_context(place, req)
             logger.info(
-                "Places candidate | card=%s | query=%s | idx=%d | name=%s | address=%s | name_matched=%s | destinations=%s",
+                "Places candidate | card=%s | query=%s | idx=%d | name=%s | address=%s | name_matched=%s | destination_matched=%s | destinations=%s",
                 card.name,
                 query,
                 index,
                 display_name,
                 formatted_address,
                 name_matched,
+                destination_matched,
                 req.destinations,
             )
-            if name_matched:
+            if name_matched and destination_matched:
                 return _apply_place_match(card, place)
 
-        if _can_accept_single_result_without_name_match(card, query, places):
+        if _can_accept_single_result_without_name_match(card, query, places) and _place_matches_destination_context(
+            places[0], req
+        ):
             logger.info(
                 "Places relaxed match accepted | card=%s | query=%s | reason=%s",
                 card.name,

--- a/apps/ai-engine/app/services/core_parse.py
+++ b/apps/ai-engine/app/services/core_parse.py
@@ -60,6 +60,15 @@ DESTINATION_ADDRESS_HINTS = {
     "후쿠오카": {"후쿠오카", "fukuoka", "japan", "日本", "福岡"},
     "나고야": {"나고야", "nagoya", "japan", "日本", "名古屋"},
 }
+DESTINATION_REGION_CODES = {
+    "도쿄": "jp",
+    "동경": "jp",
+    "오사카": "jp",
+    "교토": "jp",
+    "삿포로": "jp",
+    "후쿠오카": "jp",
+    "나고야": "jp",
+}
 
 gemini_blocked_until = 0.0
 
@@ -317,6 +326,8 @@ def _apply_flight_constraints(cards: list[ParsedCard], req: ParseRequest) -> lis
 def _query_candidates(card: ParsedCard, req: ParseRequest) -> list[str]:
     destinations = [destination.strip() for destination in req.destinations if destination.strip()]
     primary_destination = destinations[0] if destinations else ""
+    primary_destination_hints = DESTINATION_ADDRESS_HINTS.get(primary_destination, set())
+    country_hint = "japan" if "japan" in {hint.lower() for hint in primary_destination_hints} else ""
     location = (card.location or "").strip()
     alias = (card.search_alias or "").strip()
     name = card.name.strip()
@@ -324,8 +335,10 @@ def _query_candidates(card: ParsedCard, req: ParseRequest) -> list[str]:
     candidates = [
         f"{name} {location}".strip() if location else "",
         f"{name} {primary_destination}".strip(),
+        f"{name} {primary_destination} {country_hint}".strip() if country_hint else "",
         f"{alias} {location}".strip() if alias else "",
         f"{alias} {primary_destination}".strip() if alias else "",
+        f"{alias} {primary_destination} {country_hint}".strip() if alias and country_hint else "",
         name,
     ]
 
@@ -350,6 +363,18 @@ def _destination_hints(destinations: list[str]) -> set[str]:
         hints.add(normalized)
         hints.update(hint.lower() for hint in DESTINATION_ADDRESS_HINTS.get(destination.strip(), set()))
     return hints
+
+
+def _destination_region_codes(destinations: list[str]) -> list[str]:
+    codes: list[str] = []
+    seen: set[str] = set()
+    for destination in destinations:
+        code = DESTINATION_REGION_CODES.get(destination.strip())
+        if not code or code in seen:
+            continue
+        codes.append(code)
+        seen.add(code)
+    return codes
 
 
 def _place_matches_destination_context(place: dict, req: ParseRequest) -> bool:
@@ -383,11 +408,13 @@ def _can_accept_single_result_without_name_match(card: ParsedCard, query: str, p
     return False
 
 
-async def _search_place(query: str, api_key: str) -> dict | None:
+async def _search_place(query: str, api_key: str, included_region_codes: list[str] | None = None) -> dict | None:
     payload = {
         "textQuery": query,
         "pageSize": 5,
     }
+    if included_region_codes:
+        payload["includedRegionCodes"] = included_region_codes
     headers = {
         "Content-Type": "application/json",
         "X-Goog-Api-Key": api_key,
@@ -430,9 +457,10 @@ async def _enrich_card(card: ParsedCard, req: ParseRequest, api_key: str) -> Par
     if not card.name.strip():
         return card
 
+    included_region_codes = _destination_region_codes(req.destinations)
     for query in _query_candidates(card, req):
         try:
-            payload = await _search_place(query, api_key)
+            payload = await _search_place(query, api_key, included_region_codes)
         except httpx.HTTPError as exc:
             logger.warning("Places lookup failed for query=%s | error=%s", query, exc)
             return card

--- a/apps/ai-engine/tests/test_parse_service.py
+++ b/apps/ai-engine/tests/test_parse_service.py
@@ -43,7 +43,31 @@ def test_query_candidates_include_alias_fallbacks() -> None:
         "도쿄타워 도쿄",
         "東京タワー 미나토구",
         "東京タワー 도쿄",
+        "도쿄타워",
     ]
+
+
+def test_query_candidates_prioritize_destination_when_location_is_missing() -> None:
+    card = ParsedCard(
+        name="이치란 라멘",
+        category=Category.FOOD,
+        classification=Classification.CONFIRMED,
+        placement_status=PlacementStatus.READY_PARTIAL,
+        is_ai_generated=False,
+        allow_duplicate=False,
+    )
+    req = ParseRequest(
+        trip_id="trip-1",
+        dump_text="오사카 여행",
+        destinations=["오사카"],
+        travel_days=3,
+        companion_count=2,
+    )
+
+    queries = core_parse._query_candidates(card, req)
+
+    assert queries[0] == "이치란 라멘 오사카"
+    assert queries[-1] == "이치란 라멘"
 
 
 def test_name_match_accepts_search_alias() -> None:
@@ -351,6 +375,22 @@ def test_apply_place_match_keeps_original_name() -> None:
     assert updated.place_id == "place-1"
 
 
+def test_place_matches_destination_context_rejects_wrong_country_result() -> None:
+    req = ParseRequest(
+        trip_id="trip-1",
+        dump_text="오사카 여행",
+        destinations=["오사카"],
+        travel_days=3,
+        companion_count=2,
+    )
+    place = {
+        "displayName": {"text": "이치란 라멘"},
+        "formattedAddress": "271 Gangseo-ro, Gangseo-gu, Seoul, South Korea",
+    }
+
+    assert core_parse._place_matches_destination_context(place, req) is False
+
+
 @pytest.mark.asyncio
 async def test_enrich_card_skips_undecided_lookup() -> None:
     called = False
@@ -378,5 +418,48 @@ async def test_enrich_card_skips_undecided_lookup() -> None:
 
         assert updated == card
         assert called is False
+    finally:
+        core_parse._search_place = original
+
+
+@pytest.mark.asyncio
+async def test_enrich_card_rejects_name_match_when_destination_mismatches() -> None:
+    async def fake_search_place(query: str, api_key: str) -> dict | None:
+        return {
+            "places": [
+                {
+                    "id": "wrong-country-place",
+                    "displayName": {"text": "이치란 라멘"},
+                    "formattedAddress": "271 Gangseo-ro, Gangseo-gu, Seoul, South Korea",
+                    "location": {"latitude": 37.5499564, "longitude": 126.8359413},
+                }
+            ]
+        }
+
+    original = core_parse._search_place
+    core_parse._search_place = fake_search_place
+    try:
+        card = ParsedCard(
+            name="이치란 라멘",
+            category=Category.FOOD,
+            classification=Classification.CONFIRMED,
+            placement_status=PlacementStatus.READY_PARTIAL,
+            is_ai_generated=False,
+            allow_duplicate=False,
+            user_context="이치란 라멘을 먹고 싶다고 언급하셨어요.",
+        )
+        req = ParseRequest(
+            trip_id="trip-1",
+            dump_text="오사카 3박 4일 여행",
+            destinations=["오사카"],
+            travel_days=3,
+            companion_count=2,
+        )
+
+        updated = await core_parse._enrich_card(card, req, "test-key")
+
+        assert updated.place_id is None
+        assert updated.coordinates is None
+        assert "장소 정보를 확인해주세요." in (updated.user_context or "")
     finally:
         core_parse._search_place = original

--- a/apps/ai-engine/tests/test_parse_service.py
+++ b/apps/ai-engine/tests/test_parse_service.py
@@ -41,8 +41,10 @@ def test_query_candidates_include_alias_fallbacks() -> None:
     assert queries == [
         "도쿄타워 미나토구",
         "도쿄타워 도쿄",
+        "도쿄타워 도쿄 japan",
         "東京タワー 미나토구",
         "東京タワー 도쿄",
+        "東京タワー 도쿄 japan",
         "도쿄타워",
     ]
 
@@ -67,7 +69,13 @@ def test_query_candidates_prioritize_destination_when_location_is_missing() -> N
     queries = core_parse._query_candidates(card, req)
 
     assert queries[0] == "이치란 라멘 오사카"
+    assert queries[1] == "이치란 라멘 오사카 japan"
     assert queries[-1] == "이치란 라멘"
+
+
+def test_destination_region_codes_maps_supported_destinations() -> None:
+    assert core_parse._destination_region_codes(["오사카"]) == ["jp"]
+    assert core_parse._destination_region_codes(["오사카", "교토"]) == ["jp"]
 
 
 def test_name_match_accepts_search_alias() -> None:
@@ -395,7 +403,9 @@ def test_place_matches_destination_context_rejects_wrong_country_result() -> Non
 async def test_enrich_card_skips_undecided_lookup() -> None:
     called = False
 
-    async def fake_search_place(query: str, api_key: str) -> dict | None:
+    async def fake_search_place(
+        query: str, api_key: str, included_region_codes: list[str] | None = None
+    ) -> dict | None:
         nonlocal called
         called = True
         return {"places": []}
@@ -424,7 +434,12 @@ async def test_enrich_card_skips_undecided_lookup() -> None:
 
 @pytest.mark.asyncio
 async def test_enrich_card_rejects_name_match_when_destination_mismatches() -> None:
-    async def fake_search_place(query: str, api_key: str) -> dict | None:
+    seen_region_codes: list[list[str] | None] = []
+
+    async def fake_search_place(
+        query: str, api_key: str, included_region_codes: list[str] | None = None
+    ) -> dict | None:
+        seen_region_codes.append(included_region_codes)
         return {
             "places": [
                 {
@@ -461,5 +476,7 @@ async def test_enrich_card_rejects_name_match_when_destination_mismatches() -> N
         assert updated.place_id is None
         assert updated.coordinates is None
         assert "장소 정보를 확인해주세요." in (updated.user_context or "")
+        assert seen_region_codes
+        assert all(region_codes == ["jp"] for region_codes in seen_region_codes)
     finally:
         core_parse._search_place = original

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,4 +36,8 @@ services:
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     volumes:
       - ./apps/ai-engine:/app
+    networks:
+      default:
+        aliases:
+          - tripkey-ai-engine
     restart: unless-stopped


### PR DESCRIPTION
## 📝 작업 내용

> Places Blocking Enrichment에서 여행 목적지와 맞지 않는 장소 후보가 저장되지 않도록 보강했습니다.

- Places 검색 시 목적지 포함 query를 우선 사용
- 일본 목적지에 대해 `includedRegionCodes=["jp"]` 전달
- 목적지 국가/도시와 맞지 않는 Places 후보는 name match가 되어도 reject
- 확실하지 않은 경우 잘못된 place_id/coordinates를 저장하지 않고 null 유지
- dev compose에서 prod와 동일한 `tripkey-ai-engine` alias를 사용할 수 있도록 보정

## 🔗 관련 이슈

closes #109

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- 이 PR의 목표는 “정확한 장소를 무조건 찾기”가 아니라, 목적지와 불일치하는 잘못된 좌표를 저장하지 않는 것입니다.
- 예: 오사카 여행의 `이치란 라멘`이 서울 강서구 지점으로 매칭되던 문제를 방지합니다.
- 목적지와 일치하는 후보를 찾지 못하면 `place_id`, `coordinates`, `address`는 null로 유지하고 확인 힌트만 남깁니다.
- 체인/다중 지점 장소의 후보 선택 UX는 별도 정책 이슈로 분리하는 것이 좋습니다.

검증:

```bash
cd apps/ai-engine
.venv/bin/python -m pytest tests/test_parse_service.py
