### PR TITLE
[FEAT] #129 alert_cards 영속화 및 Cards SSOT 응답 노출

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/alert/AlertCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/alert/AlertCard.java
@@ -1,0 +1,82 @@
+package com.tripkey.domain.alert;
+
+import com.tripkey.common.converter.StringListConverter;
+import com.tripkey.infra.aiengine.dto.AiParseResponse;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "alert_cards")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlertCard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "trip_id", nullable = false, columnDefinition = "uuid")
+    private UUID tripId;
+
+    @Column(name = "job_id", columnDefinition = "uuid")
+    private UUID jobId;
+
+    @Column(name = "alert_id", nullable = false, columnDefinition = "text")
+    private String alertId;
+
+    @Column(name = "type", nullable = false, columnDefinition = "text")
+    private String type;
+
+    @Column(name = "category", nullable = false, columnDefinition = "text")
+    private String category;
+
+    @Column(name = "scope", nullable = false, columnDefinition = "text")
+    private String scope;
+
+    @Column(name = "day")
+    private Short day;
+
+    @Column(name = "message", nullable = false, columnDefinition = "text")
+    private String message;
+
+    @Column(name = "related_instance_ids", columnDefinition = "text")
+    @Convert(converter = StringListConverter.class)
+    private List<String> relatedInstanceIds;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    public static AlertCard fromAiResponse(AiParseResponse.AlertCard src, UUID tripId, UUID jobId) {
+        AlertCard card = new AlertCard();
+        card.tripId = tripId;
+        card.jobId = jobId;
+        card.alertId = src.id();
+        card.type = src.type();
+        card.category = src.category();
+        card.scope = src.scope() == null ? "trip" : src.scope();
+        card.day = src.day() == null ? null : src.day().shortValue();
+        card.message = src.message();
+        card.relatedInstanceIds = src.relatedInstanceIds() == null
+                ? null
+                : src.relatedInstanceIds().stream().map(UUID::toString).toList();
+        return card;
+    }
+
+    public List<UUID> relatedInstanceUuids() {
+        if (relatedInstanceIds == null || relatedInstanceIds.isEmpty()) {
+            return List.of();
+        }
+        return relatedInstanceIds.stream().map(UUID::fromString).toList();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = OffsetDateTime.now();
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/alert/AlertCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/alert/AlertCardRepository.java
@@ -1,0 +1,13 @@
+package com.tripkey.domain.alert;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AlertCardRepository extends JpaRepository<AlertCard, Long> {
+
+    List<AlertCard> findAllByTripIdOrderByCreatedAtAsc(UUID tripId);
+
+    void deleteAllByJobId(UUID jobId);
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
@@ -1,5 +1,7 @@
 package com.tripkey.domain.dump;
 
+import com.tripkey.domain.alert.AlertCard;
+import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
 import com.tripkey.domain.trip.Trip;
@@ -27,6 +29,7 @@ public class DumpAsyncProcessor {
     private final TripRepository tripRepository;
     private final TripDestinationRepository tripDestinationRepository;
     private final PlaceCardRepository placeCardRepository;
+    private final AlertCardRepository alertCardRepository;
     private final AiEngineClient aiEngineClient;
     private final NonBlockingEnrichmentProcessor nonBlockingEnrichmentProcessor;
 
@@ -81,11 +84,7 @@ public class DumpAsyncProcessor {
 
             List<PlaceCard> savedCards = placeCardRepository.saveAll(cards);
 
-            if (response.alertCards() != null && !response.alertCards().isEmpty()) {
-                log.info("Received {} alert cards for trip={} (parse_version={})",
-                        response.alertCards().size(), job.getTripId(), response.parseVersion());
-                // TODO[SCR-03]: persist alert_cards alongside Cards SSOT (`GET /trips/{trip_id}/cards`).
-            }
+            persistAlertCards(job.getTripId(), job.getJobId(), response);
 
             job.complete(response.contextSummary());
             dumpJobRepository.save(job);
@@ -95,6 +94,19 @@ public class DumpAsyncProcessor {
             job.fail("PARSE_FAILED");
             dumpJobRepository.save(job);
         }
+    }
+
+    private void persistAlertCards(UUID tripId, UUID jobId, AiParseResponse response) {
+        if (response.alertCards() == null || response.alertCards().isEmpty()) {
+            return;
+        }
+        alertCardRepository.deleteAllByJobId(jobId);
+        List<AlertCard> entities = response.alertCards().stream()
+                .map(dto -> AlertCard.fromAiResponse(dto, tripId, jobId))
+                .toList();
+        alertCardRepository.saveAll(entities);
+        log.info("Persisted {} alert cards for trip={} (parse_version={})",
+                entities.size(), tripId, response.parseVersion());
     }
 
     private void triggerNonBlockingEnrichment(List<PlaceCard> cards, List<String> destinations, Trip trip) {

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
@@ -1,5 +1,7 @@
 package com.tripkey.domain.dump;
 
+import com.tripkey.domain.alert.AlertCard;
+import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.trip.Trip;
 import com.tripkey.infra.aiengine.AiEngineClient;
@@ -11,6 +13,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -18,6 +21,7 @@ import java.util.List;
 public class NonBlockingEnrichmentProcessor {
 
     private final AiEngineClient aiEngineClient;
+    private final AlertCardRepository alertCardRepository;
 
     @Async("dumpTaskExecutor")
     public void trigger(List<PlaceCard> cards, List<String> destinations, Trip trip) {
@@ -36,10 +40,20 @@ public class NonBlockingEnrichmentProcessor {
                     log.info("Non-blocking enrichment completed. trip={} card={} alerts={} patches={}",
                             card.getTripId(), card.getInstanceId(), alertCount, patchCount);
                 }
+                if (alertCount > 0) {
+                    persistAlertCards(card.getTripId(), response);
+                }
             } catch (Exception e) {
                 log.warn("Non-blocking enrichment failed. trip={} card={}",
                         card.getTripId(), card.getInstanceId(), e);
             }
         }
+    }
+
+    private void persistAlertCards(UUID tripId, AiNonBlockingEnrichmentResponse response) {
+        List<AlertCard> entities = response.alertCards().stream()
+                .map(dto -> AlertCard.fromAiResponse(dto, tripId, null))
+                .toList();
+        alertCardRepository.saveAll(entities);
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/place/CardService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/CardService.java
@@ -3,6 +3,8 @@ package com.tripkey.domain.place;
 import com.tripkey.common.exception.CardNotFoundException;
 import com.tripkey.common.exception.FlightCardDuplicateRoleException;
 import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.alert.AlertCard;
+import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.dump.DumpJob;
 import com.tripkey.domain.dump.DumpJobRepository;
 import com.tripkey.domain.trip.TripRepository;
@@ -26,6 +28,7 @@ public class CardService {
     private final TripRepository tripRepository;
     private final PlaceCardRepository placeCardRepository;
     private final DumpJobRepository dumpJobRepository;
+    private final AlertCardRepository alertCardRepository;
 
     @Transactional(readOnly = true)
     public CardsResponse getCards(UUID tripId) {
@@ -43,8 +46,9 @@ public class CardService {
                 .map(DumpJob::getContextSummary)
                 .orElse(null);
 
-        // alert_cards 영속화는 후속 작업. 현재는 빈 배열 반환.
-        List<AlertCardDto> alertCards = List.of();
+        List<AlertCardDto> alertCards = alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId).stream()
+                .map(CardService::toAlertCardDto)
+                .toList();
 
         return new CardsResponse(cards, contextSummary, alertCards);
     }
@@ -118,5 +122,17 @@ public class CardService {
 
         placeCardRepository.save(card);
         return CardDto.from(card);
+    }
+
+    private static AlertCardDto toAlertCardDto(AlertCard entity) {
+        return new AlertCardDto(
+                entity.getAlertId(),
+                entity.getType(),
+                entity.getCategory(),
+                entity.getScope(),
+                entity.getDay() == null ? null : entity.getDay().intValue(),
+                entity.getMessage(),
+                entity.relatedInstanceUuids()
+        );
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/alert/AlertCardTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/alert/AlertCardTest.java
@@ -1,0 +1,77 @@
+package com.tripkey.domain.alert;
+
+import com.tripkey.infra.aiengine.dto.AiParseResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlertCardTest {
+
+    @Test
+    void fromAiResponseCopiesFields() {
+        UUID tripId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        UUID related = UUID.randomUUID();
+
+        AlertCard card = AlertCard.fromAiResponse(
+                new AiParseResponse.AlertCard(
+                        "alert-1",
+                        "timing_conflict",
+                        "practical",
+                        "trip",
+                        null,
+                        "체크인이 항공편보다 빨라요",
+                        List.of(related)
+                ),
+                tripId,
+                jobId
+        );
+
+        assertThat(card.getTripId()).isEqualTo(tripId);
+        assertThat(card.getJobId()).isEqualTo(jobId);
+        assertThat(card.getAlertId()).isEqualTo("alert-1");
+        assertThat(card.getType()).isEqualTo("timing_conflict");
+        assertThat(card.getCategory()).isEqualTo("practical");
+        assertThat(card.getScope()).isEqualTo("trip");
+        assertThat(card.getDay()).isNull();
+        assertThat(card.getMessage()).isEqualTo("체크인이 항공편보다 빨라요");
+        assertThat(card.relatedInstanceUuids()).containsExactly(related);
+    }
+
+    @Test
+    void fromAiResponseDefaultsScopeToTripWhenNull() {
+        UUID tripId = UUID.randomUUID();
+        AlertCard card = AlertCard.fromAiResponse(
+                new AiParseResponse.AlertCard("a", "t", "practical", null, null, "m", null),
+                tripId,
+                null
+        );
+        assertThat(card.getScope()).isEqualTo("trip");
+        assertThat(card.getJobId()).isNull();
+    }
+
+    @Test
+    void fromAiResponseConvertsDayIntegerToShort() {
+        UUID tripId = UUID.randomUUID();
+        AlertCard card = AlertCard.fromAiResponse(
+                new AiParseResponse.AlertCard("a", "t", "insight", "day", 3, "m", null),
+                tripId,
+                null
+        );
+        assertThat(card.getDay()).isEqualTo((short) 3);
+    }
+
+    @Test
+    void relatedInstanceUuidsReturnsEmptyListWhenNull() {
+        UUID tripId = UUID.randomUUID();
+        AlertCard card = AlertCard.fromAiResponse(
+                new AiParseResponse.AlertCard("a", "t", "practical", "trip", null, "m", null),
+                tripId,
+                null
+        );
+        assertThat(card.relatedInstanceUuids()).isEmpty();
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
@@ -1,5 +1,7 @@
 package com.tripkey.domain.dump;
 
+import com.tripkey.domain.alert.AlertCard;
+import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.place.PlaceCardRepository;
 import com.tripkey.domain.trip.Trip;
 import com.tripkey.domain.trip.TripDestination;
@@ -10,6 +12,7 @@ import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,6 +24,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +42,9 @@ class DumpAsyncProcessorTest {
 
     @Mock
     private PlaceCardRepository placeCardRepository;
+
+    @Mock
+    private AlertCardRepository alertCardRepository;
 
     @Mock
     private AiEngineClient aiEngineClient;
@@ -157,5 +164,78 @@ class DumpAsyncProcessorTest {
         verify(nonBlockingEnrichmentProcessor).trigger(any(), any(), any());
         assertThat(job.getStatus()).isEqualTo("completed");
         assertThat(job.getErrorCode()).isNull();
+    }
+
+    @Test
+    void processPersistsAlertCardsFromParseResponse() {
+        UUID tripId = UUID.randomUUID();
+        DumpJob job = DumpJob.create(tripId, "오사카 3박4일 여행입니다.");
+        Trip trip = new Trip((short) 4, (short) 2);
+        TripDestination destination = new TripDestination(trip, "오사카", (short) 0);
+
+        AiPlaceCardDto card = new AiPlaceCardDto(
+                "place-1", "도톤보리", "place", "confirmed", "ready_partial",
+                false, false, (short) 90, null, "오사카 중앙구",
+                null, null, null, null, null, null, null, List.of(), null, null, null
+        );
+
+        AiParseResponse.AlertCard alert1 = new AiParseResponse.AlertCard(
+                "alert-1", "timing_conflict", "practical", "trip", null, "체크인 시각 확인 필요", null
+        );
+        AiParseResponse.AlertCard alert2 = new AiParseResponse.AlertCard(
+                "alert-2", "festival", "insight", "trip", null, "축제 기간입니다", null
+        );
+
+        AiParseResponse response = new AiParseResponse(
+                List.of(card), "오사카 시내 중심 동선", List.of(alert1, alert2), "3.2.0"
+        );
+
+        when(dumpJobRepository.findById(job.getJobId())).thenReturn(Optional.of(job));
+        when(dumpJobRepository.save(any(DumpJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
+        when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(tripId)).thenReturn(List.of(destination));
+        when(aiEngineClient.parseDump(any())).thenReturn(response);
+        when(placeCardRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        dumpAsyncProcessor.process(job.getJobId());
+
+        verify(alertCardRepository).deleteAllByJobId(job.getJobId());
+        ArgumentCaptor<List<AlertCard>> captor = ArgumentCaptor.forClass(List.class);
+        verify(alertCardRepository).saveAll(captor.capture());
+        List<AlertCard> persisted = captor.getValue();
+        assertThat(persisted).hasSize(2);
+        assertThat(persisted).extracting(AlertCard::getAlertId).containsExactly("alert-1", "alert-2");
+        assertThat(persisted).extracting(AlertCard::getTripId).containsOnly(tripId);
+        assertThat(persisted).extracting(AlertCard::getJobId).containsOnly(job.getJobId());
+    }
+
+    @Test
+    void processSkipsAlertSaveWhenResponseHasNoAlerts() {
+        UUID tripId = UUID.randomUUID();
+        DumpJob job = DumpJob.create(tripId, "오사카 3박4일 여행입니다.");
+        Trip trip = new Trip((short) 4, (short) 2);
+        TripDestination destination = new TripDestination(trip, "오사카", (short) 0);
+
+        AiPlaceCardDto card = new AiPlaceCardDto(
+                "place-1", "도톤보리", "place", "confirmed", "ready_partial",
+                false, false, (short) 90, null, "오사카 중앙구",
+                null, null, null, null, null, null, null, List.of(), null, null, null
+        );
+
+        AiParseResponse response = new AiParseResponse(
+                List.of(card), "오사카 시내 중심 동선", List.of(), "3.2.0"
+        );
+
+        when(dumpJobRepository.findById(job.getJobId())).thenReturn(Optional.of(job));
+        when(dumpJobRepository.save(any(DumpJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
+        when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(tripId)).thenReturn(List.of(destination));
+        when(aiEngineClient.parseDump(any())).thenReturn(response);
+        when(placeCardRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        dumpAsyncProcessor.process(job.getJobId());
+
+        verify(alertCardRepository, never()).deleteAllByJobId(any());
+        verify(alertCardRepository, never()).saveAll(any());
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
@@ -1,10 +1,13 @@
 package com.tripkey.domain.dump;
 
+import com.tripkey.domain.alert.AlertCard;
+import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.trip.Trip;
 import com.tripkey.infra.aiengine.AiEngineClient;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
+import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +30,9 @@ class NonBlockingEnrichmentProcessorTest {
 
     @Mock
     private AiEngineClient aiEngineClient;
+
+    @Mock
+    private AlertCardRepository alertCardRepository;
 
     @InjectMocks
     private NonBlockingEnrichmentProcessor nonBlockingEnrichmentProcessor;
@@ -111,5 +117,36 @@ class NonBlockingEnrichmentProcessorTest {
         assertThat(snapshot.flightNumber()).isEqualTo("KE703");
         assertThat(snapshot.flightDatetime()).isEqualTo("2026-07-01T09:00:00+09:00");
         assertThat(snapshot.flightRole()).isEqualTo("outbound");
+    }
+
+    @Test
+    void triggerPersistsAlertsWithNullJobIdWhenEnrichmentReturnsAlerts() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard card = PlaceCard.createFromAiResponse(
+                tripId,
+                new AiPlaceCardDto(
+                        null, "도톤보리", "place", "confirmed", "ready_partial",
+                        false, false, (short) 90, null, "오사카",
+                        null, null, null, null, null, null, null, null, null, null, null
+                ),
+                "ai_parse"
+        );
+        Trip trip = new Trip((short) 3, (short) 2);
+        AiParseResponse.AlertCard insightAlert = new AiParseResponse.AlertCard(
+                "alert-insight-1", "festival", "insight", "trip", null, "축제 기간입니다", null
+        );
+        when(aiEngineClient.enrichCardNonBlocking(any()))
+                .thenReturn(new AiNonBlockingEnrichmentResponse(null, List.of(), List.of(insightAlert)));
+
+        nonBlockingEnrichmentProcessor.trigger(List.of(card), List.of("오사카"), trip);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<AlertCard>> captor = ArgumentCaptor.forClass(List.class);
+        verify(alertCardRepository).saveAll(captor.capture());
+        List<AlertCard> persisted = captor.getValue();
+        assertThat(persisted).hasSize(1);
+        assertThat(persisted.get(0).getAlertId()).isEqualTo("alert-insight-1");
+        assertThat(persisted.get(0).getTripId()).isEqualTo(tripId);
+        assertThat(persisted.get(0).getJobId()).isNull();
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
@@ -4,12 +4,15 @@ import com.tripkey.common.exception.CardNotFoundException;
 import com.tripkey.common.exception.FlightCardDuplicateRoleException;
 import com.tripkey.common.exception.InvalidClassificationTransitionException;
 import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.alert.AlertCard;
+import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.dump.DumpJobRepository;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.card.CardAddRequest;
 import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.card.CardPatchRequest;
 import com.tripkey.dto.card.CardsResponse;
+import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -38,6 +41,9 @@ class CardServiceTest {
     @Mock
     private DumpJobRepository dumpJobRepository;
 
+    @Mock
+    private AlertCardRepository alertCardRepository;
+
     @InjectMocks
     private CardService cardService;
 
@@ -47,12 +53,75 @@ class CardServiceTest {
         when(tripRepository.existsById(tripId)).thenReturn(true);
         when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
         when(dumpJobRepository.findFirstByTripIdOrderByCreatedAtDesc(tripId)).thenReturn(Optional.empty());
+        when(alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId)).thenReturn(List.of());
 
         CardsResponse response = cardService.getCards(tripId);
 
         assertThat(response.cards()).isEmpty();
         assertThat(response.contextSummary()).isNull();
         assertThat(response.alertCards()).isEmpty();
+    }
+
+    @Test
+    void getCardsReturnsAlertCardsInCreatedAtAscOrder() {
+        UUID tripId = UUID.randomUUID();
+        UUID relatedId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+        when(dumpJobRepository.findFirstByTripIdOrderByCreatedAtDesc(tripId)).thenReturn(Optional.empty());
+
+        AlertCard alert = AlertCard.fromAiResponse(
+                new AiParseResponse.AlertCard(
+                        "alert-1",
+                        "timing_conflict",
+                        "practical",
+                        "trip",
+                        null,
+                        "체크인이 항공편보다 빨라요",
+                        List.of(relatedId)
+                ),
+                tripId,
+                UUID.randomUUID()
+        );
+        when(alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId)).thenReturn(List.of(alert));
+
+        CardsResponse response = cardService.getCards(tripId);
+
+        assertThat(response.alertCards()).hasSize(1);
+        assertThat(response.alertCards().get(0).id()).isEqualTo("alert-1");
+        assertThat(response.alertCards().get(0).type()).isEqualTo("timing_conflict");
+        assertThat(response.alertCards().get(0).category()).isEqualTo("practical");
+        assertThat(response.alertCards().get(0).scope()).isEqualTo("trip");
+        assertThat(response.alertCards().get(0).day()).isNull();
+        assertThat(response.alertCards().get(0).relatedInstanceIds()).containsExactly(relatedId);
+    }
+
+    @Test
+    void getCardsAlertCardWithNullRelatedInstancesReturnsEmptyList() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+        when(dumpJobRepository.findFirstByTripIdOrderByCreatedAtDesc(tripId)).thenReturn(Optional.empty());
+
+        AlertCard alert = AlertCard.fromAiResponse(
+                new AiParseResponse.AlertCard(
+                        "alert-2",
+                        "festival",
+                        "insight",
+                        "trip",
+                        null,
+                        "축제 기간입니다",
+                        null
+                ),
+                tripId,
+                null
+        );
+        when(alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId)).thenReturn(List.of(alert));
+
+        CardsResponse response = cardService.getCards(tripId);
+
+        assertThat(response.alertCards()).hasSize(1);
+        assertThat(response.alertCards().get(0).relatedInstanceIds()).isEmpty();
     }
 
     @Test

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -86,3 +86,19 @@ create table place_cards (
 );
 
 create index idx_place_cards_geom on place_cards using gist (geom);
+
+create table alert_cards (
+  id                    bigserial   primary key,
+  trip_id               uuid        not null references trips(trip_id),
+  job_id                uuid        references dump_jobs(job_id),
+  alert_id              text        not null,
+  type                  text        not null,
+  category              text        not null,
+  scope                 text        not null default 'trip',
+  day                   smallint,
+  message               text        not null,
+  related_instance_ids  text,
+  created_at            timestamptz not null default now()
+);
+
+create index idx_alert_cards_trip_id on alert_cards (trip_id);

--- a/shared/docs/migrations/V005__alert_cards.sql
+++ b/shared/docs/migrations/V005__alert_cards.sql
@@ -1,0 +1,67 @@
+-- TripKey migration: alert_cards table
+-- Date: 2026-05-11
+-- Scope: AI 엔진 (Core Parse / Non-blocking Enrichment) 이 생성하는 AlertCard 를
+--        영속화하여 `GET /trips/{trip_id}/cards` 응답에 노출 가능하게 한다.
+--        Issue #129.
+--
+-- 적용 대상: Supabase (dev / production 모두)
+-- 적용 방법: Supabase SQL Editor 에서 본 파일 전체 실행
+-- 동기 산출물:
+--   - shared/docs/schema.sql 가 본 마이그레이션 적용 후 상태와 일치해야 함
+--   - apps/backend/src/test/resources/postgis-test-schema.sql 동일 반영
+--
+-- 컬럼 의미:
+--   - id                   : bigserial PK (BE 내부 식별자)
+--   - trip_id              : 소속 여행 세션 FK
+--   - job_id               : 생성 시점의 dump_jobs FK (nullable — 후속 enrichment 단계
+--                            에서 추가될 알림은 원본 job 추적 못할 수 있음)
+--   - alert_id             : AI 엔진이 부여한 외부 노출 식별자 (AlertCard.id)
+--   - type                 : 자유 문자열 (timing_conflict, festival 등)
+--   - category             : practical | insight
+--   - scope                : trip | day (현재 trip 만 사용)
+--   - day                  : scope=day 일 때만, 현재 항상 NULL
+--   - message              : 알림 본문
+--   - related_instance_ids : 관련 카드 instance_id 목록을 CSV 로 직렬화
+--                            (기존 options/tags 컨벤션과 일관)
+
+create table if not exists public.alert_cards (
+  id                    bigserial   primary key,
+  trip_id               uuid        not null references public.trips(trip_id),
+  job_id                uuid        references public.dump_jobs(job_id),
+  alert_id              text        not null,
+  type                  text        not null,
+  category              text        not null,
+  scope                 text        not null default 'trip',
+  day                   smallint,
+  message               text        not null,
+  related_instance_ids  text,
+  created_at            timestamptz not null default now()
+);
+
+create index if not exists idx_alert_cards_trip_id on public.alert_cards (trip_id);
+
+-- ─────────────────────────────────────────────
+-- 검증 (적용 후 Supabase SQL Editor 에서 실행하여 확인)
+-- ─────────────────────────────────────────────
+-- 1) 테이블 생성 확인
+--    select column_name, data_type, is_nullable, column_default
+--      from information_schema.columns
+--     where table_name = 'alert_cards'
+--     order by ordinal_position;
+--
+-- 2) 인덱스 확인
+--    select indexname, indexdef
+--      from pg_indexes
+--     where tablename = 'alert_cards';
+--
+-- 3) FK 확인
+--    select tc.constraint_name, kcu.column_name,
+--           ccu.table_name as referenced_table,
+--           ccu.column_name as referenced_column
+--      from information_schema.table_constraints tc
+--      join information_schema.key_column_usage kcu
+--        on tc.constraint_name = kcu.constraint_name
+--      join information_schema.constraint_column_usage ccu
+--        on ccu.constraint_name = tc.constraint_name
+--     where tc.table_name = 'alert_cards'
+--       and tc.constraint_type = 'FOREIGN KEY';

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -110,3 +110,21 @@ create table if not exists public.place_cards (
 
 create index if not exists idx_place_cards_trip_id on public.place_cards (trip_id);
 create index if not exists idx_place_cards_geom    on public.place_cards using gist (geom);
+
+-- AI 엔진 (Core Parse / Non-blocking Enrichment) 이 생성하는 알림 카드
+-- (Cards SSOT 응답의 alert_cards 배열로 노출됨)
+create table if not exists public.alert_cards (
+  id                    bigserial   primary key,                                 -- BE 내부 식별자
+  trip_id               uuid        not null references public.trips(trip_id),   -- 소속 여행 세션
+  job_id                uuid        references public.dump_jobs(job_id),         -- 생성 시점 dump_job (후속 enrichment 는 NULL 가능)
+  alert_id              text        not null,                                    -- AI 엔진이 부여한 외부 노출 식별자
+  type                  text        not null,                                    -- 자유 문자열: timing_conflict / festival 등
+  category              text        not null,                                    -- practical | insight
+  scope                 text        not null default 'trip',                     -- trip | day (현재 trip 만 사용)
+  day                   smallint,                                                -- scope=day 일 때만, 현재 항상 NULL
+  message               text        not null,                                    -- 알림 본문
+  related_instance_ids  text,                                                    -- 관련 카드 instance_id CSV
+  created_at            timestamptz not null default now()
+);
+
+create index if not exists idx_alert_cards_trip_id on public.alert_cards (trip_id);


### PR DESCRIPTION
## 📝 작업 내용

> AI 엔진(Core Parse / Non-blocking Enrichment) 이 생성하는 AlertCard 를 DB 에 영속화하고 `GET /trips/{tripId}/cards` 응답에 노출한다.

- `alert_cards` 테이블 도입 (V005 마이그레이션)
- `AlertCard` 엔티티 / Repository / `DumpAsyncProcessor` + `NonBlockingEnrichmentProcessor` 저장 연동
- `CardService.getCards` 가 영속화된 alert 를 `CardsResponse.alertCards` 로 반환

## 🔗 관련 이슈

closes #129

## 🗂️ 변경 범위

- [x] Backend (apps/backend)
- [x] 공통 / 설정 / 문서 — `shared/docs/migrations/V005`, `shared/docs/schema.sql`

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? — 전체 테스트 통과
- [x] 기존 기능이 깨지지 않았나요? — CardServiceTest / DumpAsyncProcessorTest / NonBlockingEnrichmentProcessorTest 회귀 확인
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요? — `DumpAsyncProcessor` / `CardService` 의 TODO 제거
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

### 정책 결정 사항 (이슈 #129 권장안 그대로 채택)

| 항목 | 채택 | 근거 |
|------|------|------|
| `related_instance_ids` 직렬화 | CSV(JSON 문자열) via `StringListConverter` | 기존 `options` / `tags` 컨벤션 일관 |
| `alert_id` 부여 주체 | AI 엔진 | `AlertCardResponse.id: str` required (코드 사실) |
| 멱등성 | `deleteAllByJobId` + saveAll | AI 가 새 alert_id 부여할 수 있어 UPSERT 의미 약함 |
| SCR-03 응답 처리 | BE 가 전체 반환, FE 화면단 필터링 | 명세서 단일 응답 가정과 일치 |
| `scope=day` | 본 PR 범위 밖 | 서버 배치 동기화 후 활성화 (내부기술문서 5.2) |

### 집중 확인 부탁드리는 부분

1. **NonBlockingEnrichmentProcessor 의 `jobId=null`** — non-blocking enrichment 는 카드별 호출이라 원본 dump_job 추적이 모호. nullable FK 로 저장 중. 후속에서 enrichment_job 같은 별도 추적 컬럼이 필요할 수 있음.

2. **멱등성 범위** — `deleteAllByJobId(jobId)` 는 Core Parse 재처리 시점에만 동작. NonBlocking 의 jobId=null alert 는 누적됨. 동일 카드 재-enrichment 호출이 현재 안 일어나서 운영상 문제 없지만, 향후 재시도 정책 도입 시 별도 처리 필요.

## 📸 스크린샷

UI 변경 없음.
