### PR TITLE
Feat/112 ai parse flight be integration

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -137,6 +137,12 @@ public class PlaceCard {
     @Column(name = "flight_number")
     private String flightNumber;
 
+    @Column(name = "flight_datetime")
+    private String flightDatetime;
+
+    @Column(name = "flight_role")
+    private String flightRole;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
@@ -276,6 +282,8 @@ public class PlaceCard {
         card.checkIn = trimToNull(dto.checkIn());
         card.checkOut = trimToNull(dto.checkOut());
         card.flightNumber = trimToNull(dto.flightNumber());
+        card.flightDatetime = normalizeFlightDatetime(dto.flightDatetime());
+        card.flightRole = normalizeFlightRole(dto.flightRole());
         return card;
     }
 
@@ -348,6 +356,30 @@ public class PlaceCard {
             case "unassigned" -> "blocked".equals(placementStatus) ? "fix_required" : "review_only";
             default -> "review_only";
         };
+    }
+
+    private static String normalizeFlightRole(String flightRole) {
+        if (flightRole == null || flightRole.isBlank()) {
+            return null;
+        }
+        String normalized = flightRole.trim().toLowerCase(Locale.ROOT);
+        if ("outbound".equals(normalized) || "inbound".equals(normalized)) {
+            return normalized;
+        }
+        return null;
+    }
+
+    private static String normalizeFlightDatetime(String flightDatetime) {
+        String normalized = trimToNull(flightDatetime);
+        if (normalized == null) {
+            return null;
+        }
+        try {
+            OffsetDateTime.parse(normalized);
+            return normalized;
+        } catch (java.time.format.DateTimeParseException e) {
+            return null;
+        }
     }
 
     private static String trimToNull(String value) {

--- a/apps/backend/src/main/java/com/tripkey/dto/card/CardDto.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/card/CardDto.java
@@ -37,7 +37,9 @@ public record CardDto(
         String memo,
         String checkIn,
         String checkOut,
-        String flightNumber
+        String flightNumber,
+        String flightDatetime,
+        String flightRole
 ) {
 
     public record Coordinates(Double lat, Double lng) {
@@ -78,7 +80,9 @@ public record CardDto(
                 card.getMemo(),
                 card.getCheckIn(),
                 card.getCheckOut(),
-                card.getFlightNumber()
+                card.getFlightNumber(),
+                card.getFlightDatetime(),
+                card.getFlightRole()
         );
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiNonBlockingEnrichmentRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiNonBlockingEnrichmentRequest.java
@@ -80,9 +80,14 @@ public record AiNonBlockingEnrichmentRequest(
             @JsonProperty("check_out")
             String checkOut,
 
-            // TODO[#flight-fields]: Add flight_datetime and flight_role after the BE flight schema/DTO change lands.
             @JsonProperty("flight_number")
-            String flightNumber
+            String flightNumber,
+
+            @JsonProperty("flight_datetime")
+            String flightDatetime,
+
+            @JsonProperty("flight_role")
+            String flightRole
     ) {
         public static CardSnapshot from(PlaceCard card) {
             Coordinates coordinates = (card.getLat() != null && card.getLng() != null)
@@ -106,7 +111,9 @@ public record AiNonBlockingEnrichmentRequest(
                     card.getTags(),
                     card.getCheckIn(),
                     card.getCheckOut(),
-                    card.getFlightNumber()
+                    card.getFlightNumber(),
+                    card.getFlightDatetime(),
+                    card.getFlightRole()
             );
         }
     }

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiPlaceCardDto.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiPlaceCardDto.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-// AI Engine may return v3.3 flight fields before the BE flight DTO/entity work lands.
-// Keep unknown fields non-breaking here; the owning BE flight change will map them explicitly.
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record AiPlaceCardDto(
         @JsonProperty("place_id")
@@ -61,8 +59,64 @@ public record AiPlaceCardDto(
         String checkOut,
 
         @JsonProperty("flight_number")
-        String flightNumber
+        String flightNumber,
+
+        @JsonProperty("flight_datetime")
+        String flightDatetime,
+
+        @JsonProperty("flight_role")
+        String flightRole
 ) {
+
+    public AiPlaceCardDto(
+            String placeId,
+            String name,
+            String category,
+            String classification,
+            String placementStatus,
+            Boolean isAiGenerated,
+            Boolean allowDuplicate,
+            Short estimatedDurationMin,
+            Coordinates coordinates,
+            String location,
+            String address,
+            String timeConstraint,
+            String userContext,
+            String tips,
+            String questionText,
+            List<String> options,
+            String blockedReason,
+            List<String> tags,
+            String checkIn,
+            String checkOut,
+            String flightNumber
+    ) {
+        this(
+                placeId,
+                name,
+                category,
+                classification,
+                placementStatus,
+                isAiGenerated,
+                allowDuplicate,
+                estimatedDurationMin,
+                coordinates,
+                location,
+                address,
+                timeConstraint,
+                userContext,
+                tips,
+                questionText,
+                options,
+                blockedReason,
+                tags,
+                checkIn,
+                checkOut,
+                flightNumber,
+                null,
+                null
+        );
+    }
 
     public record Coordinates(
             Double lat,

--- a/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
+++ b/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
@@ -65,7 +65,9 @@ class JsonNamingStrategyTest {
                 List.of("야경"),
                 null,
                 null,
-                null
+                "KE723",
+                "2026-07-01T08:30:00+09:00",
+                "outbound"
         );
 
         AiParseResponse response = new AiParseResponse(
@@ -95,6 +97,9 @@ class JsonNamingStrategyTest {
                 .contains("allow_duplicate")
                 .contains("estimated_duration_min")
                 .contains("time_constraint")
+                .contains("flight_number")
+                .contains("flight_datetime")
+                .contains("flight_role")
                 .contains("user_context")
                 .contains("blocked_reason")
                 .contains("related_instance_ids")
@@ -107,6 +112,9 @@ class JsonNamingStrategyTest {
                 .doesNotContain("allowDuplicate")
                 .doesNotContain("estimatedDurationMin")
                 .doesNotContain("timeConstraint")
+                .doesNotContain("flightNumber")
+                .doesNotContain("flightDatetime")
+                .doesNotContain("flightRole")
                 .doesNotContain("userContext")
                 .doesNotContain("blockedReason")
                 .doesNotContain("relatedInstanceIds");

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
@@ -3,9 +3,12 @@ package com.tripkey.domain.dump;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.trip.Trip;
 import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
+import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -13,8 +16,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,5 +64,52 @@ class NonBlockingEnrichmentProcessorTest {
         when(aiEngineClient.enrichCardNonBlocking(any())).thenThrow(new IllegalStateException("timeout"));
 
         assertDoesNotThrow(() -> nonBlockingEnrichmentProcessor.trigger(List.of(card), List.of("오사카"), trip));
+    }
+
+    @Test
+    void triggerPassesFlightFieldsToAiEngineSnapshot() {
+        PlaceCard card = PlaceCard.createFromAiResponse(
+                UUID.randomUUID(),
+                new AiPlaceCardDto(
+                        null,
+                        "ICN-NRT",
+                        "transport",
+                        "confirmed",
+                        "ready",
+                        false,
+                        true,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "09:00 출발",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "KE703",
+                        "2026-07-01T09:00:00+09:00",
+                        "outbound"
+                ),
+                "ai_parse"
+        );
+        Trip trip = new Trip((short) 3, (short) 2);
+        when(aiEngineClient.enrichCardNonBlocking(any()))
+                .thenReturn(new AiNonBlockingEnrichmentResponse(null, List.of(), List.of()));
+
+        nonBlockingEnrichmentProcessor.trigger(List.of(card), List.of("도쿄"), trip);
+
+        ArgumentCaptor<AiNonBlockingEnrichmentRequest> captor =
+                ArgumentCaptor.forClass(AiNonBlockingEnrichmentRequest.class);
+        verify(aiEngineClient).enrichCardNonBlocking(captor.capture());
+
+        AiNonBlockingEnrichmentRequest.CardSnapshot snapshot = captor.getValue().card();
+        assertThat(snapshot.flightNumber()).isEqualTo("KE703");
+        assertThat(snapshot.flightDatetime()).isEqualTo("2026-07-01T09:00:00+09:00");
+        assertThat(snapshot.flightRole()).isEqualTo("outbound");
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
@@ -2,6 +2,7 @@ package com.tripkey.domain.place;
 
 import com.tripkey.domain.trip.Trip;
 import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -78,6 +79,51 @@ class PlaceCardRepositoryIntegrationTest {
         assertThat(clusterIdByInstance.get(farId))
                 .as("1.5km 밖 카드는 다른 cluster_id 를 가져야 함")
                 .isNotEqualTo(clusterIdByInstance.get(nearAId));
+    }
+
+    @Test
+    void storesFlightDatetimeAndRole() {
+        Trip trip = new Trip((short) 3, (short) 1);
+        tripRepository.saveAndFlush(trip);
+
+        PlaceCard card = PlaceCard.createFromAiResponse(
+                trip.getTripId(),
+                new AiPlaceCardDto(
+                        null,
+                        "ICN-NRT",
+                        "transport",
+                        "confirmed",
+                        "ready",
+                        false,
+                        true,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "09:00 출발",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "KE703",
+                        "2026-07-01T09:00:00+09:00",
+                        "outbound"
+                ),
+                "ai_parse"
+        );
+
+        PlaceCard saved = placeCardRepository.saveAndFlush(card);
+        placeCardRepository.flush();
+
+        PlaceCard reloaded = placeCardRepository.findById(saved.getInstanceId()).orElseThrow();
+
+        assertThat(reloaded.getFlightNumber()).isEqualTo("KE703");
+        assertThat(reloaded.getFlightDatetime()).isEqualTo("2026-07-01T09:00:00+09:00");
+        assertThat(reloaded.getFlightRole()).isEqualTo("outbound");
     }
 
     private UUID saveReadyCard(UUID tripId, String name, double lng, double lat) {

--- a/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardTest.java
@@ -1,5 +1,6 @@
 package com.tripkey.domain.place;
 
+import com.tripkey.dto.card.CardDto;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
 import org.junit.jupiter.api.Test;
 
@@ -175,7 +176,9 @@ class PlaceCardTest {
                 null,
                 null,
                 null,
-                "KE723"
+                "KE723",
+                "2026-07-01T08:30:00+09:00",
+                "outbound"
         );
 
         PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
@@ -184,6 +187,81 @@ class PlaceCardTest {
         assertThat(card.getCanExclude()).isFalse();
         assertThat(card.getAllowDuplicate()).isTrue();
         assertThat(card.getFlightNumber()).isEqualTo("KE723");
+        assertThat(card.getFlightDatetime()).isEqualTo("2026-07-01T08:30:00+09:00");
+        assertThat(card.getFlightRole()).isEqualTo("outbound");
+
+        CardDto cardDto = CardDto.from(card);
+        assertThat(cardDto.flightNumber()).isEqualTo("KE723");
+        assertThat(cardDto.flightDatetime()).isEqualTo("2026-07-01T08:30:00+09:00");
+        assertThat(cardDto.flightRole()).isEqualTo("outbound");
+    }
+
+    @Test
+    void createFromAiResponseNullsInvalidFlightRole() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                null,
+                "김포-오사카 항공편",
+                "transport",
+                "confirmed",
+                "ready",
+                false,
+                true,
+                null,
+                null,
+                null,
+                null,
+                "08:30 출발",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "KE723",
+                "2026-07-01T08:30:00+09:00",
+                "middle"
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
+
+        assertThat(card.getFlightDatetime()).isEqualTo("2026-07-01T08:30:00+09:00");
+        assertThat(card.getFlightRole()).isNull();
+    }
+
+    @Test
+    void createFromAiResponseNullsNonIsoFlightDatetime() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                null,
+                "김포-오사카 항공편",
+                "transport",
+                "confirmed",
+                "ready",
+                false,
+                true,
+                null,
+                null,
+                null,
+                null,
+                "08:30 출발",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "KE723",
+                "7월 1일 오전 8시 30분",
+                "outbound"
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
+
+        assertThat(card.getFlightDatetime()).isNull();
+        assertThat(card.getFlightRole()).isEqualTo("outbound");
     }
 
     @Test

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -70,6 +70,8 @@ create table place_cards (
   check_in               text,
   check_out              text,
   flight_number          text,
+  flight_datetime        text,
+  flight_role            text,
   geom                   geometry(Point, 4326)
     generated always as (
       case

--- a/shared/docs/migrations/V003__place_cards_flight_datetime_role.sql
+++ b/shared/docs/migrations/V003__place_cards_flight_datetime_role.sql
@@ -1,0 +1,3 @@
+alter table public.place_cards
+  add column if not exists flight_datetime text,
+  add column if not exists flight_role text;

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -90,6 +90,8 @@ create table if not exists public.place_cards (
 
   -- 교통 전용
   flight_number          text,                                     -- 항공편 번호
+  flight_datetime        text,                                     -- 항공편 출발 ISO datetime
+  flight_role            text,                                     -- outbound / inbound / null
 
   -- 공간 (lat/lng 기반 generated column, SRID 4326)
   geom                   geometry(Point, 4326)


### PR DESCRIPTION
## 📝 작업 내용

> AI Engine v3.3 parse 응답의 항공편 필드(`flight_datetime`, `flight_role`)를 BE DTO/엔티티/DB/카드 조회 응답 전반에 연동한다.

- DB 스키마에 `flight_datetime`, `flight_role` 컬럼 추가 및 migration 적용
- `AiPlaceCardDto`, `PlaceCard`, `CardDto`에 필드 연동
- `AiNonBlockingEnrichmentRequest.CardSnapshot`에 flight 필드 추가
- `flight_role` invalid 값은 parse 실패 없이 `null`로 정리
- 저장/조회/직렬화/매핑 전반 테스트 추가

## 🔗 관련 이슈

closes #112

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- `flight_role`은 `outbound` / `inbound` / `null`만 허용하며, 그 외 값은 `null`로 정리합니다.
- `flight_datetime`은 출발지 현지 timezone offset 포함 ISO datetime 문자열이며, `time_constraint`는 표시용 보조 텍스트입니다.
- 107번 PR(`feat/107-ai-non-blocking-enrichment`)에서 `@JsonIgnoreProperties(ignoreUnknown = true)` 방어 처리 및 TODO 주석만 남겨뒀던 부분을 이 PR에서 실제 연동으로 마무리합니다.
- Non-blocking snapshot 연동(`AiNonBlockingEnrichmentRequest.CardSnapshot`)도 이 PR 범위에 포함됩니다.
