### PR TITLE
refactor: scr-02 덤프페이지 사이드바 추가

### DIFF
--- a/apps/frontend/src/components/dump/DumpForm.css
+++ b/apps/frontend/src/components/dump/DumpForm.css
@@ -1,22 +1,44 @@
 .dump-form {
+  padding: 20px;
+  border-radius: 12px;
+  background-color: #ffffff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
+}
+
+.dump-form__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.dump-form__required {
+  color: #ef4444;
+  margin-left: 2px;
+}
+
+.dump-textarea-wrapper {
+  position: relative;
 }
 
 .dump-textarea {
   width: 100%;
-  min-height: 300px;
+  min-height: 280px;
   padding: 16px;
-  border: 1px solid #e0e0e0;
-  border-radius: 12px;
+  padding-bottom: 36px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
   background-color: #ffffff;
-  font-size: 15px;
+  font-size: 14px;
   line-height: 1.6;
   color: #1a1a1a;
   resize: none;
   box-sizing: border-box;
   outline: none;
+  font-family: inherit;
 }
 
 .dump-textarea:focus {
@@ -24,18 +46,20 @@
 }
 
 .dump-textarea::placeholder {
-  color: #aaaaaa;
-}
-
-.dump-status-message {
-  min-height: 20px;
-  margin: 0;
-  font-size: 13px;
-  color: #888888;
+  color: #9ca3af;
 }
 
 .dump-text-count {
-  margin-left: auto;
+  position: absolute;
+  bottom: 12px;
+  right: 16px;
   font-size: 13px;
-  color: #aaaaaa;
+  color: #9ca3af;
+  pointer-events: none;
+}
+
+.dump-status-message {
+  margin: 0;
+  font-size: 12px;
+  color: #9ca3af;
 }

--- a/apps/frontend/src/components/dump/DumpForm.tsx
+++ b/apps/frontend/src/components/dump/DumpForm.tsx
@@ -8,13 +8,18 @@ type DumpFormProps = {
   onTextChange: (nextDumpText: string) => void;
 };
 
+const PLACEHOLDER = `도쿄 여행 3박 4일 계획중이야`;
+
+const HELPER_TEXT =
+  '메모, 카톡 대화, 검색 기록 등을 자유롭게 붙여넣어 주세요 (최소 10자 이상)';
+
 const DumpForm = ({ dumpText, dumpTextCount, onTextChange }: DumpFormProps) => {
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onTextChange(event.target.value);
   };
 
   const getStatusMessage = () => {
-    if (dumpTextCount === 0) return '';
+    if (dumpTextCount === 0) return HELPER_TEXT;
 
     if (dumpTextCount < DUMP_TEXT.MIN_LENGTH) {
       return `${DUMP_TEXT.MIN_LENGTH - dumpTextCount}자 더 입력해주세요`;
@@ -27,23 +32,29 @@ const DumpForm = ({ dumpText, dumpTextCount, onTextChange }: DumpFormProps) => {
     if (dumpTextCount >= DUMP_TEXT.WARNING_LENGTH) {
       return '3000자에 가까워요!';
     }
-    return '';
+    return HELPER_TEXT;
   };
 
   return (
     <div className="dump-form">
-      <textarea
-        className="dump-textarea"
-        value={dumpText}
-        onChange={handleChange}
-        placeholder="여행에 대해 자유롭게 적어주세요."
-        maxLength={DUMP_TEXT.MAX_LENGTH}
-      />
+      <h2 className="dump-form__title">
+        여행 정보 <span className="dump-form__required">*</span>
+      </h2>
+
+      <div className="dump-textarea-wrapper">
+        <textarea
+          className="dump-textarea"
+          value={dumpText}
+          onChange={handleChange}
+          placeholder={PLACEHOLDER}
+          maxLength={DUMP_TEXT.MAX_LENGTH}
+        />
+        <div className="dump-text-count">
+          {dumpTextCount} / {DUMP_TEXT.MAX_LENGTH.toLocaleString()}
+        </div>
+      </div>
 
       <p className="dump-status-message">{getStatusMessage()}</p>
-      <div className="dump-text-count">
-        {dumpTextCount} / {DUMP_TEXT.MAX_LENGTH}
-      </div>
     </div>
   );
 };

--- a/apps/frontend/src/components/dump/DumpGuideCard.css
+++ b/apps/frontend/src/components/dump/DumpGuideCard.css
@@ -1,28 +1,85 @@
 .dump-guide-card {
-  padding: 16px;
-  border: 1px solid #e5e5e5;
-  border-radius: 8px;
+  padding: 20px;
+  border-radius: 12px;
   background-color: #ffffff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
 }
 
 .dump-guide-title {
-  margin: 0 0 12px;
+  margin: 0 0 16px;
   font-size: 15px;
   font-weight: 600;
+  color: #111827;
 }
 
 .dump-guide-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .dump-guide-item {
-  font-size: 14px;
-  line-height: 1.6;
-  color: #555555;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background-color: #ffffff;
+  cursor: pointer;
+  font-family: inherit;
 }
 
-.dump-guide-item + .dump-guide-item {
-  margin-top: 8px;
+.dump-guide-item:hover {
+  background-color: #fafafa;
+}
+
+.dump-guide-item__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+}
+
+.dump-guide-item__icon--flight {
+  background-color: #e0f2fe;
+  color: #0284c7;
+}
+
+.dump-guide-item__icon--reservation {
+  background-color: #fef3c7;
+  color: #d97706;
+}
+
+.dump-guide-item__label {
+  flex: 1;
+  text-align: left;
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.dump-guide-item__optional {
+  font-weight: 400;
+  color: #9ca3af;
+}
+
+.dump-guide-item__chevron {
+  color: #9ca3af;
+  transition: transform 0.2s;
+}
+
+.dump-guide-item__chevron[data-open='true'] {
+  transform: rotate(180deg);
+}
+
+.dump-guide-item__content {
+  padding: 16px;
+  border: 1px dashed #e5e7eb;
+  border-radius: 10px;
+  background-color: #f9fafb;
+  min-height: 60px;
 }

--- a/apps/frontend/src/components/dump/DumpGuideCard.tsx
+++ b/apps/frontend/src/components/dump/DumpGuideCard.tsx
@@ -1,26 +1,64 @@
+import { ChevronDown, Home, Plane } from 'lucide-react';
+import { useState } from 'react';
+
 import './DumpGuideCard.css';
 
-const guideItems = [
-  '가고 싶은 지역, 관광지, 맛집',
-  '원하는 여행 분위기나 스타일',
-  '시간 제약, 이동방식',
-];
-
 const DumpGuideCard = () => {
+  const [openFlight, setOpenFlight] = useState(false);
+  const [openReservation, setOpenReservation] = useState(false);
+
   return (
     <div className="dump-guide-card">
-      <h2 className="dump-guide-title">
-        여행 계획을 세우는 데 도움이 될 수 있도록, 다음과 같은 내용을 입력해
-        주세요.
-      </h2>
+      <h2 className="dump-guide-title">보조 정보 (선택)</h2>
 
-      <ul className="dump-guide-list">
-        {guideItems.map((item) => (
-          <li key={item} className="dump-guide-item">
-            {item}
-          </li>
-        ))}
-      </ul>
+      <div className="dump-guide-list">
+        <button
+          type="button"
+          className="dump-guide-item"
+          onClick={() => setOpenFlight((prev) => !prev)}
+        >
+          <span className="dump-guide-item__icon dump-guide-item__icon--flight">
+            <Plane size={16} />
+          </span>
+          <span className="dump-guide-item__label">
+            항공편 정보{' '}
+            <span className="dump-guide-item__optional">(선택)</span>
+          </span>
+          <ChevronDown
+            className="dump-guide-item__chevron"
+            data-open={openFlight}
+            size={18}
+          />
+        </button>
+        {openFlight && (
+          <div className="dump-guide-item__content">
+            {/* 항공편 정보 입력 영역 */}
+          </div>
+        )}
+
+        <button
+          type="button"
+          className="dump-guide-item"
+          onClick={() => setOpenReservation((prev) => !prev)}
+        >
+          <span className="dump-guide-item__icon dump-guide-item__icon--reservation">
+            <Home size={16} />
+          </span>
+          <span className="dump-guide-item__label">
+            숙박 정보 <span className="dump-guide-item__optional">(선택)</span>
+          </span>
+          <ChevronDown
+            className="dump-guide-item__chevron"
+            data-open={openReservation}
+            size={18}
+          />
+        </button>
+        {openReservation && (
+          <div className="dump-guide-item__content">
+            {/* 숙박 정보 입력 영역 */}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/frontend/src/components/grouping/TripSummaryCard.tsx
+++ b/apps/frontend/src/components/grouping/TripSummaryCard.tsx
@@ -18,6 +18,7 @@ import SummaryStatBadge from './SummaryStatBadge';
 type TripSummaryCardProps = TripSummaryViewModel & {
   onNext?: () => void;
   onPrev?: () => void;
+  nextDisabled?: boolean;
 };
 
 const TripSummaryCard = ({
@@ -31,6 +32,7 @@ const TripSummaryCard = ({
   completionPct,
   onNext,
   onPrev,
+  nextDisabled,
 }: TripSummaryCardProps) => {
   return (
     <div className="rounded-2xl bg-card p-6 shadow-sm ring-1 ring-foreground/10">
@@ -54,41 +56,53 @@ const TripSummaryCard = ({
           <span className="font-semibold text-foreground">{travelers}명</span>
         </SummaryRow>
 
-        <SummaryRow icon={CreditCard} label="전체 카드">
-          <span className="font-semibold text-foreground">{totalCards}개</span>
-          <span className="mt-1.5 flex flex-wrap gap-1">
-            {cardStats.map((stat) => (
-              <SummaryStatBadge
-                key={stat.label}
-                label={stat.label}
-                count={stat.count}
-                tone={stat.tone}
-              />
-            ))}
-          </span>
-        </SummaryRow>
+        {totalCards != null && (
+          <SummaryRow icon={CreditCard} label="전체 카드">
+            <span className="font-semibold text-foreground">
+              {totalCards}개
+            </span>
+            <span className="mt-1.5 flex flex-wrap gap-1">
+              {cardStats?.map((stat) => (
+                <SummaryStatBadge
+                  key={stat.label}
+                  label={stat.label}
+                  count={stat.count}
+                  tone={stat.tone}
+                />
+              ))}
+            </span>
+          </SummaryRow>
+        )}
       </ul>
 
       <Separator className="my-5" />
 
       {/* 정리 완료도 */}
-      <ProgressStat
-        label="정리 완료도"
-        value={completionPct}
-        valueSuffix="완료"
-      />
+      {completionPct != null && (
+        <ProgressStat
+          label="정리 완료도"
+          value={completionPct}
+          valueSuffix="완료"
+        />
+      )}
 
       <div className="mt-5 flex flex-col gap-2.5">
-        <Button onClick={onNext} className="h-11 w-full text-sm font-semibold">
+        <Button
+          onClick={onNext}
+          disabled={nextDisabled}
+          className="h-11 w-full text-sm font-semibold"
+        >
           다음 단계로
         </Button>
-        <Button
-          variant="outline"
-          onClick={onPrev}
-          className="h-11 w-full text-sm"
-        >
-          이전 단계
-        </Button>
+        {onPrev && (
+          <Button
+            variant="outline"
+            onClick={onPrev}
+            className="h-11 w-full text-sm"
+          >
+            이전 단계
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/DumpPage.css
+++ b/apps/frontend/src/pages/DumpPage.css
@@ -1,19 +1,30 @@
-/* 페이지 전체 영역 */
+/* 페이지 전체 영역 — 2컬럼 grid */
 .dump-page {
   background-color: #f5f5f5;
   min-height: 100vh;
-  display: flex;
+  display: grid;
+  grid-template-columns: 720px 380px; /* 본문 + 사이드바 (온보딩과 동일) */
   justify-content: center;
+  align-items: start; /* 사이드바 sticky용 */
 }
 
 /* 본문 영역 */
 .dump-container {
-  width: 600px;
-  padding: 32px 24px;
+  width: 720px;
+  padding: 40px 32px;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 16px;
   box-sizing: border-box;
+}
+
+/* 사이드바 */
+.dump-sidebar {
+  width: 380px;
+  padding: 40px 24px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
 }
 
 /* 페이지 제목 영역 */

--- a/apps/frontend/src/pages/DumpPage.tsx
+++ b/apps/frontend/src/pages/DumpPage.tsx
@@ -45,9 +45,14 @@ const DumpPage = () => {
   };
 
   const handleClickNext = async () => {
+    if (!tripId) {
+      navigate('/onboarding');
+      return;
+    }
+
     navigate('/progress');
 
-    const isSuccess = await submitDump(tripId!);
+    const isSuccess = await submitDump(tripId);
 
     if (!isSuccess) {
       navigate('/dump');

--- a/apps/frontend/src/pages/DumpPage.tsx
+++ b/apps/frontend/src/pages/DumpPage.tsx
@@ -1,8 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 
-import DumpActionBar from '../components/dump/DumpActionBar';
 import DumpForm from '../components/dump/DumpForm';
 import DumpGuideCard from '../components/dump/DumpGuideCard';
+import TripSummaryCard from '../components/grouping/TripSummaryCard';
+import {
+  useCalendarStore,
+  formatDateRangeLabel,
+} from '../utils/calendar-store';
 import { DUMP_TEXT } from '../utils/constants';
 import { useDumpStore } from '../utils/dump-store';
 import { useOnboardingStore } from '../utils/onboarding-store';
@@ -11,10 +15,21 @@ import './DumpPage.css';
 
 const DumpPage = () => {
   const tripId = useOnboardingStore((s) => s.tripId);
-  const { dumpText, requestStatus, errorMessage, actions } = useDumpStore();
+  const { dumpText, requestStatus, actions } = useDumpStore();
   const { setDumpText, submitDump } = actions;
 
+  const { destinations, companion_count } = useOnboardingStore((s) => s.form);
+  const { type, exactDate, flexDate } = useCalendarStore();
+
+  const dateRange = formatDateRangeLabel(type, exactDate, flexDate);
+  const nights = exactDate?.nights ?? flexDate?.nights ?? 0;
+
   const dumpTextCount = dumpText.trim().length;
+
+  const completionPct = Math.min(
+    100,
+    Math.round((dumpTextCount / DUMP_TEXT.MIN_LENGTH) * 100)
+  );
 
   const isNextDisabled =
     dumpTextCount < DUMP_TEXT.MIN_LENGTH || requestStatus === 'loading';
@@ -23,11 +38,11 @@ const DumpPage = () => {
     setDumpText(nextDumpText);
   };
 
-  const handleClickBack = () => {
-    navigate('/');
-  };
-
   const navigate = useNavigate();
+
+  const handleClickBack = () => {
+    navigate('/onboarding');
+  };
 
   const handleClickNext = async () => {
     navigate('/progress');
@@ -41,8 +56,6 @@ const DumpPage = () => {
 
   return (
     <main className="dump-page">
-      <div className="area">{/* 공통 컴포넌트 순서도 */}</div>
-
       <section className="dump-container">
         <div className="dump-header">
           <h1>여행 정보 입력</h1>
@@ -56,14 +69,21 @@ const DumpPage = () => {
           dumpTextCount={dumpTextCount}
           onTextChange={handleDumpTextChange}
         />
-
-        <DumpActionBar
-          onBack={handleClickBack}
-          onNext={handleClickNext}
-          isNextDisabled={isNextDisabled}
-          errorMessage={errorMessage}
-        />
       </section>
+
+      <aside className="dump-sidebar">
+        <TripSummaryCard
+          destinations={destinations.length ? destinations : ['-']}
+          dateRange={dateRange}
+          nights={nights}
+          days={nights + 1}
+          travelers={companion_count}
+          completionPct={completionPct}
+          onNext={handleClickNext}
+          onPrev={handleClickBack}
+          nextDisabled={isNextDisabled}
+        />
+      </aside>
     </main>
   );
 };

--- a/apps/frontend/src/types/grouping.ts
+++ b/apps/frontend/src/types/grouping.ts
@@ -255,11 +255,11 @@ export type TripSummaryViewModel = {
   //동행자
   travelers: number;
   //전체 카드 개수
-  totalCards: number;
+  totalCards?: number;
   //상태 상태 배지
-  cardStats: { label: string; count: number; tone: SummaryStatTone }[];
+  cardStats?: { label: string; count: number; tone: SummaryStatTone }[];
   //정리 완료도
-  completionPct: number;
+  completionPct?: number;
 };
 
 /** GroupingPage 가 통째로 받는 화면 데이터. fixture 의 최상위 형태. */

--- a/apps/frontend/src/utils/calendar-store.ts
+++ b/apps/frontend/src/utils/calendar-store.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import { create } from 'zustand';
 
 type ExactDate = { from: Date; to: Date; nights: number };
@@ -20,3 +21,17 @@ export const useCalendarStore = create<CalendarStore>((set) => ({
   setFlexDate: (value) => set({ type: 'flexible', flexDate: value }),
   clearExactDate: () => set({ type: null, exactDate: null }),
 }));
+
+export const formatDateRangeLabel = (
+  type: CalendarStore['type'],
+  exactDate: ExactDate | null,
+  flexDate: FlexDate | null
+): string => {
+  if (type === 'exact' && exactDate) {
+    return `${format(exactDate.from, 'M월d일')} ~ ${format(exactDate.to, 'M월d일')}`;
+  }
+  if (type === 'flexible' && flexDate) {
+    return `${flexDate.year}년 ${flexDate.month}월`;
+  }
+  return '-';
+};


### PR DESCRIPTION
## 📝 작업 내용

>  SCR-02 덤프 페이지 UI 리팩토링 — 사이드바 추가, 카드 스타일 정비, 컴포넌트 구조 개선

- **`TripSummaryCard` 재사용 처리**
  - 그루핑 전용이었던 컴포넌트를 덤프에서도 사용할 수 있도록 일부 prop optional 처리
  - 그루핑 전용 필드 3종 (`totalCards`, `cardStats`, `completionPct`) → `?` 변환
  - 컴포넌트 내부 조건부 렌더링으로 안전 처리
  - 입력 글자 수에 따른 버튼 비활성화 (`nextDisabled`) 지원

- **`DumpGuideCard` 재구성**
  - 텍스트 리스트 가이드 → 보조 정보(항공편/숙박) accordion UI 로 재설계
  - 펼침 내부 영역은 빈 슬롯 (실제 입력 폼은 후속 작업)

- **`DumpForm` 카드 스타일링**
  - "여행 정보 *" 헤더 추가
  - 카드 컨테이너 스타일 (배경/border-radius/shadow)
  - 글자 수 카운트를 textarea 우하단으로 이동
  - placeholder 및 helper text 갱신

- **`DumpActionBar` 제거**
  - 다음/이전 버튼을 사이드바로 통합 이동

- **유틸 분리**
  - 페이지에 인라인이던 날짜 포맷 로직을 `formatDateRangeLabel` 로 추출

## 🔗 관련 이슈

closes #142 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- `DumpPage 의 submitDump(tripId!) non-null assertion 은 onboarding-store persist 부재로 새로고침 시 tripId 손실 가능 → 다음 브랜치에서 함께 처리 예정
- 추후 UI 디테일 작업 또한 다음 브랜치에서 진행 예정

## 📸 스크린샷

<img width="1176" height="786" alt="image" src="https://github.com/user-attachments/assets/02fb989c-0cfa-446a-8d72-eb5e0be4a8fc" />