### PR TITLE
feat/137 SCR-04V 동선 검증 로직 (거리/시간 conflict)

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmService.java
@@ -43,10 +43,14 @@ public class ConfirmService {
 
         validateAllPlacedNotExcluded(tripId, days);
 
-        verifyService.verifyAndSave(tripId, request);
+        PlacementSaveResponse verifyResponse = verifyService.verifyAndSave(tripId, request);
         trip.confirm();
 
-        return PlacementSaveResponse.of(tripId);
+        return PlacementSaveResponse.of(
+                tripId,
+                verifyResponse.skippedInstanceIds(),
+                verifyResponse.routeWarnings()
+        );
     }
 
     private void validateAllPlacedNotExcluded(UUID tripId, List<PlacementDay> days) {

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCardRepository.java
@@ -44,4 +44,24 @@ public interface PlaceCardRepository extends JpaRepository<PlaceCard, UUID> {
             @Param("tripId") UUID tripId,
             @Param("epsMeters") double epsMeters,
             @Param("minPts") int minPts);
+
+    @Query(value = """
+            select c1.instance_id as id_a,
+                   c2.instance_id as id_b,
+                   c1.day as day,
+                   st_distancesphere(c1.geom, c2.geom) as distance_meters
+              from place_cards c1
+              join place_cards c2
+                on c1.trip_id = c2.trip_id
+               and c1.day = c2.day
+               and c2.day_order = c1.day_order + 1
+             where c1.trip_id = :tripId
+               and c1.is_excluded = false
+               and c2.is_excluded = false
+               and c1.geom is not null
+               and c2.geom is not null
+               and c1.day is not null
+               and c1.day_order is not null
+            """, nativeQuery = true)
+    List<Object[]> findAdjacentCardDistances(@Param("tripId") UUID tripId);
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/verify/RouteValidator.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/verify/RouteValidator.java
@@ -1,0 +1,74 @@
+package com.tripkey.domain.verify;
+
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.dto.placement.RouteWarning;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class RouteValidator {
+
+    static final int DISTANCE_THRESHOLD_METERS = 10_000;
+    static final int DURATION_THRESHOLD_MINUTES = 600;
+
+    private final PlaceCardRepository placeCardRepository;
+
+    @Transactional(readOnly = true)
+    public List<RouteWarning> validate(UUID tripId) {
+        List<RouteWarning> warnings = new ArrayList<>();
+        warnings.addAll(distanceWarnings(tripId));
+        warnings.addAll(durationWarnings(tripId));
+        return warnings;
+    }
+
+    private List<RouteWarning> distanceWarnings(UUID tripId) {
+        List<Object[]> rows = placeCardRepository.findAdjacentCardDistances(tripId);
+        List<RouteWarning> result = new ArrayList<>();
+        for (Object[] row : rows) {
+            UUID idA = (UUID) row[0];
+            UUID idB = (UUID) row[1];
+            int day = ((Number) row[2]).intValue();
+            double distance = ((Number) row[3]).doubleValue();
+            if (distance > DISTANCE_THRESHOLD_METERS) {
+                result.add(RouteWarning.distance(day, idA, idB, (int) Math.round(distance)));
+            }
+        }
+        return result;
+    }
+
+    private List<RouteWarning> durationWarnings(UUID tripId) {
+        Map<Integer, List<PlaceCard>> byDay = new TreeMap<>();
+        for (PlaceCard card : placeCardRepository.findAllByTripId(tripId)) {
+            if (Boolean.TRUE.equals(card.getIsExcluded())) continue;
+            if (card.getDay() == null) continue;
+            if ("accommodation".equals(card.getCategory())) continue;
+            byDay.computeIfAbsent(card.getDay(), k -> new ArrayList<>()).add(card);
+        }
+
+        List<RouteWarning> result = new ArrayList<>();
+        for (Map.Entry<Integer, List<PlaceCard>> entry : byDay.entrySet()) {
+            int total = 0;
+            List<UUID> instanceIds = new ArrayList<>();
+            for (PlaceCard card : entry.getValue()) {
+                if (card.getEstimatedDurationMin() != null) {
+                    total += card.getEstimatedDurationMin();
+                }
+                instanceIds.add(card.getInstanceId());
+            }
+            if (total > DURATION_THRESHOLD_MINUTES) {
+                result.add(RouteWarning.duration(entry.getKey(), instanceIds, total));
+            }
+        }
+        return result;
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/verify/VerifyService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/verify/VerifyService.java
@@ -8,6 +8,7 @@ import com.tripkey.dto.placement.PlacementDay;
 import com.tripkey.dto.placement.PlacementDayItem;
 import com.tripkey.dto.placement.PlacementSaveRequest;
 import com.tripkey.dto.placement.PlacementSaveResponse;
+import com.tripkey.dto.placement.RouteWarning;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class VerifyService {
 
     private final TripRepository tripRepository;
     private final PlaceCardRepository placeCardRepository;
+    private final RouteValidator routeValidator;
 
     /**
      * Snapshot semantics — request 는 trip 의 Day 배치 전체 상태를 나타낸다.
@@ -69,6 +71,9 @@ public class VerifyService {
             }
         }
 
-        return PlacementSaveResponse.of(tripId, skippedInstanceIds);
+        placeCardRepository.flush();
+        List<RouteWarning> routeWarnings = routeValidator.validate(tripId);
+
+        return PlacementSaveResponse.of(tripId, skippedInstanceIds, routeWarnings);
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/placement/PlacementSaveResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/placement/PlacementSaveResponse.java
@@ -6,13 +6,18 @@ import java.util.UUID;
 public record PlacementSaveResponse(
         boolean saved,
         UUID tripId,
-        List<UUID> skippedInstanceIds
+        List<UUID> skippedInstanceIds,
+        List<RouteWarning> routeWarnings
 ) {
+    public static PlacementSaveResponse of(UUID tripId, List<UUID> skippedInstanceIds, List<RouteWarning> routeWarnings) {
+        return new PlacementSaveResponse(true, tripId, skippedInstanceIds, routeWarnings);
+    }
+
     public static PlacementSaveResponse of(UUID tripId, List<UUID> skippedInstanceIds) {
-        return new PlacementSaveResponse(true, tripId, skippedInstanceIds);
+        return of(tripId, skippedInstanceIds, List.of());
     }
 
     public static PlacementSaveResponse of(UUID tripId) {
-        return of(tripId, List.of());
+        return of(tripId, List.of(), List.of());
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/placement/RouteWarning.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/placement/RouteWarning.java
@@ -1,0 +1,37 @@
+package com.tripkey.dto.placement;
+
+import java.util.List;
+import java.util.UUID;
+
+public record RouteWarning(
+        String type,
+        Integer day,
+        List<UUID> instanceIds,
+        String message,
+        Integer distanceMeters,
+        Integer totalMinutes
+) {
+    public static RouteWarning distance(int day, UUID a, UUID b, int distanceMeters) {
+        double km = distanceMeters / 1000.0;
+        return new RouteWarning(
+                "distance",
+                day,
+                List.of(a, b),
+                String.format("인접 카드 간 거리 %.1fkm", km),
+                distanceMeters,
+                null
+        );
+    }
+
+    public static RouteWarning duration(int day, List<UUID> instanceIds, int totalMinutes) {
+        int hours = totalMinutes / 60;
+        return new RouteWarning(
+                "duration",
+                day,
+                instanceIds,
+                String.format("Day %d 활동 시간 합계 %d시간", day, hours),
+                null,
+                totalMinutes
+        );
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmServiceTest.java
@@ -12,6 +12,8 @@ import com.tripkey.dto.placement.PlacementDay;
 import com.tripkey.dto.placement.PlacementDayItem;
 import com.tripkey.dto.placement.PlacementSaveRequest;
 import com.tripkey.dto.placement.PlacementSaveResponse;
+import com.tripkey.dto.placement.RouteWarning;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -27,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -46,6 +49,12 @@ class ConfirmServiceTest {
 
     @InjectMocks
     private ConfirmService confirmService;
+
+    @BeforeEach
+    void stubVerifyServiceDefaultResponse() {
+        lenient().when(verifyService.verifyAndSave(any(), any()))
+                .thenAnswer(invocation -> PlacementSaveResponse.of(invocation.getArgument(0)));
+    }
 
     @Test
     void confirmAndSaveThrowsTripNotFoundWhenTripMissing() {
@@ -180,6 +189,35 @@ class ConfirmServiceTest {
         assertThat(second.saved()).isTrue();
         assertThat(trip.getConfirmedAt()).isNotNull();
         verify(verifyService, times(2)).verifyAndSave(tripId, request);
+    }
+
+    @Test
+    void confirmAndSavePassesThroughVerifyServiceRouteWarnings() {
+        UUID tripId = UUID.randomUUID();
+        Trip trip = new Trip((short) 3, (short) 2);
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
+
+        PlaceCard card = placeCard(tripId);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(card));
+
+        RouteWarning warning = RouteWarning.distance(
+                1, UUID.randomUUID(), UUID.randomUUID(), 12_000
+        );
+        UUID stale = UUID.randomUUID();
+        when(verifyService.verifyAndSave(eq(tripId), any())).thenReturn(
+                PlacementSaveResponse.of(tripId, List.of(stale), List.of(warning))
+        );
+
+        PlacementSaveRequest request = new PlacementSaveRequest(List.of(
+                new PlacementDay(1, List.of(
+                        new PlacementDayItem(card.getInstanceId(), 1, null)
+                ))
+        ));
+
+        PlacementSaveResponse response = confirmService.confirmAndSave(tripId, request);
+
+        assertThat(response.skippedInstanceIds()).containsExactly(stale);
+        assertThat(response.routeWarnings()).containsExactly(warning);
     }
 
     private PlaceCard placeCard(UUID tripId) {

--- a/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
@@ -132,10 +132,10 @@ class PlaceCardRepositoryIntegrationTest {
         tripRepository.saveAndFlush(trip);
         UUID tripId = trip.getTripId();
 
-        // Day 1: 도톄→우메다 → 거리는 약 5km. day_order=1,2,3 으로 두 페어 발생.
+        // Day 1: 도톈보리→우메다 → 거리는 약 5km. day_order=1,2,3 으로 두 페어 발생.
         UUID a = savePlacedCard(tripId, "Card A", 135.5023, 34.6687, 1, (short) 1);
         UUID b = savePlacedCard(tripId, "Card B", 135.4960, 34.7025, 1, (short) 2);
-        UUID c = savePlacedCard(tripId, "Card C", 135.5500, 34.7000, 1, (short) 3);
+        savePlacedCard(tripId, "Card C", 135.5500, 34.7000, 1, (short) 3);
         // Day 2: 1개만 — 페어 없음
         savePlacedCard(tripId, "Card D", 135.0000, 34.0000, 2, (short) 1);
         // Excluded — 페어 계산 제외
@@ -158,7 +158,7 @@ class PlaceCardRepositoryIntegrationTest {
                 .as("Day 1 의 인접 페어 두 건만 조회되어야 함")
                 .containsKeys(a, b);
         assertThat(distanceByFirstId.get(a))
-                .as("도톈리→우메다 거리 약 5km 이상")
+                .as("도톈보리→우메다 거리 약 5km 이상")
                 .isGreaterThan(3000.0);
     }
 

--- a/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardRepositoryIntegrationTest.java
@@ -126,6 +126,102 @@ class PlaceCardRepositoryIntegrationTest {
         assertThat(reloaded.getFlightRole()).isEqualTo("outbound");
     }
 
+    @Test
+    void findAdjacentCardDistancesReturnsConsecutiveDayPairsWithDistance() {
+        Trip trip = new Trip((short) 3, (short) 1);
+        tripRepository.saveAndFlush(trip);
+        UUID tripId = trip.getTripId();
+
+        // Day 1: 도톄→우메다 → 거리는 약 5km. day_order=1,2,3 으로 두 페어 발생.
+        UUID a = savePlacedCard(tripId, "Card A", 135.5023, 34.6687, 1, (short) 1);
+        UUID b = savePlacedCard(tripId, "Card B", 135.4960, 34.7025, 1, (short) 2);
+        UUID c = savePlacedCard(tripId, "Card C", 135.5500, 34.7000, 1, (short) 3);
+        // Day 2: 1개만 — 페어 없음
+        savePlacedCard(tripId, "Card D", 135.0000, 34.0000, 2, (short) 1);
+        // Excluded — 페어 계산 제외
+        UUID excluded = savePlacedCard(tripId, "Excluded", 135.5025, 34.6688, 1, (short) 4);
+        markExcluded(excluded);
+        // 미배치 카드 — day=null 이라 페어 없음
+        savePlacedCard(tripId, "Unplaced", 135.5026, 34.6689, null, null);
+        // geom null — 페어 계산 제외
+        saveNoGeomCard(tripId, "No Geom", 1, (short) 5);
+
+        List<Object[]> rows = placeCardRepository.findAdjacentCardDistances(tripId);
+
+        // Day 1 페어 2건만 반환 (A-B, B-C). Day 2 단일, excluded, unplaced, no-geom 제외.
+        assertThat(rows).hasSize(2);
+        Map<UUID, Double> distanceByFirstId = rows.stream()
+                .collect(Collectors.toMap(
+                        row -> (UUID) row[0],
+                        row -> ((Number) row[3]).doubleValue()));
+        assertThat(distanceByFirstId)
+                .as("Day 1 의 인접 페어 두 건만 조회되어야 함")
+                .containsKeys(a, b);
+        assertThat(distanceByFirstId.get(a))
+                .as("도톈리→우메다 거리 약 5km 이상")
+                .isGreaterThan(3000.0);
+    }
+
+    private UUID savePlacedCard(UUID tripId, String name, double lng, double lat, Integer day, Short dayOrder) {
+        PlaceCard card = new PlaceCard();
+        UUID id = UUID.randomUUID();
+        OffsetDateTime now = OffsetDateTime.now();
+        setField(card, "instanceId", id);
+        setField(card, "tripId", tripId);
+        setField(card, "name", name);
+        setField(card, "category", "place");
+        setField(card, "classification", "confirmed");
+        setField(card, "placementStatus", "ready");
+        setField(card, "processingStatus", "completed");
+        setField(card, "actionType", "review_only");
+        setField(card, "canExclude", true);
+        setField(card, "allowDuplicate", false);
+        setField(card, "isExcluded", false);
+        setField(card, "isAiGenerated", false);
+        setField(card, "pendingReorder", false);
+        setField(card, "lat", lat);
+        setField(card, "lng", lng);
+        if (day != null) {
+            setField(card, "day", day);
+            setField(card, "dayOrder", dayOrder);
+        }
+        setField(card, "createdAt", now);
+        setField(card, "updatedAt", now);
+        placeCardRepository.saveAndFlush(card);
+        return id;
+    }
+
+    private void saveNoGeomCard(UUID tripId, String name, Integer day, Short dayOrder) {
+        PlaceCard card = new PlaceCard();
+        UUID id = UUID.randomUUID();
+        OffsetDateTime now = OffsetDateTime.now();
+        setField(card, "instanceId", id);
+        setField(card, "tripId", tripId);
+        setField(card, "name", name);
+        setField(card, "category", "place");
+        setField(card, "classification", "confirmed");
+        setField(card, "placementStatus", "ready");
+        setField(card, "processingStatus", "completed");
+        setField(card, "actionType", "review_only");
+        setField(card, "canExclude", true);
+        setField(card, "allowDuplicate", false);
+        setField(card, "isExcluded", false);
+        setField(card, "isAiGenerated", false);
+        setField(card, "pendingReorder", false);
+        // lat/lng null → geom null
+        setField(card, "day", day);
+        setField(card, "dayOrder", dayOrder);
+        setField(card, "createdAt", now);
+        setField(card, "updatedAt", now);
+        placeCardRepository.saveAndFlush(card);
+    }
+
+    private void markExcluded(UUID instanceId) {
+        PlaceCard card = placeCardRepository.findById(instanceId).orElseThrow();
+        setField(card, "isExcluded", true);
+        placeCardRepository.saveAndFlush(card);
+    }
+
     private UUID saveReadyCard(UUID tripId, String name, double lng, double lat) {
         PlaceCard card = new PlaceCard();
         UUID id = UUID.randomUUID();

--- a/apps/backend/src/test/java/com/tripkey/domain/verify/RouteValidatorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/verify/RouteValidatorTest.java
@@ -1,0 +1,213 @@
+package com.tripkey.domain.verify;
+
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.dto.placement.RouteWarning;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RouteValidatorTest {
+
+    @Mock
+    private PlaceCardRepository placeCardRepository;
+
+    @InjectMocks
+    private RouteValidator routeValidator;
+
+    @Test
+    void validateReturnsEmptyWhenNoData() {
+        UUID tripId = UUID.randomUUID();
+        when(placeCardRepository.findAdjacentCardDistances(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+
+        assertThat(routeValidator.validate(tripId)).isEmpty();
+    }
+
+    @Test
+    void distanceWarningEmittedWhenAdjacentDistanceExceedsThreshold() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        when(placeCardRepository.findAdjacentCardDistances(tripId))
+                .thenReturn(List.<Object[]>of(new Object[]{a, b, 2, 11_500.0}));
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+
+        List<RouteWarning> warnings = routeValidator.validate(tripId);
+
+        assertThat(warnings).hasSize(1);
+        RouteWarning w = warnings.get(0);
+        assertThat(w.type()).isEqualTo("distance");
+        assertThat(w.day()).isEqualTo(2);
+        assertThat(w.instanceIds()).containsExactly(a, b);
+        assertThat(w.distanceMeters()).isEqualTo(11_500);
+        assertThat(w.totalMinutes()).isNull();
+    }
+
+    @Test
+    void distanceWarningSuppressedWhenAtOrBelowThreshold() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        when(placeCardRepository.findAdjacentCardDistances(tripId))
+                .thenReturn(List.<Object[]>of(new Object[]{a, b, 1, 10_000.0}));
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+
+        assertThat(routeValidator.validate(tripId)).isEmpty();
+    }
+
+    @Test
+    void distanceWarningRoundsMetersToInt() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        when(placeCardRepository.findAdjacentCardDistances(tripId))
+                .thenReturn(List.<Object[]>of(new Object[]{a, b, 1, 12345.678}));
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+
+        assertThat(routeValidator.validate(tripId).get(0).distanceMeters()).isEqualTo(12346);
+    }
+
+    @Test
+    void durationWarningEmittedWhenDailySumExceedsThreshold() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard c1 = placeCard(tripId, "place", 1, (short) 400);
+        PlaceCard c2 = placeCard(tripId, "place", 1, (short) 250);
+        when(placeCardRepository.findAdjacentCardDistances(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(c1, c2));
+
+        List<RouteWarning> warnings = routeValidator.validate(tripId);
+
+        assertThat(warnings).hasSize(1);
+        RouteWarning w = warnings.get(0);
+        assertThat(w.type()).isEqualTo("duration");
+        assertThat(w.day()).isEqualTo(1);
+        assertThat(w.totalMinutes()).isEqualTo(650);
+        assertThat(w.distanceMeters()).isNull();
+        assertThat(w.instanceIds()).containsExactlyInAnyOrder(c1.getInstanceId(), c2.getInstanceId());
+    }
+
+    @Test
+    void durationWarningSuppressedWhenAtThreshold() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard c1 = placeCard(tripId, "place", 1, (short) 600);
+        when(placeCardRepository.findAdjacentCardDistances(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(c1));
+
+        assertThat(routeValidator.validate(tripId)).isEmpty();
+    }
+
+    @Test
+    void durationExcludesAccommodationCardsFromSum() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard activity = placeCard(tripId, "place", 1, (short) 500);
+        PlaceCard accommodation = placeCard(tripId, "accommodation", 1, (short) 480);
+        when(placeCardRepository.findAdjacentCardDistances(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(activity, accommodation));
+
+        // 500 alone <= 600 → no warning
+        assertThat(routeValidator.validate(tripId)).isEmpty();
+    }
+
+    @Test
+    void durationExcludesIsExcludedCards() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard included = placeCard(tripId, "place", 1, (short) 400);
+        PlaceCard excluded = placeCard(tripId, "place", 1, (short) 300);
+        setField(excluded, "isExcluded", true);
+        when(placeCardRepository.findAdjacentCardDistances(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(included, excluded));
+
+        // 400 alone <= 600 → no warning (excluded 카드 빠짐)
+        assertThat(routeValidator.validate(tripId)).isEmpty();
+    }
+
+    @Test
+    void durationExcludesUnplacedCards() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard placed = placeCard(tripId, "place", 1, (short) 400);
+        PlaceCard unplaced = placeCard(tripId, "place", null, (short) 300);
+        when(placeCardRepository.findAdjacentCardDistances(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(placed, unplaced));
+
+        assertThat(routeValidator.validate(tripId)).isEmpty();
+    }
+
+    @Test
+    void durationWarningCalculatesPerDay() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard d1Card = placeCard(tripId, "place", 1, (short) 700);
+        PlaceCard d2Card = placeCard(tripId, "place", 2, (short) 700);
+        PlaceCard d3Card = placeCard(tripId, "place", 3, (short) 300);
+        when(placeCardRepository.findAdjacentCardDistances(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(d1Card, d2Card, d3Card));
+
+        List<RouteWarning> warnings = routeValidator.validate(tripId);
+
+        assertThat(warnings).hasSize(2);
+        assertThat(warnings).extracting(RouteWarning::day).containsExactly(1, 2);
+    }
+
+    @Test
+    void durationTreatsNullEstimatedAsZero() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard nullDuration = placeCard(tripId, "place", 1, null);
+        PlaceCard normal = placeCard(tripId, "place", 1, (short) 700);
+        when(placeCardRepository.findAdjacentCardDistances(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(nullDuration, normal));
+
+        List<RouteWarning> warnings = routeValidator.validate(tripId);
+
+        assertThat(warnings).hasSize(1);
+        assertThat(warnings.get(0).totalMinutes()).isEqualTo(700);
+    }
+
+    @Test
+    void validateReturnsBothDistanceAndDurationWarnings() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        PlaceCard busy = placeCard(tripId, "place", 1, (short) 700);
+        when(placeCardRepository.findAdjacentCardDistances(tripId))
+                .thenReturn(List.<Object[]>of(new Object[]{a, b, 2, 15_000.0}));
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(busy));
+
+        List<RouteWarning> warnings = routeValidator.validate(tripId);
+
+        assertThat(warnings).hasSize(2);
+        assertThat(warnings).extracting(RouteWarning::type)
+                .containsExactlyInAnyOrder("distance", "duration");
+    }
+
+    private PlaceCard placeCard(UUID tripId, String category, Integer day, Short estimatedDurationMin) {
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, "테스트 카드", category, null, estimatedDurationMin, null, null, null, null, null
+        );
+        setField(card, "instanceId", UUID.randomUUID());
+        if (day != null) {
+            setField(card, "day", day);
+        }
+        return card;
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field field = PlaceCard.class.getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/verify/VerifyServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/verify/VerifyServiceTest.java
@@ -8,6 +8,7 @@ import com.tripkey.dto.placement.PlacementDay;
 import com.tripkey.dto.placement.PlacementDayItem;
 import com.tripkey.dto.placement.PlacementSaveRequest;
 import com.tripkey.dto.placement.PlacementSaveResponse;
+import com.tripkey.dto.placement.RouteWarning;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,6 +31,9 @@ class VerifyServiceTest {
 
     @Mock
     private PlaceCardRepository placeCardRepository;
+
+    @Mock
+    private RouteValidator routeValidator;
 
     @InjectMocks
     private VerifyService verifyService;
@@ -248,6 +252,35 @@ class VerifyServiceTest {
         assertThat(card.getDay()).isEqualTo(2);
         assertThat(card.getDayOrder()).isEqualTo((short) 1);
         assertThat(card.getEstimatedDurationMin()).isEqualTo((short) 60);
+    }
+
+    @Test
+    void verifyAndSaveIncludesRouteWarningsFromValidator() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+        RouteWarning warning = RouteWarning.duration(1, List.of(UUID.randomUUID()), 700);
+        when(routeValidator.validate(tripId)).thenReturn(List.of(warning));
+
+        PlacementSaveResponse response = verifyService.verifyAndSave(
+                tripId, new PlacementSaveRequest(List.of())
+        );
+
+        assertThat(response.routeWarnings()).containsExactly(warning);
+    }
+
+    @Test
+    void verifyAndSaveReturnsEmptyRouteWarningsWhenValidatorReturnsEmpty() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+        when(routeValidator.validate(tripId)).thenReturn(List.of());
+
+        PlacementSaveResponse response = verifyService.verifyAndSave(
+                tripId, new PlacementSaveRequest(List.of())
+        );
+
+        assertThat(response.routeWarnings()).isEmpty();
     }
 
     private PlaceCard placeCard(UUID tripId) {


### PR DESCRIPTION
## 📝 작업 내용

> SCR-04V verify 화면의 **동선 검증 로직** 구현. 거리/시간 conflict 를 BE 가 PostGIS 기반으로 계산해 `PlacementSaveResponse.route_warnings` 로 반환합니다.

- `RouteValidator` 신규 — 거리/시간 conflict 계산
- `RouteWarning` DTO 신규 + `PlacementSaveResponse.routeWarnings` 필드 추가 (backward-compat factory 유지)
- `VerifyService` / `ConfirmService` 양쪽 모두 verify 호출 시 on-demand 계산
- `PlaceCardRepository.findAdjacentCardDistances` PostGIS native query 추가

## 🔗 관련 이슈

closes #137

## 🗂️ 변경 범위

- [x] Backend (apps/backend)
- [x] 공통 / 설정 / 문서 — `api명세서.md` 및 `내부기술문서.md` 갱신 (gitignore 대상이라 commit 미포함)

## ⚠️ DB 변경 없음

- PostGIS 인프라 (V001) 그대로 활용 (`ST_DistanceSphere` + `idx_place_cards_geom` GiST 인덱스)
- 마이그레이션 / 새 테이블 / 새 컬럼 **없음**
- Supabase 사전 적용 불필요

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인 — `./gradlew test` BUILD SUCCESSFUL
- [x] 기존 기능이 깨지지 않았나요? — verify/confirm 기존 동작 회귀 확인 (snapshot 의미론 / skipped_instance_ids 등 유지)
- [x] 하드코딩된 값이나 임시 주석 없음
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 📌 채택 정책 (이슈 #137 baseline)

| 항목 | 값 |
|------|-----|
| 거리 conflict 기준 | Day 내 day_order 연속 카드 간 직선거리 |
| 거리 임계값 | **10,000m (10km)** 초과 시 경고 |
| 시간 conflict 기준 | Day 내 `estimated_duration_min` 합계 |
| 시간 임계값 | **600분 (10h)** 초과 시 경고 |
| 시간 합계 제외 | 숙소(accommodation) 만 |
| 검증 대상 제외 | `is_excluded=true` 카드 |
| 거리 silent 제외 | `lat/lng=null` 카드 |
| 계산 시점 | verify / confirm 매번 on-demand (저장 안 함) |

## 응답 예시

```json
{
  "saved": true,
  "trip_id": "...",
  "skipped_instance_ids": [],
  "route_warnings": [
    {
      "type": "distance",
      "day": 2,
      "instance_ids": ["uuid-a", "uuid-b"],
      "message": "인접 카드 간 거리 11.5km",
      "distance_meters": 11500,
      "total_minutes": null
    },
    {
      "type": "duration",
      "day": 3,
      "instance_ids": ["uuid-c", "uuid-d"],
      "message": "Day 3 활동 시간 합계 11시간",
      "distance_meters": null,
      "total_minutes": 660
    }
  ]
}
```

## 👀 리뷰어에게

### 집중 확인 부탁드리는 부분

1. **`VerifyService.verifyAndSave` 의 `placeCardRepository.flush()`** — JPA 변경사항을 PostGIS 쿼리 이전에 DB 에 반영하기 위한 호출. 단일 트랜잭션 내 read-your-writes 보장.

2. **`ConfirmService` 의 verify pass-through** — `verifyService.verifyAndSave` 의 `routeWarnings` 를 confirm 응답에 그대로 옮김 (재계산 안 함). verify 가 confirm 의 모든 동선 검증을 책임지는 단일 진실 점.

3. **거리 측정 단위** — `ST_DistanceSphere` 는 미터 단위 직선거리. 도보/이동수단 추천이 아닌 단순 거리 기준이라 도시 내 5km 같은 자연 이동도 임계값 안에 들어옵니다. 10km 는 "구역 점프" 수준의 강한 신호만 잡도록 보수적으로 설정.

4. **post-MVP 로 미룬 항목**:
   - `time_constraint` conflict (자유 텍스트 매칭 → 자연어 처리 필요)
   - Google Directions API 연동 (이동수단 추천 / 실제 이동시간)
   - conflict 결과 DB 영속화

## 📸 스크린샷

UI 변경 없음.
