### PR TITLE
refactor: TripSummaryCard 통일 및 공통 Header 적용

### DIFF
--- a/apps/frontend/src/components/grouping/TripSummaryCard.tsx
+++ b/apps/frontend/src/components/grouping/TripSummaryCard.tsx
@@ -4,6 +4,7 @@ import {
   CreditCard,
   MapPin,
   User,
+  ClipboardCheck,
   type LucideIcon,
 } from 'lucide-react';
 import { type ReactNode } from 'react';
@@ -28,6 +29,7 @@ const TripSummaryCard = ({
   days,
   travelers,
   totalCards,
+  reservation,
   cardStats,
   completionPct,
   onNext,
@@ -55,6 +57,12 @@ const TripSummaryCard = ({
         <SummaryRow icon={User} label="동행자">
           <span className="font-semibold text-foreground">{travelers}명</span>
         </SummaryRow>
+
+        {reservation && (
+          <SummaryRow icon={ClipboardCheck} label="예약 완료">
+            <span className="font-semibold text-foreground">{reservation}</span>
+          </SummaryRow>
+        )}
 
         {totalCards != null && (
           <SummaryRow icon={CreditCard} label="전체 카드">

--- a/apps/frontend/src/components/header/Header.tsx
+++ b/apps/frontend/src/components/header/Header.tsx
@@ -12,12 +12,13 @@ export type StepId = 'onboarding' | 'dump' | 'organize' | 'arrange' | 'confirm';
 export type Step = {
   id: StepId;
   label: string;
+  path?: string;
 };
 
 const STEPS: Step[] = [
-  { id: 'onboarding', label: '온보딩' },
-  { id: 'dump', label: '덤프' },
-  { id: 'organize', label: '정리' },
+  { id: 'onboarding', label: '온보딩', path: '/onboarding' },
+  { id: 'dump', label: '덤프', path: '/dump' },
+  { id: 'organize', label: '정리', path: '/grouping' },
   { id: 'arrange', label: '배치' },
   { id: 'confirm', label: '확정' },
 ];
@@ -121,15 +122,29 @@ const Stepper = ({ currentIndex }: { currentIndex: number }) => {
                 aria-current="step"
                 className="rounded-full bg-primary px-3.5 py-1 font-medium text-primary-foreground"
               >
-                {step.label}
+                {step.path ? (
+                  <Link to={step.path}>{step.label}</Link> // 개발용 링크
+                ) : (
+                  step.label
+                )}
               </span>
             ) : status === 'done' ? (
               <span className="flex items-center gap-1 font-medium text-primary">
                 <Check className="h-4 w-4" aria-hidden="true" />
-                {step.label}
+                {step.path ? (
+                  <Link to={step.path}>{step.label}</Link> // 개발용 링크
+                ) : (
+                  step.label
+                )}
               </span>
             ) : (
-              <span className="text-muted-foreground">{step.label}</span>
+              <span className="text-muted-foreground">
+                {step.path ? (
+                  <Link to={step.path}>{step.label}</Link> // 개발용 링크
+                ) : (
+                  step.label
+                )}
+              </span>
             )}
             {!isLast && (
               <span aria-hidden="true" className="h-px w-6 bg-border" />

--- a/apps/frontend/src/pages/DumpPage.tsx
+++ b/apps/frontend/src/pages/DumpPage.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import DumpForm from '../components/dump/DumpForm';
 import DumpGuideCard from '../components/dump/DumpGuideCard';
 import TripSummaryCard from '../components/grouping/TripSummaryCard';
+import Header from '../components/header/Header';
+import { Button } from '../components/ui/button';
 import {
   useCalendarStore,
   formatDateRangeLabel,
@@ -60,36 +62,50 @@ const DumpPage = () => {
   };
 
   return (
-    <main className="dump-page">
-      <section className="dump-container">
-        <div className="dump-header">
-          <h1>여행 정보 입력</h1>
-          <p>가고 싶은 곳, 하고 싶은 것, 떠오르는 생각을 자유롭게 적어주세요</p>
-        </div>
+    <>
+      <Header
+        currentStepId="dump"
+        actions={
+          <>
+            <Button variant="outline" size="sm">
+              초기화
+            </Button>
+          </>
+        }
+      />
+      <main className="dump-page">
+        <section className="dump-container">
+          <div className="dump-header">
+            <h1>여행 정보 입력</h1>
+            <p>
+              가고 싶은 곳, 하고 싶은 것, 떠오르는 생각을 자유롭게 적어주세요
+            </p>
+          </div>
 
-        <DumpGuideCard />
+          <DumpGuideCard />
 
-        <DumpForm
-          dumpText={dumpText}
-          dumpTextCount={dumpTextCount}
-          onTextChange={handleDumpTextChange}
-        />
-      </section>
+          <DumpForm
+            dumpText={dumpText}
+            dumpTextCount={dumpTextCount}
+            onTextChange={handleDumpTextChange}
+          />
+        </section>
 
-      <aside className="dump-sidebar">
-        <TripSummaryCard
-          destinations={destinations.length ? destinations : ['-']}
-          dateRange={dateRange}
-          nights={nights}
-          days={nights + 1}
-          travelers={companion_count}
-          completionPct={completionPct}
-          onNext={handleClickNext}
-          onPrev={handleClickBack}
-          nextDisabled={isNextDisabled}
-        />
-      </aside>
-    </main>
+        <aside className="dump-sidebar">
+          <TripSummaryCard
+            destinations={destinations.length ? destinations : ['-']}
+            dateRange={dateRange}
+            nights={nights}
+            days={nights + 1}
+            travelers={companion_count}
+            completionPct={completionPct}
+            onNext={handleClickNext}
+            onPrev={handleClickBack}
+            nextDisabled={isNextDisabled}
+          />
+        </aside>
+      </main>
+    </>
   );
 };
 

--- a/apps/frontend/src/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/pages/OnboardingPage.tsx
@@ -1,10 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 
+import Header from '../components/header/Header';
 import TripCalendar from '../components/onboarding/calendar/TripCalendar';
 import OnboardingForm from '../components/onboarding/OnboardingForm';
 import TravelerCount from '../components/onboarding/TravelerCount';
 import TravelerReservation from '../components/onboarding/TravelerReservation';
 import TripSummary from '../components/summary/TripSummary';
+import { Button } from '../components/ui/button';
 import { useOnboardingStore } from '../utils/onboarding-store';
 import './OnboardingPage.css';
 
@@ -19,63 +21,75 @@ const OnboardingPage = () => {
   };
 
   return (
-    <div className="onboarding-page">
-      <main className="onboarding-page__main">
-        <header className="onboarding-page__header">
-          <h1 className="onboarding-page__title">여행 기본 정보</h1>
-          <p className="onboarding-page__desc">
-            어디로, 얼마나, 누구와 떠나나요
-          </p>
-        </header>
+    <>
+      <Header
+        currentStepId="onboarding"
+        actions={
+          <>
+            <Button variant="outline" size="sm">
+              초기화
+            </Button>
+          </>
+        }
+      />
+      <div className="onboarding-page">
+        <main className="onboarding-page__main">
+          <header className="onboarding-page__header">
+            <h1 className="onboarding-page__title">여행 기본 정보</h1>
+            <p className="onboarding-page__desc">
+              어디로, 얼마나, 누구와 떠나나요
+            </p>
+          </header>
 
-        <div className="onboarding-page__body">
-          <section className="onboarding-page__card">
-            <OnboardingForm
-              title="여행 이름"
-              name="tripName"
-              placeholder="여행의 이름을 입력하세요"
-              subtitle="여행을 구분할 수 있는 이름을 자유롭게 입력하세요."
-            />
-          </section>
+          <div className="onboarding-page__body">
+            <section className="onboarding-page__card">
+              <OnboardingForm
+                title="여행 이름"
+                name="tripName"
+                placeholder="여행의 이름을 입력하세요"
+                subtitle="여행을 구분할 수 있는 이름을 자유롭게 입력하세요."
+              />
+            </section>
 
-          <section className="onboarding-page__card">
-            <OnboardingForm
-              title="여행지"
-              placeholder="도시명을 검색하세요"
-              subtitle="복수 선택 가능. 1개 이상 필수"
-              type="destination"
-            />
-          </section>
+            <section className="onboarding-page__card">
+              <OnboardingForm
+                title="여행지"
+                placeholder="도시명을 검색하세요"
+                subtitle="복수 선택 가능. 1개 이상 필수"
+                type="destination"
+              />
+            </section>
 
-          <section className="onboarding-page__card onboarding-page__calendar">
-            <h2 className="onboarding-page__section-title">여행 일정</h2>
+            <section className="onboarding-page__card onboarding-page__calendar">
+              <h2 className="onboarding-page__section-title">여행 일정</h2>
 
-            <div className="onboarding-page__calendar-area">
-              <TripCalendar />
-            </div>
-          </section>
+              <div className="onboarding-page__calendar-area">
+                <TripCalendar />
+              </div>
+            </section>
 
-          <section className="onboarding-page__card onboarding-page__traveler">
-            <TravelerCount title="동행자 수" />
-            <TravelerReservation title="여행 예약 상태" />
-          </section>
-        </div>
-      </main>
+            <section className="onboarding-page__card onboarding-page__traveler">
+              <TravelerCount title="동행자 수" />
+              <TravelerReservation title="여행 예약 상태" />
+            </section>
+          </div>
+        </main>
 
-      <aside className="onboarding-page__sidebar">
-        <TripSummary
-          items={[
-            { icon: '✈️', label: '여행지', isNextDisabled: true },
-            { icon: '📅', label: '일정', isNextDisabled: true },
-            { icon: '👥', label: '동행자' },
-            { icon: '✅', label: '예약완료' },
-          ]}
-          onNext={handleNext}
-          errorMessage={errorMessage}
-          stateMessage="여행지와 일정을 입력하면 다음 단계로 진행할 수 있어요"
-        />
-      </aside>
-    </div>
+        <aside className="onboarding-page__sidebar">
+          <TripSummary
+            items={[
+              { icon: '✈️', label: '여행지', isNextDisabled: true },
+              { icon: '📅', label: '일정', isNextDisabled: true },
+              { icon: '👥', label: '동행자' },
+              { icon: '✅', label: '예약완료' },
+            ]}
+            onNext={handleNext}
+            errorMessage={errorMessage}
+            stateMessage="여행지와 일정을 입력하면 다음 단계로 진행할 수 있어요"
+          />
+        </aside>
+      </div>
+    </>
   );
 };
 

--- a/apps/frontend/src/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/pages/OnboardingPage.tsx
@@ -1,19 +1,50 @@
 import { useNavigate } from 'react-router-dom';
 
+import TripSummaryCard from '../components/grouping/TripSummaryCard';
 import Header from '../components/header/Header';
 import TripCalendar from '../components/onboarding/calendar/TripCalendar';
 import OnboardingForm from '../components/onboarding/OnboardingForm';
 import TravelerCount from '../components/onboarding/TravelerCount';
 import TravelerReservation from '../components/onboarding/TravelerReservation';
-import TripSummary from '../components/summary/TripSummary';
 import { Button } from '../components/ui/button';
+import {
+  useCalendarStore,
+  formatDateRangeLabel,
+} from '../utils/calendar-store';
 import { useOnboardingStore } from '../utils/onboarding-store';
 import './OnboardingPage.css';
 
 const OnboardingPage = () => {
   const navigate = useNavigate();
   const { submitOnboarding } = useOnboardingStore((s) => s.actions);
-  const errorMessage = useOnboardingStore((s) => s.errorMessage);
+  // const errorMessage = useOnboardingStore((s) => s.errorMessage);
+
+  const { destinations, companion_count, has_flight, has_accommodation } =
+    useOnboardingStore((s) => s.form);
+  const { type, exactDate, flexDate } = useCalendarStore();
+
+  const dateRange = formatDateRangeLabel(type, exactDate, flexDate);
+  const nights = exactDate?.nights ?? flexDate?.nights ?? 0;
+
+  const reservation = [has_flight && '항공편', has_accommodation && '숙소']
+    .filter(Boolean)
+    .join(', ');
+
+  const hasDestination = destinations.length > 0;
+  const hasSchedule = type !== null;
+  const filledCount = [hasDestination, hasSchedule].filter(Boolean).length;
+  const completionPct = (filledCount / 2) * 100;
+  const isNextDisabled = filledCount < 2;
+
+  const summary = {
+    destinations: destinations.length ? destinations : ['-'],
+    dateRange,
+    nights,
+    days: nights + 1,
+    travelers: companion_count,
+    reservation: reservation || undefined,
+    completionPct,
+  };
 
   const handleNext = async () => {
     const success = await submitOnboarding();
@@ -25,11 +56,9 @@ const OnboardingPage = () => {
       <Header
         currentStepId="onboarding"
         actions={
-          <>
-            <Button variant="outline" size="sm">
-              초기화
-            </Button>
-          </>
+          <Button variant="outline" size="sm">
+            초기화
+          </Button>
         }
       />
       <div className="onboarding-page">
@@ -76,16 +105,10 @@ const OnboardingPage = () => {
         </main>
 
         <aside className="onboarding-page__sidebar">
-          <TripSummary
-            items={[
-              { icon: '✈️', label: '여행지', isNextDisabled: true },
-              { icon: '📅', label: '일정', isNextDisabled: true },
-              { icon: '👥', label: '동행자' },
-              { icon: '✅', label: '예약완료' },
-            ]}
+          <TripSummaryCard
+            {...summary}
             onNext={handleNext}
-            errorMessage={errorMessage}
-            stateMessage="여행지와 일정을 입력하면 다음 단계로 진행할 수 있어요"
+            nextDisabled={isNextDisabled}
           />
         </aside>
       </div>

--- a/apps/frontend/src/types/grouping.ts
+++ b/apps/frontend/src/types/grouping.ts
@@ -254,6 +254,8 @@ export type TripSummaryViewModel = {
   days: number;
   //동행자
   travelers: number;
+  //예약 여부
+  reservation?: string;
   //전체 카드 개수
   totalCards?: number;
   //상태 상태 배지

--- a/apps/frontend/src/utils/calendar-store.ts
+++ b/apps/frontend/src/utils/calendar-store.ts
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 type ExactDate = { from: Date; to: Date; nights: number };
 type FlexDate = { year: number; month: number; nights: number };
@@ -26,6 +26,7 @@ export const useCalendarStore = create<CalendarStore>()(
     }),
     {
       name: 'calendar-storage',
+      storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         type: state.type,
         exactDate: state.exactDate,

--- a/apps/frontend/src/utils/dump-store.ts
+++ b/apps/frontend/src/utils/dump-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 import { DUMP_TEXT } from './constants';
 import { submitDumpText, parseDumpApiError } from './dump-api';
@@ -79,6 +79,7 @@ export const useDumpStore = create<DumpStore>()(
     }),
     {
       name: 'dump-storage',
+      storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         dumpText:
           state.dumpText.length >= DUMP_TEXT.MIN_LENGTH ? state.dumpText : '',

--- a/apps/frontend/src/utils/onboarding-store.ts
+++ b/apps/frontend/src/utils/onboarding-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 import type { OnboardingRequest } from '../types/onboarding';
 
@@ -59,6 +59,7 @@ export const useOnboardingStore = create<OnboardingStore>()(
     }),
     {
       name: 'onboarding-storage',
+      storage: createJSONStorage(() => sessionStorage),
       partialize: (state) => ({
         form: state.form,
         tripId: state.tripId,


### PR DESCRIPTION
## 📝 작업 내용

> 페이지별 공통 Header 적용 및 OnboardingPage 사이드바를 TripSummaryCard 로 통일


- **공통 Header 적용**
  - Onboarding / Dump 페이지 `Header` 컴포넌트 적용
  - 헤더의 step 네비게이션에 라우트 경로 추가 (개발용 임시 링크)

- **사이드바 통일 — OnboardingPage**
  - 기존 `TripSummary` → `TripSummaryCard` 로 교체

- **`TripSummaryCard` 확장**
  - `reservation?` prop 추가 — 항공편/숙소 예약 표시 영역
  - 그루핑/덤프 페이지는 영향 없음

- **persist 저장소를 sessionStorage 로 변경**
  - `onboarding-store`, `calendar-store`, `dump-store` 의 persist storage 를 `localStorage` → `sessionStorage` 로 통일
  - 탭 종료 시 자동 초기화되어 "찌꺼기 데이터" 문제 해결

## 🔗 관련 이슈

closes #148 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- 진행도 표시는 임시로 그루핑 기본 라벨(`정리 완료도 / X% 완료`) 그대로 사용 중입니다. 페이지별 커스텀(`입력 완료도 / N/M` 등) 은 후속 작업으로 분리 예정.

- 헤더의 "초기화" 버튼은 자리만 잡아두었고, 실제 store 초기화 로직 및 헤더 상태관리는 후속 PR 에서 처리 예정.

## 📸 스크린샷

<img width="1113" height="662" alt="image" src="https://github.com/user-attachments/assets/3d8468e2-adc7-41d4-87c8-4f9122177ced" />