### PR TITLE
Feat/be 115 dayview flight role mapping

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/group/DayViewService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/DayViewService.java
@@ -36,26 +36,19 @@ public class DayViewService {
                 .sorted(Comparator.comparing(PlaceCard::getCreatedAt))
                 .toList();
 
-        int maxDay = placeCardRepository.findMaxDayByTripId(tripId);
-
         PlaceCard startTimeCard = null;
         PlaceCard endTimeCard = null;
         List<PlaceCard> otherCards = new ArrayList<>();
 
         for (PlaceCard card : cardsForDay) {
-            boolean isFlightCard = "transport".equals(card.getCategory())
-                    && card.getFlightNumber() != null
-                    && !card.getFlightNumber().isBlank();
-
-            if (isFlightCard) {
-                if (dayNumber == 1 && startTimeCard == null) {
-                    startTimeCard = card;
-                    continue;
-                }
-                if (dayNumber == maxDay && endTimeCard == null) {
-                    endTimeCard = card;
-                    continue;
-                }
+            String role = card.getFlightRole();
+            if ("outbound".equals(role) && startTimeCard == null) {
+                startTimeCard = card;
+                continue;
+            }
+            if ("inbound".equals(role) && endTimeCard == null) {
+                endTimeCard = card;
+                continue;
             }
             otherCards.add(card);
         }

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -20,9 +20,6 @@ public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
 
     boolean existsByTripIdAndCategoryAndFlightNumber(UUID tripId, String category, String flightNumber);
 
-    @Query("select coalesce(max(p.day), 0) from PlaceCard p where p.tripId = :tripId")
-    int findMaxDayByTripId(@Param("tripId") UUID tripId);
-
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional
     @Query("delete from PlaceCard p where p.tripId = :tripId")

--- a/apps/backend/src/test/java/com/tripkey/domain/group/DayViewServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/DayViewServiceTest.java
@@ -61,7 +61,6 @@ class DayViewServiceTest {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
         when(placeCardRepository.findAllByTripIdAndDay(tripId, 3)).thenReturn(List.of());
-        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(0);
 
         DayViewModel response = dayViewService.getDayViewModel(tripId, 3);
 
@@ -72,16 +71,15 @@ class DayViewServiceTest {
     }
 
     @Test
-    void getDayViewModelAssignsArrivalFlightToStartTimeCardOnDayOne() {
+    void getDayViewModelAssignsOutboundFlightToStartTimeCard() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
 
-        PlaceCard arrivalFlight = dayCard(tripId, "transport", "KE723", 1, at(8, 0));
-        PlaceCard restaurant = dayCard(tripId, "food", null, 1, at(12, 0));
+        PlaceCard arrivalFlight = flightCard(tripId, "KE723", "outbound", 1, at(8, 0));
+        PlaceCard restaurant = nonFlightCard(tripId, "food", 1, at(12, 0));
 
         when(placeCardRepository.findAllByTripIdAndDay(tripId, 1))
                 .thenReturn(List.of(restaurant, arrivalFlight));
-        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(5);
 
         DayViewModel response = dayViewService.getDayViewModel(tripId, 1);
 
@@ -95,16 +93,15 @@ class DayViewServiceTest {
     }
 
     @Test
-    void getDayViewModelAssignsDepartureFlightToEndTimeCardOnMaxDay() {
+    void getDayViewModelAssignsInboundFlightToEndTimeCard() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
 
-        PlaceCard hotelCheckout = dayCard(tripId, "accommodation", null, 5, at(10, 0));
-        PlaceCard departureFlight = dayCard(tripId, "transport", "KE726", 5, at(20, 0));
+        PlaceCard hotelCheckout = nonFlightCard(tripId, "accommodation", 5, at(10, 0));
+        PlaceCard departureFlight = flightCard(tripId, "KE726", "inbound", 5, at(20, 0));
 
         when(placeCardRepository.findAllByTripIdAndDay(tripId, 5))
                 .thenReturn(List.of(hotelCheckout, departureFlight));
-        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(5);
 
         DayViewModel response = dayViewService.getDayViewModel(tripId, 5);
 
@@ -122,13 +119,13 @@ class DayViewServiceTest {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
 
-        PlaceCard arrivalFlight = dayCard(tripId, "transport", "KE723", 1, at(8, 0));
-        PlaceCard lunch = dayCard(tripId, "food", null, 1, at(12, 0));
-        PlaceCard departureFlight = dayCard(tripId, "transport", "KE726", 1, at(20, 0));
+        // 단일 day 여행 — outbound / inbound 가 같은 day=1 에 배치되어도 flight_role 로 정확히 분배.
+        PlaceCard arrivalFlight = flightCard(tripId, "KE723", "outbound", 1, at(8, 0));
+        PlaceCard lunch = nonFlightCard(tripId, "food", 1, at(12, 0));
+        PlaceCard departureFlight = flightCard(tripId, "KE726", "inbound", 1, at(20, 0));
 
         when(placeCardRepository.findAllByTripIdAndDay(tripId, 1))
                 .thenReturn(List.of(arrivalFlight, lunch, departureFlight));
-        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(1);
 
         DayViewModel response = dayViewService.getDayViewModel(tripId, 1);
 
@@ -142,16 +139,34 @@ class DayViewServiceTest {
     }
 
     @Test
-    void getDayViewModelKeepsMiddleDayFlightInCardsArray() {
+    void getDayViewModelAssignsFlightToSlotRegardlessOfDayNumber() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
 
-        // 3일차 국내선 환승편 — start/end 슬롯에 들어가지 않고 cards[] 에 표시
-        PlaceCard middleFlight = dayCard(tripId, "transport", "JL101", 3, at(14, 0));
+        // 사용자가 outbound 항공편을 day=3 에 배치한 케이스 — flight_role 만으로 슬롯 결정.
+        PlaceCard misplacedFlight = flightCard(tripId, "KE703", "outbound", 3, at(9, 0));
+
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 3))
+                .thenReturn(List.of(misplacedFlight));
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 3);
+
+        assertThat(response.startTimeCard()).isNotNull();
+        assertThat(response.startTimeCard().instanceId()).isEqualTo(misplacedFlight.getInstanceId());
+        assertThat(response.endTimeCard()).isNull();
+        assertThat(response.cards()).isEmpty();
+    }
+
+    @Test
+    void getDayViewModelKeepsMiddleDayFlightWithoutRoleInCardsArray() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        // 환승편 — flight_number 는 있지만 flight_role 이 null → cards[] 로 유지
+        PlaceCard middleFlight = flightCard(tripId, "JL101", null, 3, at(14, 0));
 
         when(placeCardRepository.findAllByTripIdAndDay(tripId, 3))
                 .thenReturn(List.of(middleFlight));
-        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(5);
 
         DayViewModel response = dayViewService.getDayViewModel(tripId, 3);
 
@@ -163,16 +178,15 @@ class DayViewServiceTest {
     }
 
     @Test
-    void getDayViewModelTreatsTransportWithoutFlightNumberAsRegularCard() {
+    void getDayViewModelTreatsTransportWithoutFlightRoleAsRegularCard() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
 
-        // transport 카테고리지만 flight_number 없음 (예: 지하철 / 버스)
-        PlaceCard subway = dayCard(tripId, "transport", null, 1, at(9, 0));
+        // 일반 transport — 지하철 / 버스 등. flight_role null
+        PlaceCard subway = nonFlightCard(tripId, "transport", 1, at(9, 0));
 
         when(placeCardRepository.findAllByTripIdAndDay(tripId, 1))
                 .thenReturn(List.of(subway));
-        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(3);
 
         DayViewModel response = dayViewService.getDayViewModel(tripId, 1);
 
@@ -184,16 +198,37 @@ class DayViewServiceTest {
     }
 
     @Test
+    void getDayViewModelKeepsExtraOutboundFlightsInCardsArray() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        // 같은 day 에 outbound 카드 2장 — createdAt ASC 정렬에 따라 첫 카드만 슬롯, 나머지는 cards[]
+        PlaceCard firstOutbound = flightCard(tripId, "KE703", "outbound", 1, at(8, 0));
+        PlaceCard duplicateOutbound = flightCard(tripId, "KE705", "outbound", 1, at(10, 0));
+
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 1))
+                .thenReturn(List.of(firstOutbound, duplicateOutbound));
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 1);
+
+        assertThat(response.startTimeCard()).isNotNull();
+        assertThat(response.startTimeCard().instanceId()).isEqualTo(firstOutbound.getInstanceId());
+        assertThat(response.endTimeCard()).isNull();
+        assertThat(response.cards())
+                .extracting(CardDto::instanceId)
+                .containsExactly(duplicateOutbound.getInstanceId());
+    }
+
+    @Test
     void getDayViewModelSortsCardsByCreatedAtAsc() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
 
-        PlaceCard later = dayCard(tripId, "place", null, 2, at(14, 0));
-        PlaceCard earlier = dayCard(tripId, "place", null, 2, at(10, 0));
+        PlaceCard later = nonFlightCard(tripId, "place", 2, at(14, 0));
+        PlaceCard earlier = nonFlightCard(tripId, "place", 2, at(10, 0));
 
         when(placeCardRepository.findAllByTripIdAndDay(tripId, 2))
                 .thenReturn(List.of(later, earlier));
-        when(placeCardRepository.findMaxDayByTripId(tripId)).thenReturn(5);
 
         DayViewModel response = dayViewService.getDayViewModel(tripId, 2);
 
@@ -202,9 +237,20 @@ class DayViewServiceTest {
                 .containsExactly(earlier.getInstanceId(), later.getInstanceId());
     }
 
-    private PlaceCard dayCard(UUID tripId, String category, String flightNumber, int day, OffsetDateTime createdAt) {
+    private PlaceCard flightCard(UUID tripId, String flightNumber, String flightRole, int day, OffsetDateTime createdAt) {
         PlaceCard card = PlaceCard.createUserCard(
-                tripId, "테스트 카드", category, null, null, null, null, null, null, flightNumber
+                tripId, "테스트 항공편", "transport", null, null, null, null, null, null, flightNumber
+        );
+        setField(card, "instanceId", UUID.randomUUID());
+        setField(card, "day", day);
+        setField(card, "createdAt", createdAt);
+        setField(card, "flightRole", flightRole);
+        return card;
+    }
+
+    private PlaceCard nonFlightCard(UUID tripId, String category, int day, OffsetDateTime createdAt) {
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, "테스트 카드", category, null, null, null, null, null, null, null
         );
         setField(card, "instanceId", UUID.randomUUID());
         setField(card, "day", day);


### PR DESCRIPTION
## 📝 작업 내용

> SCR-04 Day View 의 `start_time_card` / `end_time_card` 슬롯 매핑을 임시 휴리스틱(`dayNumber + createdAt`) 에서 `flight_role` (outbound / inbound) 기반으로 교체. PR #102 머지 시 남긴 임시 처리 한계 (단일 day 여행 + 항공편 2장 케이스의 createdAt 추정 부정확) 해소.

### 변경 핵심

**`DayViewService` 분배 로직 교체 (`c8b3917`)**
- `flight_role = "outbound"` → `start_time_card`
- `flight_role = "inbound"` → `end_time_card`
- `flight_role = null` 또는 그 외 → 일반 `cards[]`
- 기존 `dayNumber == 1` / `dayNumber == MAX(day)` 휴리스틱 제거
- `flight_number` 검사 + `findMaxDayByTripId` 조회 제거

**`findMaxDayByTripId` dead code 제거 (`3344a0a`)**
- 본 PR 가 마지막 소비자를 없앤 메서드 — 자연스러운 정리
- 향후 verify/confirm 작업에서 필요해지면 명확한 소비자와 함께 재도입

**`DayViewServiceTest` 갱신 + 신규 (9 테스트)**
- 갱신: outbound → start, inbound → end, single day 양쪽
- 신규: dayNumber 무관 슬롯 배정, multi-outbound cards[] 유지
- 회귀: empty day, middle flight no role, transport no role, createdAt 정렬

## 🔗 관련 이슈

closes #115

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 🧪 테스트

### 단위 테스트
`DayViewServiceTest` — 9개 (갱신 5 + 신규 4)

| 시나리오 | 검증 |
|---|---|
| 빈 day | 두 슬롯 null + cards 빈 배열 |
| outbound → start | 도착 항공편이 start_time_card |
| inbound → end | 출발 항공편이 end_time_card |
| 단일 day 여행 + 양쪽 항공편 | outbound → start, inbound → end (createdAt 추정 X) |
| dayNumber 와 무관한 슬롯 | outbound 가 day=3 에 있어도 그 day 의 start_time_card |
| 중간 day 환승편 (flight_role null) | cards[] 유지 |
| transport 인데 flight_role null (지하철 등) | cards[] |
| 같은 day 에 outbound 2장 | 첫 카드만 슬롯, 두 번째는 cards[] |
| createdAt ASC 정렬 | cards[] 내부 시간순 |

### 실행
```bash
cd apps/backend && ./gradlew test
```

전체 백엔드 테스트 PASS (Testcontainers 통합 테스트 포함).

## 👀 리뷰어에게

- PR #102 머지 시 남긴 *"후속 PR 에서 flight_role 기반 슬롯 매핑으로 교체"* TODO 약속을 본 PR 에서 마무리합니다.
- 이슈 #115 체크리스트의 *"PR #102 에서 남긴 임시 휴리스틱 TODO 주석 제거"* 항목은 **실제 코드에 TODO 가 없어** 처리할 게 없었습니다 (이슈 작성 시점 추정으로 적은 항목). 그 외 항목은 모두 적용/검증 완료.
- **인프라 변경 없음** — `place_cards.flight_role` / `flight_datetime` 컬럼과 엔티티 매핑은 PR #114 머지로 이미 들어와 있어, 본 PR 은 그 위에서 분배 분기만 교체합니다.
- 같은 day 에 outbound/inbound 카드가 여러 장인 경우는 `createdAt ASC` 정렬 첫 카드를 슬롯에 배정 (드문 케이스 보수적 처리). 추후 `flight_datetime` 기반 더 정교한 정렬이 필요해지면 별도 PR 로 처리 가능.
- 사용자가 outbound 카드를 day=3 같은 의외의 위치에 두면 → 그 day 의 `start_time_card` 로 배정됩니다 (per-day 쿼리가 이미 day 를 필터하므로). 의도와 맞지 않으면 알려주세요.

## 📸 스크린샷

> 없음
