### PR TITLE
refactor: SummaryCard 진행도 문구 및 Header summary props 연결

### DIFF
--- a/apps/frontend/src/components/common/ProgressStat.tsx
+++ b/apps/frontend/src/components/common/ProgressStat.tsx
@@ -7,8 +7,8 @@ type ProgressStatProps = {
   label: string;
   /** 0~100 */
   value: number;
-  /** 퍼센트 뒤에 붙는 텍스트(예: "완료"). 기본은 "%" 만 표시 */
-  valueSuffix?: string;
+  /** 우측 표시 텍스트(예: "50% 완료", "3자 남음"). 미지정 시 `${value}%` */
+  valueLabel?: string;
   /** 막대 아래 보조 설명 */
   caption?: string;
   /** 카드 박스(rounded/bg/ring/padding)로 감쌀지. 기본 false(상위 카드 안에 끼워 쓰는 용도) */
@@ -19,7 +19,7 @@ type ProgressStatProps = {
 const ProgressStat = ({
   label,
   value,
-  valueSuffix,
+  valueLabel,
   caption,
   boxed = false,
   className,
@@ -36,7 +36,7 @@ const ProgressStat = ({
           {label}
         </span>
         <span className="text-sm font-bold text-primary tabular-nums">
-          {value}%{valueSuffix ? ` ${valueSuffix}` : ''}
+          {valueLabel ?? `${value}%`}
         </span>
       </div>
 

--- a/apps/frontend/src/components/grouping/TripSummaryCard.tsx
+++ b/apps/frontend/src/components/grouping/TripSummaryCard.tsx
@@ -1,5 +1,6 @@
 // TripSummaryCard — 우측 sticky 사이드바의 "여행 요약" 카드
 import {
+  AlertCircle,
   Calendar,
   CreditCard,
   MapPin,
@@ -20,6 +21,10 @@ type TripSummaryCardProps = TripSummaryViewModel & {
   onNext?: () => void;
   onPrev?: () => void;
   nextDisabled?: boolean;
+  progressLabel?: string;
+  progressValueLabel?: string;
+  guideText?: string;
+  errorMessage?: string | null;
 };
 
 const TripSummaryCard = ({
@@ -35,6 +40,10 @@ const TripSummaryCard = ({
   onNext,
   onPrev,
   nextDisabled,
+  progressLabel = '정리 완료도',
+  progressValueLabel,
+  guideText,
+  errorMessage,
 }: TripSummaryCardProps) => {
   return (
     <div className="rounded-2xl bg-card p-6 shadow-sm ring-1 ring-foreground/10">
@@ -88,9 +97,9 @@ const TripSummaryCard = ({
       {/* 정리 완료도 */}
       {completionPct != null && (
         <ProgressStat
-          label="정리 완료도"
+          label={progressLabel}
           value={completionPct}
-          valueSuffix="완료"
+          valueLabel={progressValueLabel ?? `${completionPct}% 완료`}
         />
       )}
 
@@ -112,6 +121,18 @@ const TripSummaryCard = ({
           </Button>
         )}
       </div>
+      {nextDisabled && guideText && (
+        <p className="mt-3 text-xs text-muted-foreground">{guideText}</p>
+      )}
+      {errorMessage && (
+        <p className="mt-3 flex items-start gap-1.5 border-l-2 border-destructive pl-2.5 text-xs text-destructive">
+          <AlertCircle
+            className="mt-0.5 size-3.5 shrink-0"
+            aria-hidden="true"
+          />
+          <span>{errorMessage}</span>
+        </p>
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/pages/DumpPage.tsx
+++ b/apps/frontend/src/pages/DumpPage.tsx
@@ -27,7 +27,8 @@ const DumpPage = () => {
   const tripId = useOnboardingStore((s) => s.tripId);
   const { destinations, companion_count } = useOnboardingStore((s) => s.form);
   const { type, exactDate, flexDate } = useCalendarStore();
-  const { dumpText, requestStatus, jobId, actions } = useDumpStore();
+  const { dumpText, requestStatus, errorMessage, jobId, actions } =
+    useDumpStore();
   const { setDumpText, submitDump, clearJob } = actions;
 
   const view = useParseJobStatus(tripId, jobId);
@@ -55,6 +56,19 @@ const DumpPage = () => {
     100,
     Math.round((dumpTextCount / DUMP_TEXT.MIN_LENGTH) * 100)
   );
+
+  const remainingChars = Math.max(0, DUMP_TEXT.MIN_LENGTH - dumpTextCount);
+  const progressValueLabel =
+    remainingChars > 0 ? `${remainingChars}자 남음` : '준비 완료';
+
+  const summary = {
+    destinations: destinations.length ? destinations : ['-'],
+    dateRange,
+    nights,
+    days: nights + 1,
+    travelers: companion_count,
+    completionPct,
+  };
 
   const isNextDisabled =
     dumpTextCount < DUMP_TEXT.MIN_LENGTH || requestStatus === 'loading';
@@ -105,6 +119,10 @@ const DumpPage = () => {
     <>
       <Header
         currentStepId="dump"
+        destination={summary.destinations[0] ?? '여행'}
+        extraDestinations={Math.max(summary.destinations.length - 1, 0)}
+        travelers={summary.travelers}
+        dateRange={summary.dateRange}
         actions={
           <>
             <Button variant="outline" size="sm">
@@ -133,15 +151,14 @@ const DumpPage = () => {
 
         <aside className="dump-sidebar">
           <TripSummaryCard
-            destinations={destinations.length ? destinations : ['-']}
-            dateRange={dateRange}
-            nights={nights}
-            days={nights + 1}
-            travelers={companion_count}
-            completionPct={completionPct}
+            {...summary}
             onNext={handleClickNext}
             onPrev={handleClickBack}
             nextDisabled={isNextDisabled}
+            progressLabel="입력 완료도"
+            progressValueLabel={progressValueLabel}
+            guideText="여행 정보를 10자 이상 입력하면 다음 단계로 진행할 수 있어요."
+            errorMessage={errorMessage}
           />
         </aside>
       </main>

--- a/apps/frontend/src/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/pages/OnboardingPage.tsx
@@ -17,7 +17,7 @@ import './OnboardingPage.css';
 const OnboardingPage = () => {
   const navigate = useNavigate();
   const { submitOnboarding } = useOnboardingStore((s) => s.actions);
-  // const errorMessage = useOnboardingStore((s) => s.errorMessage);
+  const errorMessage = useOnboardingStore((s) => s.errorMessage);
 
   const { destinations, companion_count, has_flight, has_accommodation } =
     useOnboardingStore((s) => s.form);
@@ -34,7 +34,9 @@ const OnboardingPage = () => {
   const hasSchedule = type !== null;
   const filledCount = [hasDestination, hasSchedule].filter(Boolean).length;
   const completionPct = (filledCount / 2) * 100;
-  const isNextDisabled = filledCount < 2;
+  const remainingFields = 2 - filledCount;
+  const progressValueLabel =
+    remainingFields > 0 ? `${remainingFields}개 남음` : '준비 완료';
 
   const summary = {
     destinations: destinations.length ? destinations : ['-'],
@@ -46,6 +48,8 @@ const OnboardingPage = () => {
     completionPct,
   };
 
+  const isNextDisabled = filledCount < 2;
+
   const handleNext = async () => {
     const success = await submitOnboarding();
     if (success) navigate('/dump');
@@ -55,6 +59,7 @@ const OnboardingPage = () => {
     <>
       <Header
         currentStepId="onboarding"
+        showTripMeta={false}
         actions={
           <Button variant="outline" size="sm">
             초기화
@@ -109,6 +114,10 @@ const OnboardingPage = () => {
             {...summary}
             onNext={handleNext}
             nextDisabled={isNextDisabled}
+            progressLabel="입력 완료도"
+            progressValueLabel={progressValueLabel}
+            guideText="여행지와 일정을 입력하면 다음 단계로 진행할 수 있어요."
+            errorMessage={errorMessage}
           />
         </aside>
       </div>


### PR DESCRIPTION
## 📝 작업 내용

> TripSummaryCard 진행도/안내/에러 표시를 prop으로 분리하고 페이지에서 Header summary 데이터를 연결

- `TripSummaryCard`에 표시용 prop 확장
  - `progressLabel` / `progressValueLabel` — 진행도 라벨과 우측 텍스트를 caller가 자유롭게 지정
  - `guideText` — 다음 단계 비활성 상태일 때 안내 문구
  - `errorMessage` — 다음 단계 실패 시 destructive 스타일(좌측 보더 + AlertCircle)로 표시
  
- `ProgressStat`의 `valueSuffix`를 `valueLabel`로 리팩터
  - 기존 방식은 `${value}%`가 강제 렌더되어 "3자 남음" 같은 표현 불가
  - 막대 fill용 `value`와 우측 표시 텍스트의 책임을 분리
  
- 페이지에서 Header의 trip meta 데이터 연결
  - OnboardingPage: 데이터 미완성 단계라 `showTripMeta={false}`로 헤더 좌측 숨김
  - DumpPage: `destination` / `extraDestinations` / `travelers` / `dateRange` 전달
  
- OnboardingPage / DumpPage에서 store의 `errorMessage`를 사이드바에 표시되도록 연결

- DumpPage 사이드바 props를 `summary` 객체 spread 패턴으로 정리 (온보딩 및 그룹화 페이지 통일)

## 🔗 관련 이슈

closes #158 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- `valueSuffix` → `valueLabel` 변경에서 ProgressStat 호출부 회귀 없는지 (GroupingPage `boxed` 케이스 등)
- `Header.tsx` mock 기본값은 페이지 미완성 단계 안전망으로 의도적으로 유지

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.