### PR TITLE
Feat: 입력 비우기 초기화 기능 구현

### DIFF
--- a/apps/frontend/src/components/onboarding/calendar/ExactCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/ExactCalendar.tsx
@@ -1,5 +1,5 @@
 import { format, differenceInDays } from 'date-fns';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { type DateRange, DayPicker } from 'react-day-picker';
 
 import { useCalendarStore } from '@/utils/calendar-store';
@@ -18,6 +18,12 @@ export const ExactCalendar = () => {
     from: exactDate?.from,
     to: exactDate?.to,
   }));
+
+  useEffect(() => {
+    if (exactDate === null) {
+      setRange({ from: undefined, to: undefined });
+    }
+  }, [exactDate]);
 
   const handleSelect = (newRange: DateRange | undefined) => {
     const from = newRange?.from;

--- a/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
@@ -1,5 +1,5 @@
 import './FlexCalendar.css';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useCalendarStore } from '@/utils/calendar-store';
 import { useOnboardingStore } from '@/utils/onboarding-store';
@@ -15,7 +15,17 @@ const FlexCalendar = () => {
   const [selectedMonth, setSelectedMonth] = useState<number | null>(
     flexDate?.month ?? null
   );
-  const [durationNights, setDurationNights] = useState(flexDate?.nights ?? 3);
+  const [durationNights, setDurationNights] = useState<number | null>(
+    flexDate?.nights ?? null
+  );
+
+  useEffect(() => {
+    if (flexDate === null) {
+      setSelectedYear(new Date().getFullYear());
+      setSelectedMonth(null);
+      setDurationNights(null);
+    }
+  }, [flexDate]);
 
   const currentYear = new Date().getFullYear();
 
@@ -25,8 +35,10 @@ const FlexCalendar = () => {
 
   const handleMonthClick = (month: number) => {
     setSelectedMonth(month);
-    setFlexDate({ year: selectedYear, month, nights: durationNights });
-    setForm({ travel_days: durationNights });
+    if (durationNights !== null) {
+      setFlexDate({ year: selectedYear, month, nights: durationNights });
+      setForm({ travel_days: durationNights });
+    }
   };
 
   const handleDurationClick = (nights: number) => {

--- a/apps/frontend/src/components/onboarding/calendar/TripCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/TripCalendar.tsx
@@ -1,5 +1,5 @@
 import './TripCalendar.css';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useCalendarStore } from '@/utils/calendar-store';
 
@@ -9,6 +9,12 @@ import FlexCalendar from './FlexCalendar';
 const TripCalendar = () => {
   const storedTab = useCalendarStore((s) => s.type);
   const [tab, setTab] = useState<'exact' | 'flexible'>(storedTab ?? 'exact');
+
+  useEffect(() => {
+    if (storedTab === null) {
+      setTab('exact');
+    }
+  }, [storedTab]);
 
   return (
     <div>

--- a/apps/frontend/src/pages/DumpPage.tsx
+++ b/apps/frontend/src/pages/DumpPage.tsx
@@ -29,7 +29,7 @@ const DumpPage = () => {
   const { type, exactDate, flexDate } = useCalendarStore();
   const { dumpText, requestStatus, errorMessage, jobId, actions } =
     useDumpStore();
-  const { setDumpText, submitDump, clearJob } = actions;
+  const { setDumpText, submitDump, clearJob, resetDump } = actions;
 
   const view = useParseJobStatus(tripId, jobId);
 
@@ -86,6 +86,10 @@ const DumpPage = () => {
     await submitDump(tripId);
   };
 
+  const handleReset = () => {
+    resetDump();
+  };
+
   // 온보딩으로 리다이렉트되는 동안 폼이 깜빡이지 않도록 렌더를 막는다.
   if (!tripId) {
     return null;
@@ -125,7 +129,7 @@ const DumpPage = () => {
         dateRange={summary.dateRange}
         actions={
           <>
-            <Button variant="outline" size="sm">
+            <Button variant="outline" size="sm" onClick={handleReset}>
               초기화
             </Button>
           </>

--- a/apps/frontend/src/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/pages/OnboardingPage.tsx
@@ -16,12 +16,20 @@ import './OnboardingPage.css';
 
 const OnboardingPage = () => {
   const navigate = useNavigate();
-  const { submitOnboarding } = useOnboardingStore((s) => s.actions);
+  const { submitOnboarding, resetForm } = useOnboardingStore((s) => s.actions);
   const errorMessage = useOnboardingStore((s) => s.errorMessage);
 
-  const { destinations, companion_count, has_flight, has_accommodation } =
-    useOnboardingStore((s) => s.form);
+  const {
+    tripName,
+    destinations,
+    companion_count,
+    has_flight,
+    has_accommodation,
+  } = useOnboardingStore((s) => s.form);
+  const setForm = useOnboardingStore((s) => s.actions.setForm);
+
   const { type, exactDate, flexDate } = useCalendarStore();
+  const resetCalendar = useCalendarStore((s) => s.resetCalendar);
 
   const dateRange = formatDateRangeLabel(type, exactDate, flexDate);
   const nights = exactDate?.nights ?? flexDate?.nights ?? 0;
@@ -55,13 +63,18 @@ const OnboardingPage = () => {
     if (success) navigate('/dump');
   };
 
+  const handleReset = () => {
+    resetForm();
+    resetCalendar();
+  };
+
   return (
     <>
       <Header
         currentStepId="onboarding"
         showTripMeta={false}
         actions={
-          <Button variant="outline" size="sm">
+          <Button variant="outline" size="sm" onClick={handleReset}>
             초기화
           </Button>
         }
@@ -82,6 +95,8 @@ const OnboardingPage = () => {
                 name="tripName"
                 placeholder="여행의 이름을 입력하세요"
                 subtitle="여행을 구분할 수 있는 이름을 자유롭게 입력하세요."
+                value={tripName}
+                onChange={(v) => setForm({ tripName: v })}
               />
             </section>
 

--- a/apps/frontend/src/types/onboarding.ts
+++ b/apps/frontend/src/types/onboarding.ts
@@ -1,4 +1,5 @@
 export type OnboardingRequest = {
+  tripName: string;
   destinations: string[];
   travel_days: number;
   companion_count: number;

--- a/apps/frontend/src/utils/calendar-store.ts
+++ b/apps/frontend/src/utils/calendar-store.ts
@@ -12,6 +12,7 @@ type CalendarStore = {
   setExactDate: (value: ExactDate) => void;
   setFlexDate: (value: FlexDate) => void;
   clearExactDate: () => void;
+  resetCalendar: () => void;
 };
 
 export const useCalendarStore = create<CalendarStore>()(
@@ -23,6 +24,7 @@ export const useCalendarStore = create<CalendarStore>()(
       setExactDate: (value) => set({ type: 'exact', exactDate: value }),
       setFlexDate: (value) => set({ type: 'flexible', flexDate: value }),
       clearExactDate: () => set({ type: null, exactDate: null }),
+      resetCalendar: () => set({ type: null, exactDate: null, flexDate: null }),
     }),
     {
       name: 'calendar-storage',

--- a/apps/frontend/src/utils/onboarding-store.ts
+++ b/apps/frontend/src/utils/onboarding-store.ts
@@ -7,6 +7,15 @@ import { createTrip, parseOnboardingApiError } from './onboarding-api';
 
 type RequestStatus = 'idle' | 'loading' | 'success' | 'error';
 
+const INITIAL_FORM: OnboardingRequest = {
+  tripName: '',
+  destinations: [],
+  travel_days: 0,
+  companion_count: 1,
+  has_flight: false,
+  has_accommodation: false,
+};
+
 type OnboardingStore = {
   form: OnboardingRequest;
   tripId: string | null;
@@ -17,19 +26,14 @@ type OnboardingStore = {
     setForm: (form: Partial<OnboardingRequest>) => void;
     setTripId: (tripId: string | null) => void;
     submitOnboarding: () => Promise<boolean>;
+    resetForm: () => void;
   };
 };
 
 export const useOnboardingStore = create<OnboardingStore>()(
   persist(
     (set, get) => ({
-      form: {
-        destinations: [],
-        travel_days: 0,
-        companion_count: 1,
-        has_flight: false,
-        has_accommodation: false,
-      },
+      form: { ...INITIAL_FORM },
       tripId: null,
       requestStatus: 'idle',
       errorMessage: null,
@@ -39,6 +43,13 @@ export const useOnboardingStore = create<OnboardingStore>()(
           set((state) => ({ form: { ...state.form, ...partial } })),
 
         setTripId: (tripId) => set({ tripId }),
+
+        resetForm: () =>
+          set({
+            form: INITIAL_FORM,
+            requestStatus: 'idle',
+            errorMessage: null,
+          }),
 
         submitOnboarding: async () => {
           if (get().requestStatus === 'loading') return false;


### PR DESCRIPTION
## 📝 작업 내용

> 헤더의 "초기화" 버튼이 동작하지 않던 문제를 해결하고, 온보딩/덤프 페이지의 사용자 입력값과 캘린더 UI를 한 번에 비우는 흐름을 구현.

**1. 초기화 동작 정의**
- `onboarding-store`, `calendar-store`, `dump-store`에 각각 reset 액션을 추가함.
- 의도적으로 **`tripId`는 유지**
   -  초기화 후 사용자가 같은 trip 흐름 안에서 다시 제출할 수 있게 두기 위함.

**2. 캘린더 UI 동기화 패턴**
- 세 컴포넌트 모두 `useEffect`로 store가 **null**이 되는 시점을 감지해 로컬 state를 함께 reset 하도록 통일함.
- `ExactCalendar`는 DayPicker가 "from만 선택된 중간 상태"를 보존해야 해서 로컬 state를 유지한 채 동기화하는 방식으로 가져감.

**3. FlexCalendar 기본값 변경**
- 진입 시 "3박 4일" 버튼이 active로 보이던 문제가 있어 `durationNights` 기본값을 `null`로 수정함.

## 🔗 관련 이슈

closes #159 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

**1. 알려진 한계 (이번 PR 범위 외)**
- 초기화 후 "다음" 버튼을 누르면 백엔드에 **새 trip / dump_job이 생성**되고, 이전 trip은 고아 데이터로 남음.
- 두 가지 방향으로 고민 중인데 의견 부탁드림:
  - (A) `PATCH /trips/{tripId}` 엔드포인트를 도입해 같은 trip을 수정
  - (B) 초기화/뒤로 이동 시 "처음부터 새 여행을 만들게 됩니다" 안내 문구로 사용자에게 명시

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.