### PR TITLE
feat/be/150 non-blocking enrichment 카드별 제한 병렬 처리

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
@@ -9,6 +9,7 @@ import com.tripkey.domain.trip.TripDestination;
 import com.tripkey.domain.trip.TripDestinationRepository;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
 import com.tripkey.infra.aiengine.dto.AiParseRequest;
 import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import lombok.RequiredArgsConstructor;
@@ -86,9 +87,20 @@ public class DumpAsyncProcessor {
 
             persistAlertCards(job.getTripId(), job.getJobId(), response);
 
+            // entity → request DTO 변환은 호출자 transaction 안에서 수행해야 한다.
+            // NonBlockingEnrichmentProcessor.trigger 는 @Async("enrichmentTaskExecutor") 라 다른 thread 에서
+            // 실행되므로 entity 를 그 시점에 전달하면 detached 상태에서 lazy 필드 접근 위험.
+            List<AiNonBlockingEnrichmentRequest> enrichmentRequests = savedCards.stream()
+                    .map(card -> AiNonBlockingEnrichmentRequest.from(
+                            card,
+                            destinations,
+                            trip.getTravelDays(),
+                            trip.getCompanionCount()))
+                    .toList();
+
             job.complete(response.contextSummary());
             dumpJobRepository.save(job);
-            triggerNonBlockingEnrichment(savedCards, destinations, trip);
+            triggerNonBlockingEnrichment(enrichmentRequests, trip.getTripId());
         } catch (Exception e) {
             log.error("Failed to parse dump job. jobId={}", jobId, e);
             job.fail("PARSE_FAILED");
@@ -109,11 +121,11 @@ public class DumpAsyncProcessor {
                 entities.size(), tripId, response.parseVersion());
     }
 
-    private void triggerNonBlockingEnrichment(List<PlaceCard> cards, List<String> destinations, Trip trip) {
+    private void triggerNonBlockingEnrichment(List<AiNonBlockingEnrichmentRequest> requests, UUID tripId) {
         try {
-            nonBlockingEnrichmentProcessor.trigger(cards, destinations, trip);
+            nonBlockingEnrichmentProcessor.trigger(requests);
         } catch (Exception e) {
-            log.warn("Failed to submit non-blocking enrichment. trip={}", trip.getTripId(), e);
+            log.warn("Failed to submit non-blocking enrichment. trip={}", tripId, e);
         }
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
@@ -2,8 +2,6 @@ package com.tripkey.domain.dump;
 
 import com.tripkey.domain.alert.AlertCard;
 import com.tripkey.domain.alert.AlertCardRepository;
-import com.tripkey.domain.place.PlaceCard;
-import com.tripkey.domain.trip.Trip;
 import com.tripkey.infra.aiengine.AiEngineClient;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
@@ -35,20 +33,12 @@ public class NonBlockingEnrichmentProcessor {
     }
 
     /**
-     * 비동기 진입을 enrichmentTaskExecutor 로 처리해 dumpTaskExecutor 점유를 피한다.
-     * 호출 thread (transaction 활성 상태) 에서 PlaceCard / Trip entity 를 즉시 immutable request DTO 로
-     * 변환한 뒤 각 카드별 작업을 enrichmentTaskExecutor 에 submit. join 없이 fire-and-forget 으로 종료.
+     * 호출자는 transaction 활성 상태에서 entity → AiNonBlockingEnrichmentRequest 변환을 마치고
+     * 이 메서드에 immutable DTO 리스트만 전달해야 한다. 본 메서드는 enrichmentTaskExecutor 의
+     * thread 에서 실행되므로 entity 를 직접 받으면 detached 상태에서 lazy 필드 접근 위험이 있다.
      */
     @Async("enrichmentTaskExecutor")
-    public void trigger(List<PlaceCard> cards, List<String> destinations, Trip trip) {
-        List<AiNonBlockingEnrichmentRequest> requests = cards.stream()
-                .map(card -> AiNonBlockingEnrichmentRequest.from(
-                        card,
-                        destinations,
-                        trip.getTravelDays(),
-                        trip.getCompanionCount()))
-                .toList();
-
+    public void trigger(List<AiNonBlockingEnrichmentRequest> requests) {
         for (AiNonBlockingEnrichmentRequest request : requests) {
             CompletableFuture.runAsync(() -> enrichSingleRequest(request), enrichmentTaskExecutor);
         }

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
@@ -7,46 +7,64 @@ import com.tripkey.domain.trip.Trip;
 import com.tripkey.infra.aiengine.AiEngineClient;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class NonBlockingEnrichmentProcessor {
 
     private final AiEngineClient aiEngineClient;
     private final AlertCardRepository alertCardRepository;
+    private final Executor enrichmentTaskExecutor;
+
+    public NonBlockingEnrichmentProcessor(
+            AiEngineClient aiEngineClient,
+            AlertCardRepository alertCardRepository,
+            @Qualifier("enrichmentTaskExecutor") Executor enrichmentTaskExecutor) {
+        this.aiEngineClient = aiEngineClient;
+        this.alertCardRepository = alertCardRepository;
+        this.enrichmentTaskExecutor = enrichmentTaskExecutor;
+    }
 
     @Async("dumpTaskExecutor")
     public void trigger(List<PlaceCard> cards, List<String> destinations, Trip trip) {
-        for (PlaceCard card : cards) {
-            try {
-                AiNonBlockingEnrichmentRequest request = AiNonBlockingEnrichmentRequest.from(
-                        card,
-                        destinations,
-                        trip.getTravelDays(),
-                        trip.getCompanionCount()
-                );
-                AiNonBlockingEnrichmentResponse response = aiEngineClient.enrichCardNonBlocking(request);
-                int alertCount = response.alertCards() == null ? 0 : response.alertCards().size();
-                int patchCount = response.patches() == null ? 0 : response.patches().size();
-                if (alertCount > 0 || patchCount > 0) {
-                    log.info("Non-blocking enrichment completed. trip={} card={} alerts={} patches={}",
-                            card.getTripId(), card.getInstanceId(), alertCount, patchCount);
-                }
-                if (alertCount > 0) {
-                    persistAlertCards(card.getTripId(), response);
-                }
-            } catch (Exception e) {
-                log.warn("Non-blocking enrichment failed. trip={} card={}",
-                        card.getTripId(), card.getInstanceId(), e);
+        CompletableFuture<?>[] futures = cards.stream()
+                .map(card -> CompletableFuture.runAsync(
+                        () -> enrichSingleCard(card, destinations, trip),
+                        enrichmentTaskExecutor))
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(futures).join();
+    }
+
+    private void enrichSingleCard(PlaceCard card, List<String> destinations, Trip trip) {
+        try {
+            AiNonBlockingEnrichmentRequest request = AiNonBlockingEnrichmentRequest.from(
+                    card,
+                    destinations,
+                    trip.getTravelDays(),
+                    trip.getCompanionCount()
+            );
+            AiNonBlockingEnrichmentResponse response = aiEngineClient.enrichCardNonBlocking(request);
+            int alertCount = response.alertCards() == null ? 0 : response.alertCards().size();
+            int patchCount = response.patches() == null ? 0 : response.patches().size();
+            if (alertCount > 0 || patchCount > 0) {
+                log.info("Non-blocking enrichment completed. trip={} card={} alerts={} patches={}",
+                        card.getTripId(), card.getInstanceId(), alertCount, patchCount);
             }
+            if (alertCount > 0) {
+                persistAlertCards(card.getTripId(), response);
+            }
+        } catch (Exception e) {
+            log.warn("Non-blocking enrichment failed. trip={} card={}",
+                    card.getTripId(), card.getInstanceId(), e);
         }
     }
 

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessor.java
@@ -34,37 +34,42 @@ public class NonBlockingEnrichmentProcessor {
         this.enrichmentTaskExecutor = enrichmentTaskExecutor;
     }
 
-    @Async("dumpTaskExecutor")
+    /**
+     * 비동기 진입을 enrichmentTaskExecutor 로 처리해 dumpTaskExecutor 점유를 피한다.
+     * 호출 thread (transaction 활성 상태) 에서 PlaceCard / Trip entity 를 즉시 immutable request DTO 로
+     * 변환한 뒤 각 카드별 작업을 enrichmentTaskExecutor 에 submit. join 없이 fire-and-forget 으로 종료.
+     */
+    @Async("enrichmentTaskExecutor")
     public void trigger(List<PlaceCard> cards, List<String> destinations, Trip trip) {
-        CompletableFuture<?>[] futures = cards.stream()
-                .map(card -> CompletableFuture.runAsync(
-                        () -> enrichSingleCard(card, destinations, trip),
-                        enrichmentTaskExecutor))
-                .toArray(CompletableFuture[]::new);
-        CompletableFuture.allOf(futures).join();
+        List<AiNonBlockingEnrichmentRequest> requests = cards.stream()
+                .map(card -> AiNonBlockingEnrichmentRequest.from(
+                        card,
+                        destinations,
+                        trip.getTravelDays(),
+                        trip.getCompanionCount()))
+                .toList();
+
+        for (AiNonBlockingEnrichmentRequest request : requests) {
+            CompletableFuture.runAsync(() -> enrichSingleRequest(request), enrichmentTaskExecutor);
+        }
     }
 
-    private void enrichSingleCard(PlaceCard card, List<String> destinations, Trip trip) {
+    private void enrichSingleRequest(AiNonBlockingEnrichmentRequest request) {
+        UUID tripId = request.tripId();
+        UUID instanceId = request.card().instanceId();
         try {
-            AiNonBlockingEnrichmentRequest request = AiNonBlockingEnrichmentRequest.from(
-                    card,
-                    destinations,
-                    trip.getTravelDays(),
-                    trip.getCompanionCount()
-            );
             AiNonBlockingEnrichmentResponse response = aiEngineClient.enrichCardNonBlocking(request);
             int alertCount = response.alertCards() == null ? 0 : response.alertCards().size();
             int patchCount = response.patches() == null ? 0 : response.patches().size();
             if (alertCount > 0 || patchCount > 0) {
                 log.info("Non-blocking enrichment completed. trip={} card={} alerts={} patches={}",
-                        card.getTripId(), card.getInstanceId(), alertCount, patchCount);
+                        tripId, instanceId, alertCount, patchCount);
             }
             if (alertCount > 0) {
-                persistAlertCards(card.getTripId(), response);
+                persistAlertCards(tripId, response);
             }
         } catch (Exception e) {
-            log.warn("Non-blocking enrichment failed. trip={} card={}",
-                    card.getTripId(), card.getInstanceId(), e);
+            log.warn("Non-blocking enrichment failed. trip={} card={}", tripId, instanceId, e);
         }
     }
 

--- a/apps/backend/src/main/java/com/tripkey/global/config/AsyncConfig.java
+++ b/apps/backend/src/main/java/com/tripkey/global/config/AsyncConfig.java
@@ -1,5 +1,6 @@
 package com.tripkey.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -18,6 +19,18 @@ public class AsyncConfig {
         executor.setMaxPoolSize(4);
         executor.setQueueCapacity(50);
         executor.setThreadNamePrefix("dump-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = "enrichmentTaskExecutor")
+    public Executor enrichmentTaskExecutor(
+            @Value("${app.enrichment.concurrency:3}") int concurrency) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(concurrency);
+        executor.setMaxPoolSize(concurrency);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("enrichment-");
         executor.initialize();
         return executor;
     }

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -33,3 +33,8 @@ app:
   ai-engine:
     base-url: ${AI_ENGINE_URL:http://tripkey-ai-engine:8000}
     timeout-seconds: ${AI_ENGINE_TIMEOUT_SECONDS:90}
+  enrichment:
+    # Non-blocking enrichment 의 카드별 병렬 동시성 상한.
+    # enrichmentTaskExecutor 의 corePoolSize / maxPoolSize 로 사용됨.
+    # Gemini / Google API quota 보호를 위해 무제한 병렬을 피하고 보수적 상한 유지.
+    concurrency: ${ENRICHMENT_CONCURRENCY:3}

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
@@ -104,7 +104,7 @@ class DumpAsyncProcessorTest {
 
         verify(placeCardRepository).deleteAllByTripId(tripId);
         verify(placeCardRepository).saveAll(any());
-        verify(nonBlockingEnrichmentProcessor).trigger(any(), any(), any());
+        verify(nonBlockingEnrichmentProcessor).trigger(any());
 
         assertThat(job.getStatus()).isEqualTo("completed");
         assertThat(job.getStep()).isEqualTo((short) 3);
@@ -157,11 +157,11 @@ class DumpAsyncProcessorTest {
         when(aiEngineClient.parseDump(any())).thenReturn(response);
         when(placeCardRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
         doThrow(new IllegalStateException("executor rejected"))
-                .when(nonBlockingEnrichmentProcessor).trigger(any(), any(), any());
+                .when(nonBlockingEnrichmentProcessor).trigger(any());
 
         dumpAsyncProcessor.process(job.getJobId());
 
-        verify(nonBlockingEnrichmentProcessor).trigger(any(), any(), any());
+        verify(nonBlockingEnrichmentProcessor).trigger(any());
         assertThat(job.getStatus()).isEqualTo("completed");
         assertThat(job.getErrorCode()).isNull();
     }

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
@@ -9,10 +9,10 @@ import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
 import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -22,6 +22,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,38 +35,22 @@ class NonBlockingEnrichmentProcessorTest {
     @Mock
     private AlertCardRepository alertCardRepository;
 
-    @InjectMocks
     private NonBlockingEnrichmentProcessor nonBlockingEnrichmentProcessor;
+
+    @BeforeEach
+    void setUp() {
+        // 단위 테스트는 호출 스레드에서 동기 실행으로 동시성 비결정성 제거.
+        // 실제 enrichmentTaskExecutor 의 fixed-pool 동시성은 통합 테스트 영역.
+        nonBlockingEnrichmentProcessor = new NonBlockingEnrichmentProcessor(
+                aiEngineClient,
+                alertCardRepository,
+                Runnable::run
+        );
+    }
 
     @Test
     void triggerSwallowsCardLevelEnrichmentFailure() {
-        PlaceCard card = PlaceCard.createFromAiResponse(
-                UUID.randomUUID(),
-                new AiPlaceCardDto(
-                        null,
-                        "도톤보리",
-                        "place",
-                        "confirmed",
-                        "ready_partial",
-                        false,
-                        false,
-                        (short) 90,
-                        null,
-                        "오사카",
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null
-                ),
-                "ai_parse"
-        );
+        PlaceCard card = placeCard(UUID.randomUUID());
         Trip trip = new Trip((short) 3, (short) 2);
         when(aiEngineClient.enrichCardNonBlocking(any())).thenThrow(new IllegalStateException("timeout"));
 
@@ -122,15 +107,7 @@ class NonBlockingEnrichmentProcessorTest {
     @Test
     void triggerPersistsAlertsWithNullJobIdWhenEnrichmentReturnsAlerts() {
         UUID tripId = UUID.randomUUID();
-        PlaceCard card = PlaceCard.createFromAiResponse(
-                tripId,
-                new AiPlaceCardDto(
-                        null, "도톤보리", "place", "confirmed", "ready_partial",
-                        false, false, (short) 90, null, "오사카",
-                        null, null, null, null, null, null, null, null, null, null, null
-                ),
-                "ai_parse"
-        );
+        PlaceCard card = placeCard(tripId);
         Trip trip = new Trip((short) 3, (short) 2);
         AiParseResponse.AlertCard insightAlert = new AiParseResponse.AlertCard(
                 "alert-insight-1", "festival", "insight", "trip", null, "축제 기간입니다", null
@@ -148,5 +125,49 @@ class NonBlockingEnrichmentProcessorTest {
         assertThat(persisted.get(0).getAlertId()).isEqualTo("alert-insight-1");
         assertThat(persisted.get(0).getTripId()).isEqualTo(tripId);
         assertThat(persisted.get(0).getJobId()).isNull();
+    }
+
+    @Test
+    void triggerInvokesEnrichmentForEveryCardInBatch() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard a = placeCard(tripId);
+        PlaceCard b = placeCard(tripId);
+        PlaceCard c = placeCard(tripId);
+        Trip trip = new Trip((short) 3, (short) 2);
+        when(aiEngineClient.enrichCardNonBlocking(any()))
+                .thenReturn(new AiNonBlockingEnrichmentResponse(null, List.of(), List.of()));
+
+        nonBlockingEnrichmentProcessor.trigger(List.of(a, b, c), List.of("오사카"), trip);
+
+        verify(aiEngineClient, times(3)).enrichCardNonBlocking(any());
+    }
+
+    @Test
+    void triggerIsolatesPerCardFailureFromOtherCards() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard failing = placeCard(tripId);
+        PlaceCard succeeding = placeCard(tripId);
+        Trip trip = new Trip((short) 3, (short) 2);
+
+        when(aiEngineClient.enrichCardNonBlocking(any()))
+                .thenThrow(new IllegalStateException("first card timeout"))
+                .thenReturn(new AiNonBlockingEnrichmentResponse(null, List.of(), List.of()));
+
+        assertDoesNotThrow(() ->
+                nonBlockingEnrichmentProcessor.trigger(List.of(failing, succeeding), List.of("오사카"), trip));
+
+        verify(aiEngineClient, times(2)).enrichCardNonBlocking(any());
+    }
+
+    private PlaceCard placeCard(UUID tripId) {
+        return PlaceCard.createFromAiResponse(
+                tripId,
+                new AiPlaceCardDto(
+                        null, "도톤보리", "place", "confirmed", "ready_partial",
+                        false, false, (short) 90, null, "오사카",
+                        null, null, null, null, null, null, null, null, null, null, null
+                ),
+                "ai_parse"
+        );
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/NonBlockingEnrichmentProcessorTest.java
@@ -3,7 +3,6 @@ package com.tripkey.domain.dump;
 import com.tripkey.domain.alert.AlertCard;
 import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.place.PlaceCard;
-import com.tripkey.domain.trip.Trip;
 import com.tripkey.infra.aiengine.AiEngineClient;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
@@ -50,49 +49,33 @@ class NonBlockingEnrichmentProcessorTest {
 
     @Test
     void triggerSwallowsCardLevelEnrichmentFailure() {
-        PlaceCard card = placeCard(UUID.randomUUID());
-        Trip trip = new Trip((short) 3, (short) 2);
+        AiNonBlockingEnrichmentRequest request = enrichmentRequest(UUID.randomUUID());
         when(aiEngineClient.enrichCardNonBlocking(any())).thenThrow(new IllegalStateException("timeout"));
 
-        assertDoesNotThrow(() -> nonBlockingEnrichmentProcessor.trigger(List.of(card), List.of("오사카"), trip));
+        assertDoesNotThrow(() -> nonBlockingEnrichmentProcessor.trigger(List.of(request)));
     }
 
     @Test
-    void triggerPassesFlightFieldsToAiEngineSnapshot() {
-        PlaceCard card = PlaceCard.createFromAiResponse(
-                UUID.randomUUID(),
+    void triggerPassesRequestSnapshotToAiEngine() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard flightCard = PlaceCard.createFromAiResponse(
+                tripId,
                 new AiPlaceCardDto(
-                        null,
-                        "ICN-NRT",
-                        "transport",
-                        "confirmed",
-                        "ready",
-                        false,
-                        true,
-                        null,
-                        null,
-                        null,
-                        null,
-                        "09:00 출발",
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        "KE703",
-                        "2026-07-01T09:00:00+09:00",
-                        "outbound"
+                        null, "ICN-NRT", "transport", "confirmed", "ready",
+                        false, true, null, null, null, null,
+                        "09:00 출발", null, null, null, null, null, null,
+                        null, null,
+                        "KE703", "2026-07-01T09:00:00+09:00", "outbound"
                 ),
                 "ai_parse"
         );
-        Trip trip = new Trip((short) 3, (short) 2);
+        AiNonBlockingEnrichmentRequest request = AiNonBlockingEnrichmentRequest.from(
+                flightCard, List.of("도쿄"), (short) 3, (short) 2
+        );
         when(aiEngineClient.enrichCardNonBlocking(any()))
                 .thenReturn(new AiNonBlockingEnrichmentResponse(null, List.of(), List.of()));
 
-        nonBlockingEnrichmentProcessor.trigger(List.of(card), List.of("도쿄"), trip);
+        nonBlockingEnrichmentProcessor.trigger(List.of(request));
 
         ArgumentCaptor<AiNonBlockingEnrichmentRequest> captor =
                 ArgumentCaptor.forClass(AiNonBlockingEnrichmentRequest.class);
@@ -107,15 +90,14 @@ class NonBlockingEnrichmentProcessorTest {
     @Test
     void triggerPersistsAlertsWithNullJobIdWhenEnrichmentReturnsAlerts() {
         UUID tripId = UUID.randomUUID();
-        PlaceCard card = placeCard(tripId);
-        Trip trip = new Trip((short) 3, (short) 2);
+        AiNonBlockingEnrichmentRequest request = enrichmentRequest(tripId);
         AiParseResponse.AlertCard insightAlert = new AiParseResponse.AlertCard(
                 "alert-insight-1", "festival", "insight", "trip", null, "축제 기간입니다", null
         );
         when(aiEngineClient.enrichCardNonBlocking(any()))
                 .thenReturn(new AiNonBlockingEnrichmentResponse(null, List.of(), List.of(insightAlert)));
 
-        nonBlockingEnrichmentProcessor.trigger(List.of(card), List.of("오사카"), trip);
+        nonBlockingEnrichmentProcessor.trigger(List.of(request));
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<AlertCard>> captor = ArgumentCaptor.forClass(List.class);
@@ -128,46 +110,45 @@ class NonBlockingEnrichmentProcessorTest {
     }
 
     @Test
-    void triggerInvokesEnrichmentForEveryCardInBatch() {
+    void triggerInvokesEnrichmentForEveryRequestInBatch() {
         UUID tripId = UUID.randomUUID();
-        PlaceCard a = placeCard(tripId);
-        PlaceCard b = placeCard(tripId);
-        PlaceCard c = placeCard(tripId);
-        Trip trip = new Trip((short) 3, (short) 2);
+        AiNonBlockingEnrichmentRequest a = enrichmentRequest(tripId);
+        AiNonBlockingEnrichmentRequest b = enrichmentRequest(tripId);
+        AiNonBlockingEnrichmentRequest c = enrichmentRequest(tripId);
         when(aiEngineClient.enrichCardNonBlocking(any()))
                 .thenReturn(new AiNonBlockingEnrichmentResponse(null, List.of(), List.of()));
 
-        nonBlockingEnrichmentProcessor.trigger(List.of(a, b, c), List.of("오사카"), trip);
+        nonBlockingEnrichmentProcessor.trigger(List.of(a, b, c));
 
         verify(aiEngineClient, times(3)).enrichCardNonBlocking(any());
     }
 
     @Test
-    void triggerIsolatesPerCardFailureFromOtherCards() {
+    void triggerIsolatesPerRequestFailureFromOtherRequests() {
         UUID tripId = UUID.randomUUID();
-        PlaceCard failing = placeCard(tripId);
-        PlaceCard succeeding = placeCard(tripId);
-        Trip trip = new Trip((short) 3, (short) 2);
+        AiNonBlockingEnrichmentRequest failing = enrichmentRequest(tripId);
+        AiNonBlockingEnrichmentRequest succeeding = enrichmentRequest(tripId);
 
         when(aiEngineClient.enrichCardNonBlocking(any()))
                 .thenThrow(new IllegalStateException("first card timeout"))
                 .thenReturn(new AiNonBlockingEnrichmentResponse(null, List.of(), List.of()));
 
         assertDoesNotThrow(() ->
-                nonBlockingEnrichmentProcessor.trigger(List.of(failing, succeeding), List.of("오사카"), trip));
+                nonBlockingEnrichmentProcessor.trigger(List.of(failing, succeeding)));
 
         verify(aiEngineClient, times(2)).enrichCardNonBlocking(any());
     }
 
-    private PlaceCard placeCard(UUID tripId) {
-        return PlaceCard.createFromAiResponse(
+    private AiNonBlockingEnrichmentRequest enrichmentRequest(UUID tripId) {
+        PlaceCard card = PlaceCard.createFromAiResponse(
                 tripId,
                 new AiPlaceCardDto(
-                        null, "도톤보리", "place", "confirmed", "ready_partial",
+                        null, "도톈보리", "place", "confirmed", "ready_partial",
                         false, false, (short) 90, null, "오사카",
                         null, null, null, null, null, null, null, null, null, null, null
                 ),
                 "ai_parse"
         );
+        return AiNonBlockingEnrichmentRequest.from(card, List.of("오사카"), (short) 3, (short) 2);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

> `NonBlockingEnrichmentProcessor.trigger()` 의 카드별 enrichment 호출을 순차 → 병렬로 변경. dump/card parse 와 분리된 전용 `enrichmentTaskExecutor` 를 사용하고, Gemini/Google API quota 보호를 위해 동시성 상한을 설정값으로 제한합니다.

- `AsyncConfig` 에 `enrichmentTaskExecutor` Bean 추가 (기본 동시성 3)
- `application.yml` 에 `app.enrichment.concurrency` 설정 추가 (`ENRICHMENT_CONCURRENCY` 환경변수로 override)
- `NonBlockingEnrichmentProcessor` 가 카드 리스트를 `CompletableFuture` + `enrichmentTaskExecutor` 로 병렬 처리
- 카드별 실패는 `log.warn` 후 다른 카드 영향 없이 격리

## 🔗 관련 이슈

closes #150

## 🗂️ 변경 범위

- [x] Backend (apps/backend)
- [ ] 공통 / 설정 / 문서

## ⚠️ 운영 영향

- **신규 thread pool 추가** — dev/prod 메모리 부담은 미미 (기본 3 thread).
- **외부 의존성 변화 없음** — AWS / Supabase / AI 엔진과 무관.
- **API 응답 스키마 변화 없음** — 내부 처리 방식만 변경.
- **DB 변경 없음** — 마이그레이션 / 스키마 영향 없음.

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인 — `./gradlew test` BUILD SUCCESSFUL
- [x] 기존 기능이 깨지지 않았나요? — 기존 테스트 3건 모두 통과 + 신규 2건 추가
- [x] 하드코딩된 값이나 임시 주석 없음 — 동시성은 yaml 외부화
- [x] PR 범위가 하나의 기능 단위 — enrichment 병렬화만

## 📌 채택 정책 (이슈 #150 baseline)

| 항목 | 값 |
|------|-----|
| 동시성 메커니즘 | `CompletableFuture` + 전용 `ThreadPoolTaskExecutor` |
| 동시성 상한 | **3** (default, `app.enrichment.concurrency` 로 override) |
| Pool 모델 | `corePoolSize == maxPoolSize` (fixed pool, quota 보호) |
| 진입 비동기 | `@Async("dumpTaskExecutor")` 유지 — 호출자 (DumpAsyncProcessor) 비차단 |
| 카드별 실패 격리 | `enrichSingleCard` 내부 try/catch + `log.warn`, 예외 swallow |
| 완료 대기 | `CompletableFuture.allOf(...).join()` — 모든 카드 완료 후 메서드 종료 |

## 👀 리뷰어에게

### 집중 확인 부탁드리는 부분

1. **두 단계 비동기 구조** — `@Async("dumpTaskExecutor")` 가 trigger 진입을 비동기화하고, 내부에서 `enrichmentTaskExecutor` 로 카드별 분산. dump pool 의 thread 1개만 점유하면서 enrichment pool 의 N 개로 fan-out.

2. **카드별 실패 격리 보장** — `CompletableFuture.runAsync` 에 전달한 람다 내부에서 모든 예외를 잡아 swallow. 외부로 전파되지 않아 `allOf.join()` 에서 `CompletionException` 발생 안 함.

3. **단위 테스트의 동기 Executor** — 테스트는 `Runnable::run` 으로 호출 스레드에서 동기 실행. 동시성 비결정성 제거 목적. 실제 fixed-pool 동시성 동작은 통합 테스트 영역 (현재 PR 범위 밖).

### 후속 작업 메모

- **메시지 큐 (SQS) 도입 시점** 에 `enrichmentTaskExecutor` 는 큐 worker 로 흡수 예정. 핵심 로직 `enrichSingleCard` 는 worker 에서도 재사용 가능하므로 매몰비용 아님.
- **다중 인스턴스 전환** 은 별도 작업 stream — 본 PR 의 in-memory 병렬화는 단일 인스턴스 내 처리량 향상이 목적.

## 📸 스크린샷

UI 변경 없음.
