### PR TITLE
fix: 새로고침 시 tripId 및 여행정보 유실 수정

### DIFF
--- a/apps/frontend/src/components/onboarding/calendar/ExactCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/ExactCalendar.tsx
@@ -9,14 +9,15 @@ import { CalendarNav } from './CalendarNav';
 import './ExactCalendar.css';
 
 export const ExactCalendar = () => {
-  const [range, setRange] = useState<DateRange>({
-    from: undefined,
-    to: undefined,
-  });
-
   const setExactDate = useCalendarStore((s) => s.setExactDate);
   const clearExactDate = useCalendarStore((s) => s.clearExactDate);
+  const exactDate = useCalendarStore((s) => s.exactDate);
   const setForm = useOnboardingStore((s) => s.actions.setForm);
+
+  const [range, setRange] = useState<DateRange>(() => ({
+    from: exactDate?.from,
+    to: exactDate?.to,
+  }));
 
   const handleSelect = (newRange: DateRange | undefined) => {
     const from = newRange?.from;

--- a/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
@@ -5,12 +5,17 @@ import { useCalendarStore } from '@/utils/calendar-store';
 import { useOnboardingStore } from '@/utils/onboarding-store';
 
 const FlexCalendar = () => {
-  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
-  const [selectedMonth, setSelectedMonth] = useState<number | null>(null);
-  const [durationNights, setDurationNights] = useState(3);
-
+  const flexDate = useCalendarStore((s) => s.flexDate);
   const setFlexDate = useCalendarStore((s) => s.setFlexDate);
   const setForm = useOnboardingStore((s) => s.actions.setForm);
+
+  const [selectedYear, setSelectedYear] = useState(
+    flexDate?.year ?? new Date().getFullYear()
+  );
+  const [selectedMonth, setSelectedMonth] = useState<number | null>(
+    flexDate?.month ?? null
+  );
+  const [durationNights, setDurationNights] = useState(flexDate?.nights ?? 3);
 
   const currentYear = new Date().getFullYear();
 

--- a/apps/frontend/src/components/onboarding/calendar/TripCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/TripCalendar.tsx
@@ -1,11 +1,14 @@
 import './TripCalendar.css';
 import { useState } from 'react';
 
+import { useCalendarStore } from '@/utils/calendar-store';
+
 import { ExactCalendar } from './ExactCalendar';
 import FlexCalendar from './FlexCalendar';
 
 const TripCalendar = () => {
-  const [tab, setTab] = useState<'exact' | 'flexible'>('exact');
+  const storedTab = useCalendarStore((s) => s.type);
+  const [tab, setTab] = useState<'exact' | 'flexible'>(storedTab ?? 'exact');
 
   return (
     <div>

--- a/apps/frontend/src/utils/calendar-store.ts
+++ b/apps/frontend/src/utils/calendar-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 type ExactDate = { from: Date; to: Date; nights: number };
 type FlexDate = { year: number; month: number; nights: number };
@@ -12,11 +13,39 @@ type CalendarStore = {
   clearExactDate: () => void;
 };
 
-export const useCalendarStore = create<CalendarStore>((set) => ({
-  type: null,
-  exactDate: null,
-  flexDate: null,
-  setExactDate: (value) => set({ type: 'exact', exactDate: value }),
-  setFlexDate: (value) => set({ type: 'flexible', flexDate: value }),
-  clearExactDate: () => set({ type: null, exactDate: null }),
-}));
+export const useCalendarStore = create<CalendarStore>()(
+  persist(
+    (set) => ({
+      type: null,
+      exactDate: null,
+      flexDate: null,
+      setExactDate: (value) => set({ type: 'exact', exactDate: value }),
+      setFlexDate: (value) => set({ type: 'flexible', flexDate: value }),
+      clearExactDate: () => set({ type: null, exactDate: null }),
+    }),
+    {
+      name: 'calendar-storage',
+      partialize: (state) => ({
+        type: state.type,
+        exactDate: state.exactDate,
+        flexDate: state.flexDate,
+      }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<
+          Pick<CalendarStore, 'type' | 'exactDate' | 'flexDate'>
+        >;
+        return {
+          ...currentState,
+          ...persisted,
+          exactDate: persisted.exactDate
+            ? {
+                from: new Date(persisted.exactDate.from),
+                to: new Date(persisted.exactDate.to),
+                nights: persisted.exactDate.nights,
+              }
+            : null,
+        };
+      },
+    }
+  )
+);

--- a/apps/frontend/src/utils/onboarding-store.ts
+++ b/apps/frontend/src/utils/onboarding-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 import type { OnboardingRequest } from '../types/onboarding';
 
@@ -18,39 +19,50 @@ type OnboardingStore = {
   };
 };
 
-export const useOnboardingStore = create<OnboardingStore>()((set, get) => ({
-  form: {
-    destinations: [],
-    travel_days: 0,
-    companion_count: 1,
-    has_flight: false,
-    has_accommodation: false,
-  },
-  tripId: null,
-  requestStatus: 'idle',
-  errorMessage: null,
+export const useOnboardingStore = create<OnboardingStore>()(
+  persist(
+    (set, get) => ({
+      form: {
+        destinations: [],
+        travel_days: 0,
+        companion_count: 1,
+        has_flight: false,
+        has_accommodation: false,
+      },
+      tripId: null,
+      requestStatus: 'idle',
+      errorMessage: null,
 
-  actions: {
-    setForm: (partial) =>
-      set((state) => ({ form: { ...state.form, ...partial } })),
+      actions: {
+        setForm: (partial) =>
+          set((state) => ({ form: { ...state.form, ...partial } })),
 
-    submitOnboarding: async () => {
-      if (get().requestStatus === 'loading') return false;
-      set({ requestStatus: 'loading', errorMessage: null });
+        submitOnboarding: async () => {
+          if (get().requestStatus === 'loading') return false;
+          set({ requestStatus: 'loading', errorMessage: null });
 
-      try {
-        const result = await createTrip(get().form);
-        set({ requestStatus: 'success', tripId: result.trip_id });
-        return true;
-      } catch (error) {
-        set({
-          requestStatus: 'error',
-          errorMessage:
-            parseOnboardingApiError(error)?.message ??
-            '서버 통신 오류가 발생했습니다.',
-        });
-        return false;
-      }
-    },
-  },
-}));
+          try {
+            const result = await createTrip(get().form);
+            set({ requestStatus: 'success', tripId: result.trip_id });
+            return true;
+          } catch (error) {
+            set({
+              requestStatus: 'error',
+              errorMessage:
+                parseOnboardingApiError(error)?.message ??
+                '서버 통신 오류가 발생했습니다.',
+            });
+            return false;
+          }
+        },
+      },
+    }),
+    {
+      name: 'onboarding-storage',
+      partialize: (state) => ({
+        form: state.form,
+        tripId: state.tripId,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## 📝 작업 내용

> SCR-02 새로고침 시 `tripId` 및 여행 정보(여행지, 일정, 동행자 등) 가 유실되는 문제 수정

-  **`onboarding-store` persist 추가**
   - `partialize` 로 저장 대상 한정 (`form`, `tripId`)
   - `requestStatus`, `errorMessage` 등 임시 상태는 제외 

- **`calendar-store` persist 추가**
  - `partialize` 로 `type`, `exactDate`, `flexDate` 만 저장
  - `merge` 옵션으로 `Date` 객체 역직렬화 처리 (localStorage 는 string 으로 저장되므로 복원 시 `new Date()` 로 변환)

- **캘린더 컴포넌트 초기 상태 복원**
  - `ExactCalendar`: `useState` 초기값을 store 의 `exactDate` 로 설정
  - `FlexCalendar`: `useState` 초기값을 store 의 `flexDate` 로 설정
  - `TripCalendar`: 활성 탭(`exact`/`flexible`) 도 store 의 `type` 으로 복원

## 🔗 관련 이슈

closes #이슈번호

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.
- dump-ui-refactoring 보다 먼저 머지 예정.

- 새로고침 후에도 데이터가 영구히 남아 사용자가 "지금 진행 중인 여행" 외 데이터까지 보게 됨 → "새 여행 시작" 같은 명시적 초기화 액션 추가 검토 필요 

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.