### PR TITLE
feat: 163 SCR-04 일정 배치 화면 UI (#163)

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
+import ArrangePage from './pages/ArrangePage';
 import DevIndexPage from './pages/DevIndexPage';
 import DumpPage from './pages/DumpPage';
 import GroupingPage from './pages/GroupingPage';
@@ -15,6 +16,7 @@ const App = () => {
         <Route path="/dump" element={<DumpPage />} />
         <Route path="/progress" element={<ProgressPageDev />} />
         <Route path="/grouping" element={<GroupingPage />} />
+        <Route path="/arrange" element={<ArrangePage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/apps/frontend/src/components/arrange/ArrangeCard.tsx
+++ b/apps/frontend/src/components/arrange/ArrangeCard.tsx
@@ -1,0 +1,102 @@
+// ArrangeCard — 배치 화면(SCR-04) 좌측 "카드 목록"의 카드 한 장.
+// 정리 화면의 PlaceCard 와 같은 액센트 바 + PlaceCardBadge 를 재사용한다.
+// - 클릭: 우측 상세 패널(ArrangeCardDetailPanel) 열기
+// - 드래그: Day 컬럼으로 끌어다 배치(네이티브 HTML5 DnD). 고정 카드(항공권, draggable=false)는 드래그 불가.
+
+import { GripVertical, RefreshCw } from 'lucide-react';
+import type { DragEvent } from 'react';
+
+import PlaceCardBadge from '@/components/grouping/PlaceCardBadge';
+import { cn } from '@/lib/utils';
+import type { ArrangeCardViewModel } from '@/types/arrange';
+import type { PlaceCardAccent } from '@/types/grouping';
+
+const ACCENT_BAR: Record<PlaceCardAccent, string> = {
+  blue: 'bg-blue-500',
+  green: 'bg-green-500',
+  amber: 'bg-amber-500',
+  red: 'bg-destructive',
+  muted: 'bg-muted-foreground/30',
+};
+
+type ArrangeCardProps = ArrangeCardViewModel & {
+  /** 카드 클릭 — 우측 상세 패널 열기 */
+  onClick?: () => void;
+  /** 드래그 시작(배치 대상 강조용) */
+  onDragStart?: () => void;
+  /** 드래그 종료 */
+  onDragEnd?: () => void;
+  /** 드래그 중인 카드면 살짝 흐리게 */
+  isDragging?: boolean;
+};
+
+const ArrangeCard = ({
+  id,
+  name,
+  accent = 'green',
+  badges = [],
+  draggable = true,
+  onClick,
+  onDragStart,
+  onDragEnd,
+  isDragging = false,
+}: ArrangeCardProps) => {
+  const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
+    // Day 컬럼 드롭 핸들러가 읽을 카드 식별자. (Firefox 는 setData 가 있어야 드래그가 시작됨)
+    event.dataTransfer.setData('text/plain', id);
+    event.dataTransfer.effectAllowed = 'move';
+    onDragStart?.();
+  };
+
+  return (
+    <button
+      type="button"
+      draggable={draggable}
+      onClick={onClick}
+      onDragStart={handleDragStart}
+      onDragEnd={onDragEnd}
+      className={cn(
+        'flex w-full overflow-hidden rounded-xl bg-card text-left ring-1 ring-foreground/10 transition-shadow hover:shadow-sm',
+        draggable && 'cursor-grab active:cursor-grabbing',
+        isDragging && 'opacity-40'
+      )}
+    >
+      {/* 좌측 컬러 액센트 바 */}
+      <span
+        aria-hidden="true"
+        className={cn('w-1 shrink-0', ACCENT_BAR[accent])}
+      />
+
+      <div className="flex min-w-0 flex-1 items-center gap-3 px-3.5 py-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-foreground">
+            {name}
+          </p>
+          {badges.length > 0 && (
+            <div className="mt-1 flex items-center gap-1.5">
+              {badges.map((badge, index) => (
+                <PlaceCardBadge key={index} {...badge} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {draggable ? (
+          // 드래그 어포던스(그립). 카드 전체가 draggable 이라 시각적 힌트 역할.
+          <GripVertical
+            className="size-4 shrink-0 text-muted-foreground/50"
+            aria-hidden="true"
+          />
+        ) : (
+          // 고정 카드(항공권): "이동" 힌트 — 드래그 불가, Day에 고정
+          <span className="inline-flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
+            <RefreshCw className="size-3" aria-hidden="true" />
+            이동
+          </span>
+        )}
+      </div>
+    </button>
+  );
+};
+
+export default ArrangeCard;

--- a/apps/frontend/src/components/arrange/ArrangeCardDetailPanel.tsx
+++ b/apps/frontend/src/components/arrange/ArrangeCardDetailPanel.tsx
@@ -1,0 +1,177 @@
+// ArrangeCardDetailPanel — 배치 화면(SCR-04) 좌측 카드 클릭 시 우측에서 열리는 상세 패널.
+// 정리 화면(SCR-03)의 CardDetailPanel 과 동일한 조립 부품
+// (SidePanel / StatusInfoBox / DetailRow / UserMemoField / PanelActions / PlaceCardBadge)을 재사용한다.
+
+import { Clock, Info, MapPin, Plane, User, X } from 'lucide-react';
+import { Dialog } from 'radix-ui';
+import { useState } from 'react';
+
+import PanelActions from '@/components/common/PanelActions';
+import SidePanel from '@/components/common/SidePanel';
+import {
+  DetailRow,
+  StatusInfoBox,
+  UserMemoField,
+} from '@/components/grouping/CardDetailParts';
+import PlaceCardBadge from '@/components/grouping/PlaceCardBadge';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import type { ArrangeCardViewModel } from '@/types/arrange';
+
+type ArrangeCardDetailPanelProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  card: ArrangeCardViewModel | null;
+  onSaveMemo?: (memo: string) => void;
+};
+
+const ArrangeCardDetailPanel = ({
+  open,
+  onOpenChange,
+  card,
+  onSaveMemo,
+}: ArrangeCardDetailPanelProps) => {
+  return (
+    <SidePanel open={open} onOpenChange={onOpenChange}>
+      {card?.detail ? (
+        // key={card.id}: 다른 카드로 다시 열렸을 때 메모 입력 state 가 초기화되도록.
+        <ArrangeCardDetailBody
+          key={card.id}
+          card={card}
+          onClose={() => onOpenChange(false)}
+          onSaveMemo={onSaveMemo}
+        />
+      ) : null}
+    </SidePanel>
+  );
+};
+
+export default ArrangeCardDetailPanel;
+
+// 패널 본문(헤더 + 스크롤 영역 + 푸터)
+const ArrangeCardDetailBody = ({
+  card,
+  onClose,
+  onSaveMemo,
+}: {
+  card: ArrangeCardViewModel;
+  onClose: () => void;
+  onSaveMemo?: (memo: string) => void;
+}) => {
+  const detail = card.detail!;
+  // 고정 카드(항공권 등)는 상단 상태 pill 을 파란색(info), 일반 카드는 초록색(done)으로.
+  const isFixed = card.draggable === false;
+
+  const initialMemo = detail.memo ?? '';
+  const [memo, setMemo] = useState(initialMemo);
+  const memoDirty = memo.trim() !== initialMemo.trim();
+
+  const categoryBadge = card.badges?.find((badge) => badge.kind === 'category');
+
+  return (
+    <>
+      <div className="shrink-0 px-6 pt-6 pb-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <PlaceCardBadge
+              kind="status"
+              label={detail.classification}
+              tone={isFixed ? 'info' : 'done'}
+            />
+            {categoryBadge && <PlaceCardBadge {...categoryBadge} />}
+          </div>
+          <Dialog.Close asChild>
+            <button
+              type="button"
+              aria-label="닫기"
+              className="-mt-1 -mr-1.5 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <X className="size-5" aria-hidden="true" />
+            </button>
+          </Dialog.Close>
+        </div>
+        <Dialog.Title className="mt-3 text-xl font-bold text-foreground">
+          {card.name}
+        </Dialog.Title>
+        <Dialog.Description className="sr-only">
+          {card.name} 카드의 배치 상태·상세 정보와 사용자 메모
+        </Dialog.Description>
+      </div>
+
+      <Separator />
+
+      {/* 본문(스크롤 영역) */}
+      <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
+        {/* 상태 정보 박스(회색): 분류 / 배치 상태 2칼럼 */}
+        <StatusInfoBox
+          classification={detail.classification}
+          placementStatus={detail.placementStatus}
+        />
+
+        {/* 상세 정보: 고정 시작 시간 / 위치 / 예상 소요 시간 / 원하셨던 내용 / 알아두면 좋아요 */}
+        <section>
+          <h3 className="text-sm font-semibold text-foreground">상세 정보</h3>
+          <ul className="mt-3 space-y-3.5">
+            {detail.fixedTimeLabel && (
+              <DetailRow
+                icon={Plane}
+                label="고정 시작 시간"
+                value={detail.fixedTimeLabel}
+              />
+            )}
+            {detail.region && (
+              <DetailRow icon={MapPin} label="위치" value={detail.region} />
+            )}
+            {detail.durationLabel && (
+              <DetailRow
+                icon={Clock}
+                label="예상 소요 시간"
+                value={detail.durationLabel}
+              />
+            )}
+            {detail.userIntent && (
+              <DetailRow
+                icon={User}
+                label="원하셨던 내용"
+                value={detail.userIntent}
+              />
+            )}
+            {detail.aiHint && (
+              <DetailRow
+                icon={Info}
+                label="알아두면 좋아요"
+                value={detail.aiHint}
+                emphasis
+              />
+            )}
+          </ul>
+        </section>
+
+        <Separator />
+
+        {/* 사용자 메모 */}
+        <UserMemoField value={memo} onChange={setMemo} />
+      </div>
+
+      {/* 푸터 */}
+      <PanelActions>
+        <Button
+          type="button"
+          variant="outline"
+          className="h-11 flex-1 text-sm"
+          onClick={onClose}
+        >
+          닫기
+        </Button>
+        <Button
+          type="button"
+          className="h-11 flex-1 text-sm font-semibold"
+          disabled={!memoDirty}
+          onClick={() => onSaveMemo?.(memo)}
+        >
+          메모 저장
+        </Button>
+      </PanelActions>
+    </>
+  );
+};

--- a/apps/frontend/src/components/arrange/CardGroupSection.tsx
+++ b/apps/frontend/src/components/arrange/CardGroupSection.tsx
@@ -1,0 +1,41 @@
+// CardGroupSection — 배치 화면 좌측 "카드 목록"의 그룹 한 덩어리.
+// 제목 + 우상단 카운트 배지 + 설명 한 줄 + 카드 스택. (정리 화면의 상태 아이콘/접기 기능은 없음)
+
+import type { ReactNode } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+
+type CardGroupSectionProps = {
+  title: string;
+  count: number;
+  description?: string;
+  children: ReactNode;
+};
+
+const CardGroupSection = ({
+  title,
+  count,
+  description,
+  children,
+}: CardGroupSectionProps) => {
+  return (
+    <section className="rounded-xl bg-card p-3.5 ring-1 ring-foreground/10">
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="text-sm font-bold text-foreground">{title}</h3>
+        <Badge variant="secondary" className="shrink-0 text-[11px]">
+          {count}개
+        </Badge>
+      </div>
+
+      {description && (
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+      )}
+
+      <div className="mt-3 flex flex-col gap-2">{children}</div>
+    </section>
+  );
+};
+
+export default CardGroupSection;

--- a/apps/frontend/src/components/arrange/CardListPanel.tsx
+++ b/apps/frontend/src/components/arrange/CardListPanel.tsx
@@ -1,0 +1,81 @@
+// CardListPanel — 배치 화면 좌측 패널 전체.
+// 헤더("카드 목록" + 재정렬 버튼 + 전체 카드 수) + 세로 스크롤되는 그룹 목록.
+// 카드는 클릭 시 상세 패널이 열리고, 드래그하여 우측 Day 컬럼에 배치할 수 있다.
+
+import { RefreshCw } from 'lucide-react';
+
+import ArrangeCard from '@/components/arrange/ArrangeCard';
+import CardGroupSection from '@/components/arrange/CardGroupSection';
+import { Button } from '@/components/ui/button';
+import type { ArrangeCardGroup, ArrangeCardViewModel } from '@/types/arrange';
+
+type CardListPanelProps = {
+  title: string;
+  totalCards: number;
+  groups: ArrangeCardGroup[];
+  /** "재정렬" 클릭(동작은 depth) */
+  onReorder?: () => void;
+  /** 카드 클릭 — 우측 상세 패널 열기 */
+  onSelectCard?: (card: ArrangeCardViewModel) => void;
+  /** 카드 드래그 시작(배치 대상 강조용) */
+  onDragCardStart?: (cardId: string) => void;
+  /** 카드 드래그 종료 */
+  onDragCardEnd?: () => void;
+  /** 현재 드래그 중인 카드 id(흐림 처리용) */
+  draggingCardId?: string | null;
+};
+
+const CardListPanel = ({
+  title,
+  totalCards,
+  groups,
+  onReorder,
+  onSelectCard,
+  onDragCardStart,
+  onDragCardEnd,
+  draggingCardId,
+}: CardListPanelProps) => {
+  // 카드가 모두 배치되어 비워진 그룹은 목록에서 숨긴다.
+  const visibleGroups = groups.filter((group) => group.cards.length > 0);
+
+  return (
+    <div className="flex w-[380px] shrink-0 flex-col overflow-hidden rounded-2xl bg-muted/40 ring-1 ring-foreground/10">
+      <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <h2 className="text-sm font-bold text-foreground">{title}</h2>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onReorder}>
+            <RefreshCw className="size-3.5" aria-hidden="true" />
+            재정렬
+          </Button>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {totalCards}개
+          </span>
+        </div>
+      </header>
+
+      <div className="flex flex-col gap-3 overflow-y-auto px-3 py-3">
+        {visibleGroups.map((group) => (
+          <CardGroupSection
+            key={group.id}
+            title={group.title}
+            count={group.cards.length}
+            description={group.description}
+          >
+            {group.cards.map((card) => (
+              <ArrangeCard
+                key={card.id}
+                {...card}
+                onClick={() => onSelectCard?.(card)}
+                onDragStart={() => onDragCardStart?.(card.id)}
+                onDragEnd={onDragCardEnd}
+                isDragging={draggingCardId === card.id}
+              />
+            ))}
+          </CardGroupSection>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CardListPanel;

--- a/apps/frontend/src/components/arrange/DayColumn.tsx
+++ b/apps/frontend/src/components/arrange/DayColumn.tsx
@@ -1,0 +1,106 @@
+// DayColumn — 우측 칸반 보드의 Day 컬럼 한 개.
+// 헤더(Day 라벨 + 날짜 + 카드 수) + 본문(배치된 카드들 또는 빈 드롭 플레이스홀더).
+// 좌측 카드 목록에서 드래그한 카드를 여기에 드롭하면 onDropCard 로 전달된다(네이티브 HTML5 DnD).
+
+import { Plus } from 'lucide-react';
+import { useState, type DragEvent } from 'react';
+
+import ScheduleCard from '@/components/arrange/ScheduleCard';
+import { cn } from '@/lib/utils';
+import type { DayColumnViewModel } from '@/types/arrange';
+
+type DayColumnProps = DayColumnViewModel & {
+  /** 카드를 이 Day에 드롭했을 때(드래그된 카드 id) */
+  onDropCard?: (cardId: string) => void;
+  /** 드래그가 진행 중이면 모든 컬럼을 드롭 가능 상태로 강조 */
+  dragActive?: boolean;
+};
+
+const DayColumn = ({
+  dayLabel,
+  dateLabel,
+  cards,
+  onDropCard,
+  dragActive = false,
+}: DayColumnProps) => {
+  const isEmpty = cards.length === 0;
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault(); // drop 을 허용하려면 필수
+    event.dataTransfer.dropEffect = 'move';
+    if (!isOver) setIsOver(true);
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    // 자식 요소로 이동할 때 발생하는 leave 는 무시(컬럼 밖으로 나갈 때만 해제)
+    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      setIsOver(false);
+    }
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsOver(false);
+    const cardId = event.dataTransfer.getData('text/plain');
+    if (cardId) onDropCard?.(cardId);
+  };
+
+  return (
+    <div
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className={cn(
+        'flex h-full w-[280px] shrink-0 flex-col rounded-2xl border border-border bg-background/60 p-3 transition-colors',
+        dragActive && 'border-dashed border-primary/40',
+        isOver &&
+          'border-solid border-primary bg-primary/5 ring-2 ring-primary/30'
+      )}
+    >
+      <header className="flex items-start justify-between gap-2 px-1">
+        <div>
+          <p className="text-sm font-bold text-foreground">{dayLabel}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">{dateLabel}</p>
+        </div>
+        <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+          {cards.length}개
+        </span>
+      </header>
+
+      {isEmpty ? (
+        // 빈 컬럼 — 드롭 플레이스홀더
+        <div
+          className={cn(
+            'mt-3 flex flex-1 flex-col items-center justify-center gap-2 rounded-xl border border-dashed py-10 text-center transition-colors',
+            isOver ? 'border-primary text-primary' : 'border-border'
+          )}
+        >
+          <Plus
+            className={cn(
+              'size-5',
+              isOver ? 'text-primary' : 'text-muted-foreground/50'
+            )}
+            aria-hidden="true"
+          />
+          <p
+            className={cn(
+              'text-xs',
+              isOver ? 'text-primary' : 'text-muted-foreground/70'
+            )}
+          >
+            카드를 여기에 드롭하세요
+          </p>
+        </div>
+      ) : (
+        <div className="mt-3 flex flex-1 flex-col gap-2.5 overflow-y-auto">
+          {cards.map((card) => (
+            <ScheduleCard key={card.id} {...card} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DayColumn;

--- a/apps/frontend/src/components/arrange/ScheduleCard.tsx
+++ b/apps/frontend/src/components/arrange/ScheduleCard.tsx
@@ -1,0 +1,75 @@
+// ScheduleCard — 우측 보드(Day 컬럼)에 배치된 일정 카드 한 장.
+// fixedTime 이 있으면 "고정 시작 시간" 강조 카드(항공권 등), 없으면 일반 일정 카드.
+
+import { Clock } from 'lucide-react';
+
+import PlaceCardBadge from '@/components/grouping/PlaceCardBadge';
+import { cn } from '@/lib/utils';
+import type { ScheduledCardViewModel } from '@/types/arrange';
+import type { PlaceCardAccent } from '@/types/grouping';
+
+const ACCENT_BAR: Record<PlaceCardAccent, string> = {
+  blue: 'bg-blue-500',
+  green: 'bg-green-500',
+  amber: 'bg-amber-500',
+  red: 'bg-destructive',
+  muted: 'bg-muted-foreground/30',
+};
+
+const ScheduleCard = ({
+  name,
+  accent = 'green',
+  badges = [],
+  fixedTime,
+  timeLabel,
+}: ScheduledCardViewModel) => {
+  // 고정 시작 시간 카드 — 옅은 primary 톤 박스
+  if (fixedTime) {
+    return (
+      <div className="rounded-xl border border-primary/30 bg-primary/5 px-3.5 py-3">
+        <p className="text-[11px] font-medium text-primary/80">
+          고정 시작 시간
+        </p>
+        <div className="mt-1 flex items-center justify-between gap-2">
+          <p className="truncate text-sm font-semibold text-foreground">
+            {name}
+          </p>
+          <span className="shrink-0 text-sm font-bold text-primary tabular-nums">
+            {fixedTime}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex overflow-hidden rounded-xl bg-card ring-1 ring-foreground/10">
+      <span
+        aria-hidden="true"
+        className={cn('w-1 shrink-0', ACCENT_BAR[accent])}
+      />
+      <div className="min-w-0 flex-1 px-3.5 py-3">
+        <div className="flex items-center justify-between gap-2">
+          <p className="truncate text-sm font-semibold text-foreground">
+            {name}
+          </p>
+          {timeLabel && (
+            <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground tabular-nums">
+              <Clock className="size-3.5" aria-hidden="true" />
+              {timeLabel}
+            </span>
+          )}
+        </div>
+        {badges.length > 0 && (
+          <div className="mt-1 flex items-center gap-1.5">
+            {badges.map((badge, index) => (
+              <PlaceCardBadge key={index} {...badge} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleCard;

--- a/apps/frontend/src/components/header/Header.tsx
+++ b/apps/frontend/src/components/header/Header.tsx
@@ -19,7 +19,7 @@ const STEPS: Step[] = [
   { id: 'onboarding', label: '온보딩', path: '/onboarding' },
   { id: 'dump', label: '덤프', path: '/dump' },
   { id: 'organize', label: '정리', path: '/grouping' },
-  { id: 'arrange', label: '배치' },
+  { id: 'arrange', label: '배치', path: '/arrange' },
   { id: 'confirm', label: '확정' },
 ];
 

--- a/apps/frontend/src/dev-fixtures/arrange-fixture.ts
+++ b/apps/frontend/src/dev-fixtures/arrange-fixture.ts
@@ -1,0 +1,277 @@
+// 배치(SCR-04) 화면 개발용 목데이터.
+// 스크린샷 시안과 동일한 카드 구성(좌측 12개 그룹 카드 + Day 1~5 보드, 미배치 10개).
+// 실제 BE 연동(그룹/배치 API) 전까지 ArrangePage 를 정적으로 렌더링하기 위한 임시 데이터다.
+// BE 연동 시 이 파일은 삭제하고 fetch + 매퍼로 교체한다.
+import type { ArrangeViewModel } from '@/types/arrange';
+
+export const ARRANGE_FIXTURE: ArrangeViewModel = {
+  summary: {
+    destination: '교토',
+    extraDestinations: 2,
+    travelers: 2,
+    dateRange: '5월 10일 ~ 5월 14일',
+  },
+  heading: {
+    title: '일정 배치',
+    subtitle: 'available/unavailable 구조로 배치 가능한 카드를 정리했어요',
+  },
+  cardListTitle: '카드 목록',
+  groups: [
+    {
+      id: 'flight',
+      title: '항공권',
+      description:
+        '항공권은 Day에 고정되어 있어도 변경될 수 있어요. 드래그하지 않고 클릭해서 수정합니다.',
+      cards: [
+        {
+          id: 'flight-arrive',
+          name: '간사이 공항 도착',
+          accent: 'green',
+          draggable: false,
+          detail: {
+            classification: '고정 일정',
+            placementStatus: 'Day 1 고정',
+            fixedTimeLabel: '5월 10일 11:20 도착',
+            region: '간사이 국제공항 (KIX)',
+            durationLabel: '입국 수속 약 1시간',
+            userIntent: '오사카 인근 공항으로 도착하는 항공편',
+            aiHint: '공항에서 교토 시내까지 하루카 특급으로 약 75분 걸려요.',
+          },
+        },
+        {
+          id: 'flight-depart',
+          name: '간사이 공항 출발',
+          accent: 'green',
+          draggable: false,
+          detail: {
+            classification: '고정 일정',
+            placementStatus: 'Day 5 고정',
+            fixedTimeLabel: '5월 14일 13:40 출발',
+            region: '간사이 국제공항 (KIX)',
+            durationLabel: '탑승 수속 2시간 전 도착 권장',
+            userIntent: '귀국 항공편',
+            aiHint:
+              '출국 당일 오전은 공항 이동 시간을 고려해 가볍게 잡는 게 좋아요.',
+          },
+        },
+      ],
+    },
+    {
+      id: 'lodging',
+      title: '숙소',
+      description:
+        '숙소 카드는 체크인/체크아웃 기준이 달라 지역 그룹과 분리했어요.',
+      cards: [
+        {
+          id: 'lodging-kyoto',
+          name: '교토 게스트하우스',
+          accent: 'blue',
+          badges: [{ kind: 'category', category: 'lodging' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '교토 기온',
+            durationLabel: '체크인 15:00 / 체크아웃 11:00',
+            userIntent: '교토 중심부 도보 이동이 가능한 숙소',
+            aiHint: '기온 거리·야사카 신사가 도보 10분 거리예요.',
+          },
+        },
+        {
+          id: 'lodging-namba',
+          name: '오사카 난바 호텔',
+          accent: 'green',
+          badges: [{ kind: 'category', category: 'lodging' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '오사카 난바',
+            durationLabel: '체크인 16:00 / 체크아웃 10:00',
+            userIntent: '난바역 인근 교통이 편한 호텔',
+            aiHint: '도톤보리·신사이바시가 도보권이라 저녁 일정과 묶기 좋아요.',
+          },
+        },
+        {
+          id: 'lodging-umeda',
+          name: '오사카 우메다 호텔',
+          accent: 'green',
+          badges: [{ kind: 'category', category: 'lodging' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '오사카 우메다',
+            durationLabel: '체크인 15:00 / 체크아웃 11:00',
+            userIntent: '우메다 쇼핑가 근처 숙소',
+            aiHint: '우메다는 교토·고베 모두 접근이 좋아 거점으로 적합해요.',
+          },
+        },
+      ],
+    },
+    {
+      id: 'osaka',
+      title: '오사카',
+      description: '오사카 기준으로 바로 배치 가능한 카드를 묶은 그룹이에요.',
+      cards: [
+        {
+          id: 'osaka-usj',
+          name: '유니버설 스튜디오 재팬',
+          accent: 'green',
+          badges: [{ kind: 'category', category: 'place' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '오사카 코노하나구',
+            durationLabel: '약 8시간',
+            userIntent: '하루 종일 즐기고 싶은 테마파크',
+            aiHint:
+              '개장 직후 입장하면 인기 어트랙션 대기를 크게 줄일 수 있어요.',
+          },
+        },
+      ],
+    },
+    {
+      id: 'kyoto',
+      title: '교토',
+      description: '교토 기준으로 바로 배치 가능한 카드를 묶은 그룹이에요.',
+      cards: [
+        {
+          id: 'kyoto-gion',
+          name: '기온 거리 산책',
+          accent: 'green',
+          badges: [{ kind: 'category', category: 'activity' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '교토 기온',
+            durationLabel: '약 2시간',
+            userIntent: '전통 거리 분위기를 느끼고 싶음',
+            aiHint: '해질 무렵 하나미코지 거리가 가장 분위기 있어요.',
+          },
+        },
+        {
+          id: 'kyoto-arashiyama',
+          name: '아라시야마 대나무숲',
+          accent: 'blue',
+          badges: [{ kind: 'ai' }, { kind: 'category', category: 'place' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '교토 아라시야마',
+            durationLabel: '약 3시간',
+            userIntent: '사진 찍기 좋은 자연 명소',
+            aiHint: '오전 9시 이전이 인파가 적어 대나무숲 사진 찍기 좋아요.',
+          },
+        },
+      ],
+    },
+    {
+      id: 'nara',
+      title: '나라',
+      description: '나라 기준으로 바로 배치 가능한 카드를 묶은 그룹이에요.',
+      cards: [
+        {
+          id: 'nara-deer',
+          name: '나라 사슴 공원',
+          accent: 'green',
+          badges: [{ kind: 'category', category: 'place' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '나라 공원',
+            durationLabel: '약 2시간 30분',
+            userIntent: '사슴과 교감할 수 있는 곳',
+            aiHint:
+              '시카센베이(사슴 과자)는 공원 입구 가판에서 구할 수 있어요.',
+          },
+        },
+      ],
+    },
+    {
+      id: 'food',
+      title: '맛집',
+      description:
+        '식사/카페 카드는 어느 Day에나 끼워 넣기 좋아 따로 묶었어요.',
+      cards: [
+        {
+          id: 'food-dotonbori',
+          name: '도톤보리 맛집 투어',
+          accent: 'amber',
+          badges: [{ kind: 'category', category: 'food' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '오사카 도톤보리',
+            durationLabel: '약 2시간',
+            userIntent: '오사카 명물 길거리 음식 탐방',
+            aiHint: '타코야키·오코노미야키는 저녁 시간대 웨이팅이 길어요.',
+          },
+        },
+        {
+          id: 'food-ramen',
+          name: '이치란 라멘 본점',
+          accent: 'green',
+          badges: [{ kind: 'category', category: 'food' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '오사카 난바',
+            durationLabel: '약 1시간',
+            userIntent: '유명 돈코츠 라멘 맛보기',
+            aiHint: '본점은 식사 시간대 줄이 길어 피크 시간을 피하면 좋아요.',
+          },
+        },
+        {
+          id: 'food-cafe',
+          name: '아라비카 교토 카페',
+          accent: 'green',
+          badges: [{ kind: 'ai' }, { kind: 'category', category: 'food' }],
+          detail: {
+            classification: '확정됨',
+            placementStatus: '배치 가능',
+            region: '교토 아라시야마',
+            durationLabel: '약 1시간',
+            userIntent: '강변 뷰 카페에서 휴식',
+            aiHint: '아라시야마 대나무숲 일정과 묶으면 동선이 자연스러워요.',
+          },
+        },
+      ],
+    },
+  ],
+  days: [
+    {
+      id: 'day-1',
+      dayLabel: 'Day 1',
+      dateLabel: '5월 10일 (토)',
+      cards: [
+        {
+          id: 'sched-arrive',
+          name: '간사이 공항 도착',
+          fixedTime: '11:20',
+        },
+      ],
+    },
+    {
+      id: 'day-2',
+      dayLabel: 'Day 2',
+      dateLabel: '5월 11일 (일)',
+      cards: [],
+    },
+    {
+      id: 'day-3',
+      dayLabel: 'Day 3',
+      dateLabel: '5월 12일 (월)',
+      cards: [],
+    },
+    {
+      id: 'day-4',
+      dayLabel: 'Day 4',
+      dateLabel: '5월 13일 (화)',
+      cards: [],
+    },
+    {
+      id: 'day-5',
+      dayLabel: 'Day 5',
+      dateLabel: '5월 14일 (수)',
+      cards: [],
+    },
+  ],
+};

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -1,0 +1,264 @@
+// ArrangePage (SCR-04 배치 '일정 배치' 페이지)
+// 좌측 "카드 목록"(그룹별) + 우측 Day 칸반 보드 + 하단 푸터.
+// 좌측 카드는 클릭하면 우측 상세 패널이 열리고, 드래그하여 Day 컬럼에 배치할 수 있다(목데이터).
+// 동선 검증/다음 단계/API 연동은 depth(이후 작업).
+
+import { ArrowLeft, ArrowRight, Plus } from 'lucide-react';
+import { useState } from 'react';
+
+import ArrangeCardDetailPanel from '@/components/arrange/ArrangeCardDetailPanel';
+import CardListPanel from '@/components/arrange/CardListPanel';
+import DayColumn from '@/components/arrange/DayColumn';
+import AddCardModal, {
+  type AddCardDraft,
+} from '@/components/grouping/AddCardModal';
+import Header from '@/components/header/Header';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { ARRANGE_FIXTURE } from '@/dev-fixtures/arrange-fixture';
+import type {
+  ArrangeCardViewModel,
+  ScheduledCardViewModel,
+} from '@/types/arrange';
+import type { PlaceCardBadgeSpec, PlaceCategory } from '@/types/grouping';
+
+const logStub = (action: string) => () => {
+  console.log('[ArrangePage] stub action:', action);
+};
+
+// 좌측 목록 카드 → Day 보드에 배치되는 일정 카드로 변환.
+const toScheduledCard = (
+  card: ArrangeCardViewModel
+): ScheduledCardViewModel => ({
+  id: card.id,
+  name: card.name,
+  accent: card.accent,
+  badges: card.badges,
+});
+
+// 직접 추가한 카드가 모이는 좌측 그룹(첫 추가 시 생성).
+const ADDED_GROUP_ID = 'added';
+
+// AddCardModal 의 카테고리 → 카드 배지(PlaceCardBadge) 카테고리.
+const ADD_CATEGORY_TO_BADGE: Partial<
+  Record<AddCardDraft['category'], PlaceCategory>
+> = {
+  place: 'place',
+  activity: 'activity',
+  flight: 'transport',
+  lodging: 'lodging',
+  food: 'food',
+};
+
+// 모달 입력(draft) → 좌측 카드 목록에 올릴 ArrangeCard.
+const draftToArrangeCard = (draft: AddCardDraft): ArrangeCardViewModel => {
+  const category = ADD_CATEGORY_TO_BADGE[draft.category];
+  const badges: PlaceCardBadgeSpec[] | undefined = category
+    ? [{ kind: 'category', category }]
+    : undefined;
+
+  return {
+    id: `added-${crypto.randomUUID()}`,
+    name: draft.name,
+    accent: 'green',
+    badges,
+    detail: {
+      classification: '추가한 카드',
+      placementStatus: '배치 가능',
+      region: draft.region || undefined,
+      durationLabel:
+        draft.durationMin > 0 ? `약 ${draft.durationMin}분` : undefined,
+      userIntent: draft.timeMemo || undefined,
+      memo: draft.memo || undefined,
+    },
+  };
+};
+
+const ArrangePage = () => {
+  const { summary, heading, cardListTitle } = ARRANGE_FIXTURE;
+
+  // 배치에 따라 좌측 목록과 우측 보드가 함께 바뀌므로 상태로 보관(목데이터로 초기화).
+  const [groups, setGroups] = useState(ARRANGE_FIXTURE.groups);
+  const [days, setDays] = useState(ARRANGE_FIXTURE.days);
+  const [draggingCardId, setDraggingCardId] = useState<string | null>(null);
+
+  const [detailCard, setDetailCard] = useState<ArrangeCardViewModel | null>(
+    null
+  );
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [addCardOpen, setAddCardOpen] = useState(false);
+
+  // 좌측 패널 카운트(전체/미배치)는 현재 상태에서 파생한다.
+  const remainingCards = groups.reduce(
+    (total, group) => total + group.cards.length,
+    0
+  );
+  const unplacedCount = groups
+    .flatMap((group) => group.cards)
+    .filter((card) => card.draggable !== false).length;
+
+  const openCardDetail = (card: ArrangeCardViewModel) => {
+    setDetailCard(card);
+    setDetailOpen(true);
+  };
+
+  // 카드를 좌측 목록에서 빼고 해당 Day 컬럼에 추가한다.
+  const placeCardOnDay = (cardId: string, dayId: string) => {
+    const card = groups
+      .flatMap((group) => group.cards)
+      .find((item) => item.id === cardId);
+    if (!card) return;
+
+    setGroups((prev) =>
+      prev.map((group) => ({
+        ...group,
+        cards: group.cards.filter((item) => item.id !== cardId),
+      }))
+    );
+    setDays((prev) =>
+      prev.map((day) =>
+        day.id === dayId
+          ? { ...day, cards: [...day.cards, toScheduledCard(card)] }
+          : day
+      )
+    );
+    setDraggingCardId(null);
+  };
+
+  // 모달에서 추가한 카드를 좌측 "추가한 카드" 그룹에 올린다(없으면 그룹 생성).
+  const handleAddCard = (draft: AddCardDraft) => {
+    const newCard = draftToArrangeCard(draft);
+    setGroups((prev) => {
+      if (prev.some((group) => group.id === ADDED_GROUP_ID)) {
+        return prev.map((group) =>
+          group.id === ADDED_GROUP_ID
+            ? { ...group, cards: [...group.cards, newCard] }
+            : group
+        );
+      }
+      return [
+        ...prev,
+        {
+          id: ADDED_GROUP_ID,
+          title: '추가한 카드',
+          description: '직접 추가한 카드예요. 드래그해서 Day에 배치하세요.',
+          cards: [newCard],
+        },
+      ];
+    });
+    setAddCardOpen(false);
+  };
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-muted">
+      <Header
+        currentStepId="arrange"
+        destination={summary.destination}
+        extraDestinations={summary.extraDestinations}
+        travelers={summary.travelers}
+        dateRange={summary.dateRange}
+        actions={
+          <Button size="sm" onClick={() => setAddCardOpen(true)}>
+            <Plus className="size-4" aria-hidden="true" />
+            카드 추가하기
+          </Button>
+        }
+      />
+
+      <main className="flex min-h-0 flex-1 flex-col">
+        {/* 페이지 헤딩 + 우측 액션 */}
+        <div className="flex shrink-0 items-start justify-between gap-4 px-6 pt-5 pb-4">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-foreground">
+              {heading.title}
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {heading.subtitle}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button variant="outline" onClick={logStub('validate-route')}>
+              동선 검증하기
+            </Button>
+            <Button onClick={logStub('next-step')}>다음 단계</Button>
+          </div>
+        </div>
+
+        {/* 본문: 좌 카드 목록 + 우 칸반 보드 */}
+        <div className="flex min-h-0 flex-1 gap-5 px-6 pb-5">
+          <CardListPanel
+            title={cardListTitle}
+            totalCards={remainingCards}
+            groups={groups}
+            onReorder={logStub('reorder')}
+            onSelectCard={openCardDetail}
+            draggingCardId={draggingCardId}
+            onDragCardStart={setDraggingCardId}
+            onDragCardEnd={() => setDraggingCardId(null)}
+          />
+
+          {/* 칸반 보드 — 가로 스크롤 */}
+          <div className="min-w-0 flex-1 overflow-x-auto">
+            <div className="flex h-full gap-4">
+              {days.map((day) => (
+                <DayColumn
+                  key={day.id}
+                  {...day}
+                  dragActive={draggingCardId !== null}
+                  onDropCard={(cardId) => placeCardOnDay(cardId, day.id)}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </main>
+
+      {/* 하단 푸터 */}
+      <footer className="flex shrink-0 items-center justify-between gap-4 border-t border-border bg-background px-6 py-3">
+        <Button variant="outline" onClick={logStub('prev-step')}>
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          이전 단계
+        </Button>
+
+        <div className="flex items-center gap-4">
+          {unplacedCount > 0 && (
+            <span className="text-sm text-muted-foreground">
+              {unplacedCount}개 카드가 아직 배치되지 않았습니다
+            </span>
+          )}
+          <Button onClick={logStub('confirm-itinerary')}>
+            일정 확정하기
+            <ArrowRight className="size-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </footer>
+
+      {/* 좌하단 플로팅 참여자 아바타 */}
+      <Avatar className="fixed bottom-4 left-4 z-50 size-9 shadow-md ring-2 ring-background">
+        <AvatarFallback className="bg-orange-500 text-xs font-semibold text-white">
+          N
+        </AvatarFallback>
+      </Avatar>
+
+      {/* 카드 클릭 시 우측에서 열리는 상세 패널 */}
+      <ArrangeCardDetailPanel
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+        card={detailCard}
+        onSaveMemo={(memo) => {
+          logStub(`save-memo:${detailCard?.id}:${memo}`)();
+          setDetailOpen(false);
+        }}
+      />
+
+      {/* "카드 추가하기" 모달 — 정리 화면(SCR-03)의 AddCardModal 재사용 */}
+      <AddCardModal
+        open={addCardOpen}
+        onOpenChange={setAddCardOpen}
+        onSubmit={handleAddCard}
+      />
+    </div>
+  );
+};
+
+export default ArrangePage;

--- a/apps/frontend/src/pages/DevIndexPage.tsx
+++ b/apps/frontend/src/pages/DevIndexPage.tsx
@@ -5,21 +5,37 @@ import './DevIndexPage.css';
 // 백엔드 시드 데이터(개발 DB)의 첫 trip id. 실 환경에선 존재하지 않을 수 있다.
 const DEFAULT_TRIP_ID = '550e8400-e29b-41d4-a716-446655440000';
 
-const pages = [
+// 화면 흐름(SCR 번호) 순서대로 나열한다. grouping(SCR-03)만 tripId 입력 폼이 필요해
+// 'grouping' 종류로 따로 렌더한다.
+type DevNavEntry =
+  | { kind: 'link'; path: string; title: string; description: string }
+  | { kind: 'grouping' };
+
+const pages: DevNavEntry[] = [
   {
+    kind: 'link',
     path: '/onboarding',
     title: 'Onboarding Page',
     description: '온보딩 페이지',
   },
   {
+    kind: 'link',
     path: '/dump',
     title: 'Dump Page',
     description: '여행 정보 입력 페이지',
   },
   {
+    kind: 'link',
     path: '/progress',
     title: 'Progress Page',
     description: '진행 상태 페이지 (mock 파라미터로 상태 전환 가능)',
+  },
+  { kind: 'grouping' }, // SCR-03
+  {
+    kind: 'link',
+    path: '/arrange',
+    title: 'Arrange Page (SCR-04)',
+    description: '일정 배치 페이지 — Day 칸반 보드 (목데이터 UI)',
   },
 ];
 
@@ -40,38 +56,42 @@ const DevIndexPage = () => {
       <p className="dev-index-desc">개발 중인 페이지 목록입니다.</p>
 
       <ul className="dev-index-list">
-        {pages.map(({ path, title, description }) => (
-          <li key={path} className="dev-index-item">
-            <Link to={path} className="dev-index-link">
-              <strong>{title}</strong>
-              <span className="dev-index-path">{path}</span>
-              <span className="dev-index-description">{description}</span>
-            </Link>
-          </li>
-        ))}
-
-        <li className="dev-index-item">
-          <form className="dev-index-link" onSubmit={handleOpenGrouping}>
-            <strong>Grouping (SCR-03)</strong>
-            <span className="dev-index-path">/grouping?tripId=…</span>
-            <span className="dev-index-description">
-              정보 정리하기 — 그룹화 화면 (실제 BE 연동)
-            </span>
-            <div className="dev-index-tripid-row">
-              <input
-                type="text"
-                value={tripId}
-                onChange={(event) => setTripId(event.target.value)}
-                placeholder="trip UUID"
-                className="dev-index-tripid-input"
-                aria-label="trip ID"
-              />
-              <button type="submit" className="dev-index-tripid-button">
-                이동
-              </button>
-            </div>
-          </form>
-        </li>
+        {pages.map((page) =>
+          page.kind === 'grouping' ? (
+            <li key="grouping" className="dev-index-item">
+              <form className="dev-index-link" onSubmit={handleOpenGrouping}>
+                <strong>Grouping (SCR-03)</strong>
+                <span className="dev-index-path">/grouping?tripId=…</span>
+                <span className="dev-index-description">
+                  정보 정리하기 — 그룹화 화면 (실제 BE 연동)
+                </span>
+                <div className="dev-index-tripid-row">
+                  <input
+                    type="text"
+                    value={tripId}
+                    onChange={(event) => setTripId(event.target.value)}
+                    placeholder="trip UUID"
+                    className="dev-index-tripid-input"
+                    aria-label="trip ID"
+                  />
+                  <button type="submit" className="dev-index-tripid-button">
+                    이동
+                  </button>
+                </div>
+              </form>
+            </li>
+          ) : (
+            <li key={page.path} className="dev-index-item">
+              <Link to={page.path} className="dev-index-link">
+                <strong>{page.title}</strong>
+                <span className="dev-index-path">{page.path}</span>
+                <span className="dev-index-description">
+                  {page.description}
+                </span>
+              </Link>
+            </li>
+          )
+        )}
       </ul>
     </main>
   );

--- a/apps/frontend/src/types/arrange.ts
+++ b/apps/frontend/src/types/arrange.ts
@@ -1,0 +1,105 @@
+/**
+ * SCR-04 배치 '일정 배치' 화면(ArrangePage)이 통째로 받아 렌더링하는
+ * 화면 데이터(ViewModel)의 타입 모음.
+ *
+ * 좌측 "카드 목록"(그룹별) + 우측 Day 칸반 보드 + 하단 푸터로 구성된다.
+ * 1차는 정적 UI(드래그앤드롭 동작 = depth, 이후 작업)만 다룬다.
+ */
+import type { PlaceCardAccent, PlaceCardBadgeSpec } from './grouping';
+
+/**
+ * 좌측 "카드 목록"의 카드 한 장.
+ * - draggable=true(기본): 우측에 그립 핸들 — 보드로 드래그해 배치(동작은 depth)
+ * - draggable=false: 항공권처럼 Day에 고정되는 카드. 그립 대신 "이동" 힌트 +
+ *   actionLabel 버튼("클릭하여 수정")을 노출한다.
+ */
+export type ArrangeCardViewModel = {
+  /** React key + stub 핸들러 식별용. 도메인 id 아님 */
+  id: string;
+  name: string;
+  /** 좌측 액센트 바 색. 미지정 시 'green' */
+  accent?: PlaceCardAccent;
+  /** 카테고리/AI 배지들(PlaceCardBadge 재사용). 좌 → 우 순서로 렌더 */
+  badges?: PlaceCardBadgeSpec[];
+  /** false면 고정 카드(항공권 등) — 그립 핸들 대신 "이동" 힌트를 표시. 기본 true */
+  draggable?: boolean;
+  /** 카드 클릭 시 우측에서 슬라이드되어 열리는 상세 패널(ArrangeCardDetailPanel) 데이터 */
+  detail?: ArrangeCardDetailViewModel;
+};
+
+/**
+ * 카드 클릭 시 열리는 상세 패널(ArrangeCardDetailPanel)에 들어가는 데이터.
+ * 정리 화면(SCR-03)의 패널 구성요소(SidePanel / StatusInfoBox / DetailRow / UserMemoField)를
+ * 그대로 재사용하므로 필드 구성도 CardDetailViewModel 과 비슷하게 맞춘다.
+ */
+export type ArrangeCardDetailViewModel = {
+  /** "상태 정보" 박스의 "분류" 값(예: "확정됨", "고정 일정"). 상단 상태 pill 라벨로도 쓰인다 */
+  classification: string;
+  /** "상태 정보" 박스의 "배치 상태" 값(예: "배치 가능", "Day 1 고정") */
+  placementStatus: string;
+  /** "상세 정보" — 고정 시작 시간(✈, 항공권 등). 없으면 행 생략 */
+  fixedTimeLabel?: string;
+  /** "상세 정보" — 위치(📍). 없으면 행 생략 */
+  region?: string;
+  /** "상세 정보" — 예상 소요 시간/체크인 정보(⏱). 없으면 행 생략 */
+  durationLabel?: string;
+  /** "상세 정보" — 원하셨던 내용(🙂). 없으면 행 생략 */
+  userIntent?: string;
+  /** "상세 정보" — 알아두면 좋아요(ⓘ amber 강조). 없으면 행 생략 */
+  aiHint?: string;
+  /** "사용자 메모" textarea 초기값. 보통 ''. 입력값이 달라지면 "메모 저장"이 활성화된다 */
+  memo?: string;
+};
+
+/** 좌측 카드 그룹 한 덩어리(항공권 / 숙소 / 지역 그룹 등). */
+export type ArrangeCardGroup = {
+  id: string;
+  /** 그룹 제목("항공권", "숙소", "오사카" 등) */
+  title: string;
+  /** 제목 아래 설명 한 줄(없으면 생략) */
+  description?: string;
+  cards: ArrangeCardViewModel[];
+};
+
+/** 보드(Day 컬럼)에 배치된 일정 카드 한 장. */
+export type ScheduledCardViewModel = {
+  id: string;
+  name: string;
+  accent?: PlaceCardAccent;
+  badges?: PlaceCardBadgeSpec[];
+  /** 고정 시작 시간(항공권 등). 있으면 "고정 시작 시간" 라벨 + 시간 강조 카드로 렌더 */
+  fixedTime?: string;
+  /** 일반 일정 시간 라벨("10:30" 등). fixedTime이 없을 때만 사용 */
+  timeLabel?: string;
+};
+
+/** 우측 칸반 보드의 Day 컬럼 한 개. */
+export type DayColumnViewModel = {
+  id: string;
+  /** "Day 1" */
+  dayLabel: string;
+  /** "5월 10일 (토)" */
+  dateLabel: string;
+  cards: ScheduledCardViewModel[];
+};
+
+/** ArrangePage 가 통째로 받는 화면 데이터. fixture 의 최상위 형태. */
+export type ArrangeViewModel = {
+  /** 헤더(Header)에 넘기는 여행 메타 */
+  summary: {
+    destination: string;
+    extraDestinations: number;
+    travelers: number;
+    dateRange: string;
+  };
+  /** 페이지 헤딩 블록(h1 + 보조 설명) */
+  heading: { title: string; subtitle: string };
+  /** 좌측 패널 제목(보통 "카드 목록") */
+  cardListTitle: string;
+  /** 좌측 카드 그룹 목록(렌더 순서 = 배열 순서) */
+  groups: ArrangeCardGroup[];
+  /** 우측 보드의 Day 컬럼들 */
+  days: DayColumnViewModel[];
+};
+// 좌측 패널의 카드 수/미배치 수는 배치(드래그앤드롭)에 따라 바뀌므로
+// 고정 필드로 두지 않고 ArrangePage 에서 groups/days 상태로부터 파생한다.


### PR DESCRIPTION
## 📝 작업 내용

>
(1) SCR-04 '일정 배치' 화면 UI를 추가
(2) 정리 화면(SCR-03) 컴포넌트를 재사용
(3) 카드를 Day 보드에 드래그앤드롭으로 배치하도록 구현


## 🔗 관련 이슈

closes #163

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? — 카드 클릭→상세 패널, 카드 드래그→Day 배치, 카드 추가 모달 제출까지 브라우저로 확인. `tsc -b && vite build` 성공, `/arrange` 콘솔 에러 0
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — `/arrange` 신규 추가 + 라우트/Header/DevIndex 진입점만 변경(가산적). 기존 페이지 로직 미수정, 빌드 통과
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요? — TODO/FIXME 없음. 목데이터는 `dev-fixtures/arrange-fixture.ts`에 격리(BE 연동 시 fetch+매퍼로 교체 예정), 미연동 액션은 `logStub`로 명시
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? — SCR-04 배치 화면 UI 단일 기능 (커밋 1개 / FE 12개 파일)

## 👀 리뷰어에게

- **컴포넌트 재사용**: `ArrangeCardDetailPanel`은 SCR-03 `CardDetailPanel`과 동일한 부품(SidePanel·StatusInfoBox·DetailRow·UserMemoField·PanelActions·PlaceCardBadge) 조합입니다. 카드 추가 모달은 `grouping/AddCardModal`을 그대로 가져와 씁니다.
- **드래그앤드롭**: 의존성 추가 없이 네이티브 HTML5 DnD로 구현했습니다. 한계로 **터치 디바이스 / Day 간 이동 / 보드→목록 되돌리기 / 재정렬**은 아직 미지원입니다. 추후 필요 시 `@dnd-kit` 도입을 검토하면 좋겠습니다.
- **항공권 카드**: `draggable: false`로 드래그 대상에서 제외했습니다(Day 고정 의미 유지). "모든 카드 드래그"가 요구사항이면 알려주세요.
- 좌측 카운트(전체/미배치)는 별도 상태 없이 `groups`/`days`에서 파생합니다.
- 현재는 정적 UI 단계라 **동선 검증 / 다음·이전 단계 / 일정 확정 / 재정렬 / 메모 저장**은 `logStub` 스텁입니다(API 연동은 이후 작업).

## 📸 스크린샷
