### PR TITLE
feat(be): dump API 항공편 구조화 입력 수용

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
@@ -64,7 +64,10 @@ public class DumpAsyncProcessor {
                     job.getDumpText(),
                     destinations,
                     trip.getTravelDays(),
-                    trip.getCompanionCount()
+                    trip.getCompanionCount(),
+                    null,
+                    deserializeFlight(job.getDepartureFlight()),
+                    deserializeFlight(job.getReturnFlight())
             );
 
             AiParseResponse response = aiEngineClient.parseDump(request);
@@ -113,6 +116,17 @@ public class DumpAsyncProcessor {
             return objectMapper.writeValueAsString(request);
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Failed to serialize enrichment request", e);
+        }
+    }
+
+    private AiParseRequest.FlightInput deserializeFlight(String json) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(json, AiParseRequest.FlightInput.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize flight input", e);
         }
     }
 

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpController.java
@@ -28,7 +28,7 @@ public class DumpController {
             @PathVariable UUID tripId,
             @Valid @RequestBody DumpSubmitRequest request) {
 
-        DumpSubmitResponse response = dumpService.submit(tripId, request.dumpText());
+        DumpSubmitResponse response = dumpService.submit(tripId, request);
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(response);
     }
 

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJob.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJob.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -36,6 +38,14 @@ public class DumpJob {
     @Column(name = "context_summary", columnDefinition = "text")
     private String contextSummary;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "departure_flight", columnDefinition = "jsonb")
+    private String departureFlight;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "return_flight", columnDefinition = "jsonb")
+    private String returnFlight;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
@@ -43,10 +53,17 @@ public class DumpJob {
     private OffsetDateTime updatedAt;
 
     public static DumpJob create(UUID tripId, String dumpText) {
+        return create(tripId, dumpText, null, null);
+    }
+
+    public static DumpJob create(UUID tripId, String dumpText,
+                                 String departureFlight, String returnFlight) {
         DumpJob job = new DumpJob();
         job.jobId = UUID.randomUUID();
         job.tripId = tripId;
         job.dumpText = dumpText;
+        job.departureFlight = departureFlight;
+        job.returnFlight = returnFlight;
         job.status = "pending";
         job.step = null;
         return job;

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpService.java
@@ -1,9 +1,12 @@
 package com.tripkey.domain.dump;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tripkey.common.exception.DumpNotFoundException;
 import com.tripkey.common.exception.DumpUrlNotAllowedException;
 import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.dump.DumpSubmitRequest;
 import com.tripkey.dto.dump.DumpSubmitResponse;
 import com.tripkey.dto.dump.ParseJobStatusResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,17 +27,23 @@ public class DumpService {
     private final DumpJobRepository dumpJobRepository;
     private final TripRepository tripRepository;
     private final DumpAsyncProcessor dumpAsyncProcessor;
+    private final ObjectMapper objectMapper;
 
-    public DumpSubmitResponse submit(UUID tripId, String dumpText) {
+    public DumpSubmitResponse submit(UUID tripId, DumpSubmitRequest request) {
         if (!tripRepository.existsById(tripId)) {
             throw new TripNotFoundException(tripId);
         }
 
+        String dumpText = request.dumpText();
         if (URL_PATTERN.matcher(dumpText).find()) {
             throw new DumpUrlNotAllowedException();
         }
 
-        DumpJob job = DumpJob.create(tripId, dumpText);
+        DumpJob job = DumpJob.create(
+                tripId,
+                dumpText,
+                serializeFlight(request.departureFlight()),
+                serializeFlight(request.returnFlight()));
         dumpJobRepository.save(job);
         dumpAsyncProcessor.process(job.getJobId());
 
@@ -47,5 +56,16 @@ public class DumpService {
                 .orElseThrow(() -> new DumpNotFoundException(tripId, jobId));
 
         return new ParseJobStatusResponse(job.getJobId(), job.getStatus(), job.getStep(), job.getErrorCode());
+    }
+
+    private String serializeFlight(DumpSubmitRequest.FlightInput flight) {
+        if (flight == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(flight);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize flight input", e);
+        }
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/dump/DumpSubmitRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/dump/DumpSubmitRequest.java
@@ -1,11 +1,28 @@
 package com.tripkey.dto.dump;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record DumpSubmitRequest(
         @NotBlank
         @Size(min = 10, max = 3000, message = "10자 이상 3000자 이하로 입력해주세요")
-        String dumpText
+        String dumpText,
+
+        @JsonProperty("departure_flight")
+        FlightInput departureFlight,
+
+        @JsonProperty("return_flight")
+        FlightInput returnFlight
 ) {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record FlightInput(
+            @JsonProperty("departure_airport") String departureAirport,
+            @JsonProperty("arrival_airport") String arrivalAirport,
+            @JsonProperty("flight_number") String flightNumber,
+            String datetime
+    ) {
+    }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
@@ -9,6 +9,7 @@ import com.tripkey.domain.trip.TripDestination;
 import com.tripkey.domain.trip.TripDestinationRepository;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiParseRequest;
 import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -197,5 +198,37 @@ class DumpAsyncProcessorTest {
 
         verify(alertCardRepository, never()).deleteByTripIdAndAlertIdIn(any(), any());
         verify(alertCardRepository, never()).saveAll(any());
+    }
+
+    @Test
+    void processPassesStoredFlightsToParseRequest() {
+        UUID tripId = UUID.randomUUID();
+        String depJson = "{\"departure_airport\":\"ICN\",\"arrival_airport\":\"NRT\",\"flight_number\":\"KE703\",\"datetime\":\"2026-07-01T09:00:00+09:00\"}";
+        DumpJob job = DumpJob.create(tripId, "오사카 3박4일 여행입니다.", depJson, null);
+        Trip trip = new Trip((short) 4, (short) 2);
+        TripDestination destination = new TripDestination(trip, "오사카", (short) 0);
+
+        AiPlaceCardDto card = new AiPlaceCardDto(
+                "place-1", "도톈보리", "place", "confirmed", "ready_partial",
+                false, false, (short) 90, null, "오사카",
+                null, null, null, null, null, null, null, List.of(), null, null, null);
+        AiParseResponse response = new AiParseResponse(List.of(card), "요약", List.of(), "3.2.0");
+
+        when(dumpJobRepository.findById(job.getJobId())).thenReturn(Optional.of(job));
+        when(dumpJobRepository.save(any(DumpJob.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
+        when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(tripId)).thenReturn(List.of(destination));
+        when(placeCardRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        org.mockito.ArgumentCaptor<AiParseRequest> captor = org.mockito.ArgumentCaptor.forClass(AiParseRequest.class);
+        when(aiEngineClient.parseDump(captor.capture())).thenReturn(response);
+
+        dumpAsyncProcessor.process(job.getJobId());
+
+        AiParseRequest sent = captor.getValue();
+        assertThat(sent.departureFlight()).isNotNull();
+        assertThat(sent.departureFlight().departureAirport()).isEqualTo("ICN");
+        assertThat(sent.departureFlight().flightNumber()).isEqualTo("KE703");
+        assertThat(sent.returnFlight()).isNull();
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpJobFlightInputIntegrationTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpJobFlightInputIntegrationTest.java
@@ -1,0 +1,53 @@
+package com.tripkey.domain.dump;
+
+import com.tripkey.domain.trip.Trip;
+import com.tripkey.domain.trip.TripRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Testcontainers
+class DumpJobFlightInputIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgis/postgis:16-3.4").asCompatibleSubstituteFor("postgres"))
+            .withInitScript("postgis-test-schema.sql");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        r.add("spring.datasource.username", POSTGRES::getUsername);
+        r.add("spring.datasource.password", POSTGRES::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    }
+
+    @Autowired DumpJobRepository dumpJobRepository;
+    @Autowired TripRepository tripRepository;
+
+    @Test
+    void dumpJobPersistsFlightJsonbRoundTrip() {
+        Trip trip = new Trip((short) 3, (short) 1);
+        tripRepository.saveAndFlush(trip);
+        String depJson = "{\"departure_airport\":\"ICN\",\"arrival_airport\":\"NRT\",\"flight_number\":\"KE703\",\"datetime\":\"2026-07-01T09:00:00+09:00\"}";
+
+        DumpJob job = DumpJob.create(trip.getTripId(), "오사카 3박4일 여행입니다.", depJson, null);
+        dumpJobRepository.saveAndFlush(job);
+
+        DumpJob reloaded = dumpJobRepository.findById(job.getJobId()).orElseThrow();
+        assertThat(reloaded.getDepartureFlight()).contains("ICN").contains("KE703");
+        assertThat(reloaded.getReturnFlight()).isNull();
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpServiceTest.java
@@ -1,13 +1,16 @@
 package com.tripkey.domain.dump;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tripkey.domain.place.PlaceCardRepository;
 import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.dump.DumpSubmitRequest;
 import com.tripkey.dto.dump.DumpSubmitResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.UUID;
@@ -32,6 +35,9 @@ class DumpServiceTest {
     @Mock
     private DumpAsyncProcessor dumpAsyncProcessor;
 
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
     @InjectMocks
     private DumpService dumpService;
 
@@ -41,7 +47,8 @@ class DumpServiceTest {
         when(tripRepository.existsById(tripId)).thenReturn(true);
         when(dumpJobRepository.save(any(DumpJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        DumpSubmitResponse response = dumpService.submit(tripId, "오사카 3박4일 여행입니다.");
+        DumpSubmitRequest req = new DumpSubmitRequest("오사카 3박4일 여행입니다.", null, null);
+        DumpSubmitResponse response = dumpService.submit(tripId, req);
 
         ArgumentCaptor<DumpJob> jobCaptor = ArgumentCaptor.forClass(DumpJob.class);
         verify(dumpJobRepository).save(jobCaptor.capture());
@@ -51,5 +58,23 @@ class DumpServiceTest {
         assertThat(savedJob.getTripId()).isEqualTo(tripId);
         assertThat(response.jobId()).isEqualTo(savedJob.getJobId());
         assertThat(response.status()).isEqualTo("pending");
+    }
+
+    @Test
+    void submitStoresStructuredFlightsOnDumpJob() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        org.mockito.ArgumentCaptor<DumpJob> jobCaptor = org.mockito.ArgumentCaptor.forClass(DumpJob.class);
+        when(dumpJobRepository.save(jobCaptor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        DumpSubmitRequest.FlightInput dep =
+                new DumpSubmitRequest.FlightInput("ICN", "NRT", "KE703", "2026-07-01T09:00:00+09:00");
+        DumpSubmitRequest req = new DumpSubmitRequest("오사카 3박4일 여행입니다.", dep, null);
+
+        dumpService.submit(tripId, req);
+
+        DumpJob saved = jobCaptor.getValue();
+        assertThat(saved.getDepartureFlight()).contains("ICN").contains("KE703");
+        assertThat(saved.getReturnFlight()).isNull();
     }
 }

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -30,7 +30,9 @@ create table dump_jobs (
   status          text        not null,
   step            smallint,
   error_code      text,
-  context_summary text,
+  context_summary  text,
+  departure_flight jsonb,
+  return_flight    jsonb,
   created_at      timestamptz not null default now(),
   updated_at      timestamptz not null default now()
 );

--- a/shared/docs/migrations/V008__dump_jobs_flight_inputs.sql
+++ b/shared/docs/migrations/V008__dump_jobs_flight_inputs.sql
@@ -1,0 +1,10 @@
+-- TripKey migration: dump_jobs 항공편 구조화 입력 컬럼
+-- Date: 2026-05-27
+-- Scope: /trips/{tripId}/dump 가 departure_flight/return_flight(구조화)를 받아 비동기 처리 시
+--        AiParseRequest 로 전달하기 위해 DumpJob 에 jsonb 로 영속화한다.
+-- 적용 대상: Supabase (단일 인스턴스). 적용 방법: SQL Editor 전체 실행 (멱등).
+-- 동기 산출물: schema.sql / postgis-test-schema.sql / DumpJob 엔티티.
+
+alter table public.dump_jobs
+  add column if not exists departure_flight jsonb,
+  add column if not exists return_flight    jsonb;

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -32,7 +32,9 @@ create table if not exists public.dump_jobs (
   status          text        not null,                            -- 작업 상태: pending / processing / completed / failed
   step            smallint,                                        -- 파싱 진행 단계 (1~3), null이면 미시작
   error_code      text,                                            -- 실패 시 오류 코드: PARSE_FAILED / NO_PLACES_FOUND
-  context_summary text,                                            -- AI가 파악한 여행 스타일 요약
+  context_summary  text,                                            -- AI가 파악한 여행 스타일 요약
+  departure_flight jsonb,                                           -- 출발 항공편 구조화 입력 (FlightInput JSON)
+  return_flight    jsonb,                                           -- 귀국 항공편 구조화 입력 (FlightInput JSON)
   created_at      timestamptz not null default now(),
   updated_at      timestamptz not null default now()
 );


### PR DESCRIPTION
## 📝 작업 내용

> `/trips/{tripId}/dump` 가 구조화된 항공편(`departure_flight`/`return_flight`)을 받아 AI 파싱으로 전달하도록 확장

- FE가 항공편을 구조화 입력으로 보내도 기존엔 `dump_text`만 받아 전달되지 못하던 문제를 해결.
- 체인 연결: `DumpSubmitRequest`(departure_flight/return_flight 추가) → `DumpService`(JSON 직렬화) → `DumpJob`(jsonb 영속화) → `DumpAsyncProcessor`(역직렬화) → `AiParseRequest`(8-arg) → AI 엔진.
- AI 엔진(`/internal/ai/parse`)은 두 항공편 + flight_role 세팅을 **이미 완전 지원** → BE 배관만 연결.
- 항공편 필드 모두 nullable(미입력 허용). `accommodation_inputs`는 범위 밖.

## 🔗 관련 이슈

closes #이슈번호  <!-- [FEAT] dump API 항공편 구조화 입력 수용 이슈 번호로 교체 -->

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)  <!-- 변경 없음 (기존 지원) -->
- [x] 공통 / 설정 / 문서 (마이그레이션 V008, schema.sql, postgis-test-schema.sql)

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? — 전체 스위트 그린(단위 + Testcontainers jsonb 왕복)
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — `DumpJob.create` 2-arg 오버로드 유지, enrichment/outbox 로직 무손상, 기존 테스트 통과
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? — dump 항공편 입력 수용 단일 단위

## 👀 리뷰어에게

> - **직렬화 왕복**: `DumpSubmitRequest.FlightInput`(저장 직렬화)과 `AiParseRequest.FlightInput`(역직렬화)이 동일한 `@JsonProperty` snake_case(departure_airport/arrival_airport/flight_number/datetime)라, ObjectMapper 설정과 무관하게 라운드트립이 일치합니다.
> - **저장 위치**: 비동기 처리가 jobId로 DB에서 Job을 로드하므로 항공편을 `dump_jobs`(jsonb)에 영속화해야 전달됩니다.
> - **에러 처리**: 직렬화/역직렬화 실패는 `IllegalStateException`으로 감싸지고, `process()`의 catch가 `PARSE_FAILED`로 잡아 카드가 processing에 갇히지 않습니다.
>
> **배포 마이그레이션:** [x] 단일 Supabase에 `shared/docs/migrations/V008__dump_jobs_flight_inputs.sql` 적용 — **완료** (컬럼 nullable, 코드 부팅 전 적용 완료).
>
> follow-up(비차단): schema 정렬 공백 정리, 양쪽 항공편 동시 입력 테스트(대칭 코드라 단방향 테스트로 메커니즘 커버됨).

## 📸 스크린샷

UI 변경 없음 (Backend 전용).