### PR TITLE
feat: (ai) generate non-blocking alert cards safety

### DIFF
--- a/apps/ai-engine/app/prompts/non_blocking_enrichment.py
+++ b/apps/ai-engine/app/prompts/non_blocking_enrichment.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+from app.schemas.non_blocking_enrichment import NonBlockingEnrichmentRequest
+
+
+def build_non_blocking_enrichment_prompt(req: NonBlockingEnrichmentRequest) -> str:
+    payload = req.model_dump(mode="json")
+    return f"""
+You are TripKey's non-blocking enrichment engine.
+
+Review one already-parsed trip card and return only lightweight enrichments:
+- patches: optional, conservative suggestions for weak fields.
+- alert_cards: trip-level practical or insight alerts that help the traveler notice timing,
+  logistics, missing confirmation details, or destination-specific context.
+
+Rules:
+- Return valid JSON only. Do not wrap it in Markdown.
+- Do not rewrite the card itself.
+- Do not invent precise facts such as opening hours, ticket prices, reservation policies, or events
+  unless they are present in the input.
+- Prefer an empty patches array. Only use patches for low-risk suggestions.
+- Patch apply_mode must always be "suggestion"; never use "auto".
+- Patch only these fields: "tips", "estimated_duration_min", "tags", "user_context".
+- Never patch fields that require external verification: "address", "location", "place_id",
+  "coordinates", "search_alias", "check_in", "check_out", "flight_number", "flight_datetime".
+- Use alert_cards when the card implies a real traveler-facing risk or useful trip insight.
+- Use category "practical" for logistics, missing details, timing, or confirmation risks.
+- Use category "insight" for softer trip-planning advice derived from the card.
+- Alert scope must be "trip"; day must be null.
+- If card.instance_id is a UUID string and the alert is about this card, set related_instance_ids
+  to an array containing that instance_id. Otherwise use null.
+- If you cannot add useful enrichment, return empty arrays.
+- Keep Korean messages concise and directly actionable.
+
+Response schema:
+{{
+  "card_instance_id": "string | null",
+  "patches": [
+    {{
+      "field": "string",
+      "value": "any JSON value",
+      "apply_mode": "suggestion",
+      "confidence": "high" | "medium" | "low",
+      "reason": "string"
+    }}
+  ],
+  "alert_cards": [
+    {{
+      "id": "string",
+      "type": "string",
+      "category": "practical" | "insight",
+      "scope": "trip",
+      "day": null,
+      "message": "string",
+      "related_instance_ids": ["uuid"] | null
+    }}
+  ]
+}}
+
+Input:
+{json.dumps(payload, ensure_ascii=False)}
+""".strip()

--- a/apps/ai-engine/app/services/non_blocking_enrichment.py
+++ b/apps/ai-engine/app/services/non_blocking_enrichment.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 import uuid
 from datetime import datetime
 
+from app.prompts.non_blocking_enrichment import build_non_blocking_enrichment_prompt
 from app.schemas.non_blocking_enrichment import (
     EnrichmentPatch,
     NonBlockingEnrichmentRequest,
     NonBlockingEnrichmentResponse,
 )
 from app.schemas.parse import AlertCardResponse, AlertCategory, Category, FlightRole
+from app.services.core_parse import _call_gemini, _extract_json, _parse_alert_cards
+
+logger = logging.getLogger(__name__)
+
+SAFE_PATCH_FIELDS = {"tips", "estimated_duration_min", "tags", "user_context"}
 
 
 def _parse_iso_datetime(value: str | None) -> datetime | None:
@@ -79,9 +87,95 @@ def _build_patch_suggestions(req: NonBlockingEnrichmentRequest) -> list[Enrichme
     return patches
 
 
-async def enrich_card_non_blocking(req: NonBlockingEnrichmentRequest) -> NonBlockingEnrichmentResponse:
+def _fallback_response(req: NonBlockingEnrichmentRequest) -> NonBlockingEnrichmentResponse:
     return NonBlockingEnrichmentResponse(
         card_instance_id=req.card.instance_id,
         patches=_build_patch_suggestions(req),
         alert_cards=_build_transport_alerts(req),
     )
+
+
+def _parse_patches(raw_patches: list[dict]) -> list[EnrichmentPatch]:
+    patches: list[EnrichmentPatch] = []
+    for raw_patch in raw_patches:
+        if not isinstance(raw_patch, dict):
+            logger.warning("Skipping non-object enrichment patch | raw=%s", raw_patch)
+            continue
+
+        field = raw_patch.get("field")
+        if field not in SAFE_PATCH_FIELDS:
+            logger.warning("Skipping unsafe enrichment patch field=%s | raw=%s", field, raw_patch)
+            continue
+
+        if raw_patch.get("apply_mode") != "suggestion":
+            logger.warning("Skipping non-suggestion enrichment patch | raw=%s", raw_patch)
+            continue
+
+        try:
+            patches.append(EnrichmentPatch.model_validate(raw_patch))
+        except Exception as exc:
+            logger.warning("Skipping invalid enrichment patch | error=%s | raw=%s", exc, raw_patch)
+    return patches
+
+
+def _uuid_or_none(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        uuid.UUID(value)
+    except ValueError:
+        return None
+    return value
+
+
+def _attach_current_card_relation(
+    alerts: list[AlertCardResponse],
+    req: NonBlockingEnrichmentRequest,
+) -> list[AlertCardResponse]:
+    instance_id = _uuid_or_none(req.card.instance_id)
+    if not instance_id:
+        return alerts
+
+    related_alerts: list[AlertCardResponse] = []
+    for alert in alerts:
+        if alert.related_instance_ids:
+            related_alerts.append(alert)
+            continue
+        related_alerts.append(alert.model_copy(update={"related_instance_ids": [instance_id]}))
+    return related_alerts
+
+
+def _parse_ai_response(raw_text: str, req: NonBlockingEnrichmentRequest) -> NonBlockingEnrichmentResponse:
+    parsed = _extract_json(raw_text)
+
+    raw_patches = parsed.get("patches", [])
+    if raw_patches is None:
+        raw_patches = []
+    if not isinstance(raw_patches, list):
+        raise ValueError("patches must be an array when provided.")
+
+    raw_alerts = parsed.get("alert_cards", [])
+    if raw_alerts is None:
+        raw_alerts = []
+    if not isinstance(raw_alerts, list):
+        raise ValueError("alert_cards must be an array when provided.")
+
+    card_instance_id = parsed.get("card_instance_id", req.card.instance_id)
+    if card_instance_id is not None and not isinstance(card_instance_id, str):
+        card_instance_id = req.card.instance_id
+
+    return NonBlockingEnrichmentResponse(
+        card_instance_id=card_instance_id,
+        patches=_parse_patches(raw_patches),
+        alert_cards=_attach_current_card_relation(_parse_alert_cards(raw_alerts), req),
+    )
+
+
+async def enrich_card_non_blocking(req: NonBlockingEnrichmentRequest) -> NonBlockingEnrichmentResponse:
+    prompt = build_non_blocking_enrichment_prompt(req)
+    try:
+        raw_text = await asyncio.to_thread(_call_gemini, prompt)
+        return _parse_ai_response(raw_text, req)
+    except Exception as exc:
+        logger.warning("Falling back to rule-based non-blocking enrichment | trip_id=%s | error=%s", req.trip_id, exc)
+        return _fallback_response(req)

--- a/apps/ai-engine/tests/test_non_blocking_enrichment.py
+++ b/apps/ai-engine/tests/test_non_blocking_enrichment.py
@@ -1,14 +1,130 @@
+from uuid import uuid4
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
 from app.schemas.non_blocking_enrichment import EnrichmentCardSnapshot, NonBlockingEnrichmentRequest
 from app.schemas.parse import Category, Classification, FlightRole, PlacementStatus
+from app.services import non_blocking_enrichment
 from app.services.non_blocking_enrichment import enrich_card_non_blocking
 
 
+def _raise_gemini_error(_: str) -> str:
+    raise RuntimeError("boom")
+
+
 @pytest.mark.asyncio
-async def test_non_blocking_enrichment_generates_trip_scope_insight_alert() -> None:
+async def test_non_blocking_enrichment_uses_ai_alert_cards(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        non_blocking_enrichment,
+        "_call_gemini",
+        lambda _: """
+        {
+          "card_instance_id": "card-1",
+          "patches": [],
+          "alert_cards": [
+            {
+              "id": "alert-ai-1",
+              "type": "missing_reservation_detail",
+              "category": "practical",
+              "scope": "trip",
+              "day": null,
+              "message": "예약 확정 여부를 확인해두면 좋아요.",
+              "related_instance_ids": null
+            }
+          ]
+        }
+        """,
+    )
+
+    req = NonBlockingEnrichmentRequest(
+        trip_id="trip-1",
+        destinations=["오사카"],
+        card=EnrichmentCardSnapshot(
+            instance_id="card-1",
+            name="스시집 예약",
+            category=Category.FOOD,
+            classification=Classification.CONFIRMED,
+            placement_status=PlacementStatus.READY_PARTIAL,
+            time_constraint="저녁",
+        ),
+    )
+
+    result = await enrich_card_non_blocking(req)
+
+    assert result.card_instance_id == "card-1"
+    assert result.patches == []
+    assert len(result.alert_cards) == 1
+    assert result.alert_cards[0].id == "alert-ai-1"
+    assert result.alert_cards[0].category.value == "practical"
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_enrichment_filters_unsafe_ai_patches(monkeypatch: pytest.MonkeyPatch) -> None:
+    card_id = str(uuid4())
+    monkeypatch.setattr(
+        non_blocking_enrichment,
+        "_call_gemini",
+        lambda _: """
+        {
+          "card_instance_id": "card-id-from-ai",
+          "patches": [
+            {
+              "field": "address",
+              "value": "일본 〒282-0004 치바현 나리타시 후루고메 1-1",
+              "apply_mode": "auto",
+              "confidence": "high",
+              "reason": "Standard address for Narita International Airport."
+            },
+            {
+              "field": "tips",
+              "value": "방문 전 운영시간을 확인해보세요.",
+              "apply_mode": "suggestion",
+              "confidence": "medium",
+              "reason": "운영시간은 변동될 수 있습니다."
+            }
+          ],
+          "alert_cards": [
+            {
+              "id": "alert-ai-2",
+              "type": "late_arrival_notice",
+              "category": "practical",
+              "scope": "trip",
+              "day": null,
+              "message": "도착 후 시내 이동 시간을 확인해 주세요.",
+              "related_instance_ids": null
+            }
+          ]
+        }
+        """,
+    )
+
+    req = NonBlockingEnrichmentRequest(
+        trip_id="trip-1",
+        destinations=["도쿄"],
+        card=EnrichmentCardSnapshot(
+            instance_id=card_id,
+            name="ICN → NRT",
+            category=Category.TRANSPORT,
+            classification=Classification.CONFIRMED,
+            placement_status=PlacementStatus.READY,
+        ),
+    )
+
+    result = await enrich_card_non_blocking(req)
+
+    assert [patch.field for patch in result.patches] == ["tips"]
+    assert result.patches[0].apply_mode == "suggestion"
+    assert result.alert_cards[0].related_instance_ids == [card_id]
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_enrichment_falls_back_to_trip_scope_insight_alert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(non_blocking_enrichment, "_call_gemini", _raise_gemini_error)
+
     req = NonBlockingEnrichmentRequest(
         trip_id="trip-1",
         destinations=["도쿄"],
@@ -37,7 +153,11 @@ async def test_non_blocking_enrichment_generates_trip_scope_insight_alert() -> N
 
 
 @pytest.mark.asyncio
-async def test_non_blocking_enrichment_keeps_name_change_as_suggestion_only() -> None:
+async def test_non_blocking_enrichment_keeps_name_change_as_suggestion_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(non_blocking_enrichment, "_call_gemini", _raise_gemini_error)
+
     req = NonBlockingEnrichmentRequest(
         trip_id="trip-1",
         destinations=["오사카"],
@@ -58,7 +178,9 @@ async def test_non_blocking_enrichment_keeps_name_change_as_suggestion_only() ->
 
 
 @pytest.mark.asyncio
-async def test_non_blocking_enrichment_endpoint() -> None:
+async def test_non_blocking_enrichment_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(non_blocking_enrichment, "_call_gemini", _raise_gemini_error)
+
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post(
             "/internal/ai/enrich/non-blocking/card",


### PR DESCRIPTION
## 📝 작업 내용

> non-blocking enrichment 단계에서 AI가 alert_cards를 생성하도록 처리하고, patches는 안전한 suggestion 범위로 제한했습니다.

- card-level non-blocking enrichment에서 Gemini 기반 `alert_cards` 생성을 추가했습니다.
- Gemini 응답 파싱 실패 또는 호출 실패 시 기존 룰 기반 fallback을 유지했습니다.
- AI가 반환하는 `patches`는 `suggestion`만 허용하고, 안전한 필드만 통과하도록 제한했습니다.
- `address`, `location`, `place_id`, `coordinates`처럼 외부 검증이 필요한 patch는 응답에서 필터링합니다.
- UUID 기반 카드에서 생성된 alert는 현재 카드의 `related_instance_ids`로 연결되도록 후처리했습니다.
- AI alert 생성, unsafe patch 필터링, fallback 동작 테스트를 추가했습니다.

## 🔗 관련 이슈

closes #107

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

non-blocking enrichment의 `alert_cards` 생성은 AI Engine에서 처리하고, 저장 흐름은 기존 Backend의 `NonBlockingEnrichmentProcessor`가 담당합니다.

`patches`는 현재 백엔드에서 저장/적용하지 않으므로, 이번 PR에서는 AI 응답이 과도하게 카드 데이터를 수정하지 않도록 suggestion-only로 제한했습니다. 특히 주소, 좌표, place_id 등 검증이 필요한 값은 AI가 반환해도 필터링됩니다.
`patches`의 사용 또한 논의해야할 내용입니다.

카드 재처리 및 프론트에서 `alert_cards`를 어떻게 노출할지는 후속 이슈에서 별도로 다루는 것이 좋을 것 같습니다.

검증 명령:

```bash
cd apps/ai-engine
.venv/bin/python -m pytest
