### PR TITLE
Refactor/120 header props api

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import DevIndexPage from './pages/DevIndexPage';
 import DumpPage from './pages/DumpPage';
+import HeaderPreviewPage from './pages/HeaderPreviewPage';
 import OnboardingPage from './pages/OnboardingPage';
 import ProgressPageDev from './pages/ProgressPageDev';
 
@@ -15,6 +16,7 @@ const App = () => {
         <Route path="/onboarding" element={<OnboardingPage />} />
         <Route path="/dump" element={<DumpPage tripId={tripId} />} />
         <Route path="/progress" element={<ProgressPageDev />} />
+        <Route path="/header-preview" element={<HeaderPreviewPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/apps/frontend/src/components/header/Header.tsx
+++ b/apps/frontend/src/components/header/Header.tsx
@@ -1,55 +1,59 @@
-import { Calendar, Check, MapPin, Plus, Users } from 'lucide-react';
+import { Calendar, Check, MapPin, Users } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 
-type StepStatus = 'done' | 'current' | 'upcoming';
+export type StepStatus = 'done' | 'current' | 'upcoming';
 
-type Step = {
-  id: string;
+export type StepId = 'onboarding' | 'dump' | 'organize' | 'arrange' | 'confirm';
+
+export type Step = {
+  id: StepId;
   label: string;
-  status: StepStatus;
 };
 
 const STEPS: Step[] = [
-  { id: 'onboarding', label: '온보딩', status: 'done' },
-  { id: 'dump', label: '덤프', status: 'done' },
-  { id: 'organize', label: '정리', status: 'current' },
-  { id: 'arrange', label: '배치', status: 'upcoming' },
-  { id: 'confirm', label: '확정', status: 'upcoming' },
+  { id: 'onboarding', label: '온보딩' },
+  { id: 'dump', label: '덤프' },
+  { id: 'organize', label: '정리' },
+  { id: 'arrange', label: '배치' },
+  { id: 'confirm', label: '확정' },
 ];
 
-type HeaderProps = {
+export type HeaderProps = {
+  currentStepId?: StepId;
   destination?: string;
   extraDestinations?: number;
   travelers?: number;
   dateRange?: string;
   userInitials?: string;
-  onAddCard?: () => void;
-  onAlertDemo?: () => void;
-  onAlertMergedDemo?: () => void;
+  actions?: ReactNode;
+  showTripMeta?: boolean;
 };
 
 const Header = ({
+  currentStepId = 'onboarding',
   destination = '교토',
   extraDestinations = 2,
   travelers = 2,
   dateRange = '5월 10일 ~ 5월 14일',
   userInitials = 'KY',
-  onAddCard,
-  onAlertDemo,
-  onAlertMergedDemo,
+  actions,
+  showTripMeta = true,
 }: HeaderProps) => {
+  const currentIndex = STEPS.findIndex((step) => step.id === currentStepId);
+
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background">
       <div className="flex h-16 items-center justify-between px-6">
-        <a href="/" className="flex items-center gap-2.5">
+        <Link to="/" className="flex items-center gap-2.5">
           <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary text-base font-bold text-primary-foreground">
             T
           </span>
           <span className="text-xl font-bold tracking-tight">TripKey</span>
-        </a>
+        </Link>
         <Avatar className="h-9 w-9">
           <AvatarFallback className="bg-primary text-xs font-semibold text-primary-foreground">
             {userInitials}
@@ -58,43 +62,40 @@ const Header = ({
       </div>
 
       <div className="flex h-16 items-center justify-between gap-6 border-t border-border px-6">
-        <div className="flex items-center gap-5 text-sm text-muted-foreground">
-          <div className="flex items-center gap-1.5">
-            <MapPin className="h-4 w-4" aria-hidden="true" />
-            <span className="font-medium text-foreground">{destination}</span>
-            {extraDestinations > 0 && (
-              <Badge
-                variant="secondary"
-                className="ml-0.5 px-1.5 py-0 text-[11px]"
-              >
-                +{extraDestinations}
-              </Badge>
-            )}
+        {showTripMeta ? (
+          <div className="flex items-center gap-5 text-sm text-muted-foreground">
+            <div className="flex items-center gap-1.5">
+              <MapPin className="h-4 w-4" aria-hidden="true" />
+              <span className="font-medium text-foreground">{destination}</span>
+              {extraDestinations > 0 && (
+                <Badge
+                  variant="secondary"
+                  className="ml-0.5 px-1.5 py-0 text-[11px]"
+                >
+                  +{extraDestinations}
+                </Badge>
+              )}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Users className="h-4 w-4" aria-hidden="true" />
+              <span className="font-medium text-foreground">{travelers}인</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Calendar className="h-4 w-4" aria-hidden="true" />
+              <span className="font-medium text-foreground">{dateRange}</span>
+            </div>
           </div>
-          <div className="flex items-center gap-1.5">
-            <Users className="h-4 w-4" aria-hidden="true" />
-            <span className="font-medium text-foreground">{travelers}인</span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <Calendar className="h-4 w-4" aria-hidden="true" />
-            <span className="font-medium text-foreground">{dateRange}</span>
-          </div>
-        </div>
+        ) : (
+          <div />
+        )}
 
-        <Stepper steps={STEPS} />
+        <Stepper currentIndex={currentIndex} />
 
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={onAlertDemo}>
-            Alert Demo
-          </Button>
-          <Button variant="outline" size="sm" onClick={onAlertMergedDemo}>
-            Alert 합친 Demo
-          </Button>
-          <Button size="sm" onClick={onAddCard}>
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            카드 추가하기
-          </Button>
-        </div>
+        {actions ? (
+          <div className="flex items-center gap-2">{actions}</div>
+        ) : (
+          <div />
+        )}
       </div>
     </header>
   );
@@ -102,21 +103,27 @@ const Header = ({
 
 export default Header;
 
-const Stepper = ({ steps }: { steps: Step[] }) => {
+const Stepper = ({ currentIndex }: { currentIndex: number }) => {
   return (
     <ol className="flex items-center gap-2 text-sm">
-      {steps.map((step, index) => {
-        const isLast = index === steps.length - 1;
+      {STEPS.map((step, index) => {
+        const isLast = index === STEPS.length - 1;
+        const status: StepStatus =
+          index < currentIndex
+            ? 'done'
+            : index === currentIndex
+              ? 'current'
+              : 'upcoming';
         return (
           <li key={step.id} className="flex items-center gap-2">
-            {step.status === 'current' ? (
+            {status === 'current' ? (
               <span
                 aria-current="step"
                 className="rounded-full bg-primary px-3.5 py-1 font-medium text-primary-foreground"
               >
                 {step.label}
               </span>
-            ) : step.status === 'done' ? (
+            ) : status === 'done' ? (
               <span className="flex items-center gap-1 font-medium text-primary">
                 <Check className="h-4 w-4" aria-hidden="true" />
                 {step.label}

--- a/apps/frontend/src/pages/DevIndexPage.tsx
+++ b/apps/frontend/src/pages/DevIndexPage.tsx
@@ -17,6 +17,11 @@ const pages = [
     title: 'Progress Page',
     description: '진행 상태 페이지 (mock 파라미터로 상태 전환 가능)',
   },
+  {
+    path: '/header-preview',
+    title: 'Header Preview',
+    description: 'SCR 공통 헤더 컴포넌트 variant 미리보기',
+  },
 ];
 
 const DevIndexPage = () => {

--- a/apps/frontend/src/pages/HeaderPreviewPage.tsx
+++ b/apps/frontend/src/pages/HeaderPreviewPage.tsx
@@ -1,0 +1,70 @@
+import { Plus } from 'lucide-react';
+
+import Header, { type StepId } from '@/components/header/Header';
+import { Button } from '@/components/ui/button';
+
+const STEP_IDS: StepId[] = [
+  'onboarding',
+  'dump',
+  'organize',
+  'arrange',
+  'confirm',
+];
+
+const HeaderPreviewPage = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <section className="border-b border-border">
+        <div className="bg-muted/40 px-6 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Variant 1 — default (no props)
+        </div>
+        <Header />
+      </section>
+
+      <section className="mt-8 border-b border-border">
+        <div className="bg-muted/40 px-6 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Variant 2 — currentStepId &quot;dump&quot; + actions slot
+        </div>
+        <Header
+          currentStepId="dump"
+          destination="후쿠오카"
+          extraDestinations={0}
+          travelers={3}
+          dateRange="6월 1일 ~ 6월 5일"
+          userInitials="HE"
+          actions={
+            <Button size="sm">
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              카드 추가하기
+            </Button>
+          }
+        />
+      </section>
+
+      <section className="mt-8 border-b border-border">
+        <div className="bg-muted/40 px-6 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Variant 3 — showTripMeta=false + currentStepId &quot;confirm&quot;
+        </div>
+        <Header showTripMeta={false} currentStepId="confirm" />
+      </section>
+
+      <section className="mt-8">
+        <div className="bg-muted/40 px-6 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Variant 4 — currentStepId 전체 순회 (Stepper 상태 확인용)
+        </div>
+        <div className="flex flex-col gap-4 px-6 py-4">
+          {STEP_IDS.map((id) => (
+            <div key={id} className="rounded border border-border">
+              <div className="px-4 py-2 text-xs font-medium text-muted-foreground">
+                currentStepId=&quot;{id}&quot;
+              </div>
+              <Header currentStepId={id} />
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default HeaderPreviewPage;


### PR DESCRIPTION
## 📝 작업 내용

> SCR 공통 Header 컴포넌트를 페이지에서 props 만으로 재사용할 수 있도록 API 보완 (#120).

1차 UI 구현 단계의 후속 정리. 기능 / 데이터 연결 / 반응형은 본 PR 범위 외이며, 팀원이 각 SCR 페이지에서 `import Header from '@/components/header/Header'` 로 바로 가져다 쓸 수 있는 상태를 목표로 함.

### refactor(fe): Stepper 현재 단계를 props 로 받기

- `STEPS` 상수에서 하드코딩되어 있던 `status` 필드 제거 → `{ id, label }` 만 보유
- `HeaderProps.currentStepId?: StepId` 추가 — 페이지가 자기 단계만 넘기면 됨
- 인덱스 비교로 `done` / `current` / `upcoming` 자동 계산
- 미지정 시 첫 단계 (`'onboarding'`) 디폴트

### refactor(fe): 우측 액션 영역 슬롯화

- 박혀있던 데모 버튼 2개 (`Alert Demo` / `Alert 합친 Demo`) 와 `카드 추가하기` 버튼 제거
- `actions?: ReactNode` prop 으로 추출 — 페이지별로 자유 구성
- `onAddCard` / `onAlertDemo` / `onAlertMergedDemo` props 제거
- 사용처 없던 `Button` / `Plus` 아이콘 import 제거

### refactor(fe): 로고 SPA 라우팅

- `<a href="/">` → `<Link to="/">` (react-router-dom)
- 클릭 시 전체 페이지 리로드 → SPA 네비게이션

### refactor(fe): 트립 메타 영역 토글

- `showTripMeta?: boolean` 추가 (default `true`)
- 트립 정보가 아직 없는 화면 (예: 온보딩 초입) 에서 `showTripMeta={false}` 로 하단 좌측 메타 (📍 / 👤 / 📅) 숨김 가능

### chore(fe): Header variant 미리보기용 dev 페이지 추가

- `src/pages/HeaderPreviewPage.tsx` — `default` / `currentStepId`+`actions` / `showTripMeta=false` / `currentStepId` 전체 순회, 4개 variant
- `src/App.tsx` — `/header-preview` 라우트 등록
- `src/pages/DevIndexPage.tsx` — dev 네비게이션에 `Header Preview` 항목 추가
- dev 환경 전용 — 라우팅 통합 시 영향 없음

### chore(fe): 타입 named export

- `HeaderProps`, `StepId`, `StepStatus`, `Step` 타입 named export
- 컨슈머 사용 예:

```tsx
import Header, { type StepId } from '@/components/header/Header';
import { Button } from '@/components/ui/button';
import { Plus } from 'lucide-react';

const DumpPage = () => {
  const handleAddCard = () => { /* ... */ };

  return (
    <Header
      currentStepId="dump"
      destination="교토"
      travelers={2}
      dateRange="5월 10일 ~ 5월 14일"
      actions={
        <Button size="sm" onClick={handleAddCard}>
          <Plus className="h-4 w-4" aria-hidden="true" />
          카드 추가하기
        </Button>
      }
    />
  );
};
```

## 🔗 관련 이슈

closes #120

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] `npm run lint` — Header.tsx 신규/잔여 경고 없음 (총 카운트 1079 → 1078, 본 PR 의 prettier 경고 1건 해소)
- [x] `npx tsc -b --noEmit` — 타입 체크 통과
- [ ] 로컬에서 정상 동작 확인 (vite dev → `/header-preview` 에서 `currentStepId` 별 Stepper 상태 / `actions` slot 렌더 / 로고 SPA 라우팅 / `showTripMeta={false}` 토글 확인) — *PR 올리기 전 직접 확인*
- [x] 기존 기능 회귀 없음 — Header 는 현재 어떤 페이지에서도 import 되지 않아 호출처 영향 없음
- [x] 하드코딩된 값 / 임시 주석 (TODO, FIXME) 없음
- [x] PR 범위가 하나의 단위 (Header 컴포넌트 API 보완) 로 정리됨

## 👀 리뷰어에게

- **Breaking change** — `onAddCard` / `onAlertDemo` / `onAlertMergedDemo` props 제거. 현재 호출처 없음
- **Stepper API 결정** — `currentStepId` 만 받게 하고 `STEPS` 자체는 모듈 상수로 유지. 1차 UI 단계에선 단계 구성 자체가 페이지별로 달라지지 않는다는 가정. 향후 필요하면 `steps?: Step[]` prop 으로 확장 가능
- **actions slot 디폴트 없음** — 페이지에서 명시적으로 JSX 를 넘기는 방식. `카드 추가하기` 같은 공통 액션도 헤더에 박지 않고 각 SCR 페이지가 책임짐
- **barrel (`index.ts`) 미포함 이유** — `eslint.config.js` 의 `check-file/filename-naming-convention` 이 `src/components/**` 경로에 PASCAL_CASE 를 강제. `index.{ts,tsx}` 허용을 위한 ESLint 예외 추가는 팀 컨벤션 변경이라 별도 합의/PR 로 분리. 현 PR 에서는 `import Header, { type HeaderProps } from '@/components/header/Header'` 형태로 사용
- **레이아웃 안정성** — `justify-between` 유지를 위해 `showTripMeta={false}` 또는 `actions` 미지정 시 빈 `<div />` 플레이스홀더로 자리 채움. Stepper 가 중앙으로 밀리는 식의 무너짐 없음

## 📸 스크린샷

> 작업 후 첨부 예정 — `currentStepId` 별 Stepper 상태 (`onboarding` / `dump` / `organize` / `arrange` / `confirm`), `actions` slot 사용 예시, `showTripMeta={false}` 적용 예시
