### PR TITLE
Feat/be 170 dump accommodation inputs

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpAsyncProcessor.java
@@ -1,6 +1,7 @@
 package com.tripkey.domain.dump;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tripkey.domain.alert.AlertCard;
 import com.tripkey.domain.alert.AlertCardRepository;
@@ -65,7 +66,7 @@ public class DumpAsyncProcessor {
                     destinations,
                     trip.getTravelDays(),
                     trip.getCompanionCount(),
-                    null,
+                    deserializeAccommodations(job.getAccommodationInputs()),
                     deserializeFlight(job.getDepartureFlight()),
                     deserializeFlight(job.getReturnFlight())
             );
@@ -127,6 +128,17 @@ public class DumpAsyncProcessor {
             return objectMapper.readValue(json, AiParseRequest.FlightInput.class);
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Failed to deserialize flight input", e);
+        }
+    }
+
+    private List<AiParseRequest.AccommodationInput> deserializeAccommodations(String json) {
+        if (json == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<AiParseRequest.AccommodationInput>>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize accommodation inputs", e);
         }
     }
 

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJob.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpJob.java
@@ -46,6 +46,10 @@ public class DumpJob {
     @Column(name = "return_flight", columnDefinition = "jsonb")
     private String returnFlight;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "accommodation_inputs", columnDefinition = "jsonb")
+    private String accommodationInputs;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
@@ -53,17 +57,24 @@ public class DumpJob {
     private OffsetDateTime updatedAt;
 
     public static DumpJob create(UUID tripId, String dumpText) {
-        return create(tripId, dumpText, null, null);
+        return create(tripId, dumpText, null, null, null);
     }
 
     public static DumpJob create(UUID tripId, String dumpText,
                                  String departureFlight, String returnFlight) {
+        return create(tripId, dumpText, departureFlight, returnFlight, null);
+    }
+
+    public static DumpJob create(UUID tripId, String dumpText,
+                                 String departureFlight, String returnFlight,
+                                 String accommodationInputs) {
         DumpJob job = new DumpJob();
         job.jobId = UUID.randomUUID();
         job.tripId = tripId;
         job.dumpText = dumpText;
         job.departureFlight = departureFlight;
         job.returnFlight = returnFlight;
+        job.accommodationInputs = accommodationInputs;
         job.status = "pending";
         job.step = null;
         return job;

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/DumpService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/DumpService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -43,7 +44,8 @@ public class DumpService {
                 tripId,
                 dumpText,
                 serializeFlight(request.departureFlight()),
-                serializeFlight(request.returnFlight()));
+                serializeFlight(request.returnFlight()),
+                serializeAccommodations(request.accommodationInputs()));
         dumpJobRepository.save(job);
         dumpAsyncProcessor.process(job.getJobId());
 
@@ -66,6 +68,17 @@ public class DumpService {
             return objectMapper.writeValueAsString(flight);
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Failed to serialize flight input", e);
+        }
+    }
+
+    private String serializeAccommodations(List<DumpSubmitRequest.AccommodationInput> accommodations) {
+        if (accommodations == null || accommodations.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(accommodations);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize accommodation inputs", e);
         }
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/dump/DumpSubmitRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/dump/DumpSubmitRequest.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
 public record DumpSubmitRequest(
         @NotBlank
         @Size(min = 10, max = 3000, message = "10자 이상 3000자 이하로 입력해주세요")
@@ -14,7 +16,10 @@ public record DumpSubmitRequest(
         FlightInput departureFlight,
 
         @JsonProperty("return_flight")
-        FlightInput returnFlight
+        FlightInput returnFlight,
+
+        @JsonProperty("accommodation_inputs")
+        List<AccommodationInput> accommodationInputs
 ) {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -23,6 +28,15 @@ public record DumpSubmitRequest(
             @JsonProperty("arrival_airport") String arrivalAirport,
             @JsonProperty("flight_number") String flightNumber,
             String datetime
+    ) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record AccommodationInput(
+            String name,
+            String location,
+            @JsonProperty("check_in") String checkIn,
+            @JsonProperty("check_out") String checkOut
     ) {
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpAsyncProcessorTest.java
@@ -231,4 +231,36 @@ class DumpAsyncProcessorTest {
         assertThat(sent.departureFlight().flightNumber()).isEqualTo("KE703");
         assertThat(sent.returnFlight()).isNull();
     }
+
+    @Test
+    void processPassesStoredAccommodationsToParseRequest() {
+        UUID tripId = UUID.randomUUID();
+        String accJson = "[{\"name\":\"호텔 그란비아 오사카\",\"location\":\"오사카\",\"check_in\":\"2026-07-01\",\"check_out\":\"2026-07-03\"}]";
+        DumpJob job = DumpJob.create(tripId, "오사카 3박4일 여행입니다.", null, null, accJson);
+        Trip trip = new Trip((short) 4, (short) 2);
+        TripDestination destination = new TripDestination(trip, "오사카", (short) 0);
+
+        AiPlaceCardDto card = new AiPlaceCardDto(
+                "place-1", "도톈보리", "place", "confirmed", "ready_partial",
+                false, false, (short) 90, null, "오사카",
+                null, null, null, null, null, null, null, List.of(), null, null, null);
+        AiParseResponse response = new AiParseResponse(List.of(card), "요약", List.of(), "3.2.0");
+
+        when(dumpJobRepository.findById(job.getJobId())).thenReturn(Optional.of(job));
+        when(dumpJobRepository.save(any(DumpJob.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
+        when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(tripId)).thenReturn(List.of(destination));
+        when(placeCardRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ArgumentCaptor<AiParseRequest> captor = ArgumentCaptor.forClass(AiParseRequest.class);
+        when(aiEngineClient.parseDump(captor.capture())).thenReturn(response);
+
+        dumpAsyncProcessor.process(job.getJobId());
+
+        AiParseRequest sent = captor.getValue();
+        assertThat(sent.accommodationInputs()).isNotNull().hasSize(1);
+        assertThat(sent.accommodationInputs().get(0).name()).isEqualTo("호텔 그란비아 오사카");
+        assertThat(sent.accommodationInputs().get(0).checkIn()).isEqualTo("2026-07-01");
+        assertThat(sent.accommodationInputs().get(0).checkOut()).isEqualTo("2026-07-03");
+    }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpJobFlightInputIntegrationTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpJobFlightInputIntegrationTest.java
@@ -50,4 +50,19 @@ class DumpJobFlightInputIntegrationTest {
         assertThat(reloaded.getDepartureFlight()).contains("ICN").contains("KE703");
         assertThat(reloaded.getReturnFlight()).isNull();
     }
+
+    @Test
+    void dumpJobPersistsAccommodationJsonbRoundTrip() {
+        Trip trip = new Trip((short) 3, (short) 1);
+        tripRepository.saveAndFlush(trip);
+        String accJson = "[{\"name\":\"호텔 그란비아 오사카\",\"location\":\"오사카\",\"check_in\":\"2026-07-01\",\"check_out\":\"2026-07-03\"}]";
+
+        DumpJob job = DumpJob.create(trip.getTripId(), "오사카 3박4일 여행입니다.", null, null, accJson);
+        dumpJobRepository.saveAndFlush(job);
+
+        DumpJob reloaded = dumpJobRepository.findById(job.getJobId()).orElseThrow();
+        assertThat(reloaded.getAccommodationInputs()).contains("호텔 그란비아 오사카").contains("check_in");
+        assertThat(reloaded.getDepartureFlight()).isNull();
+        assertThat(reloaded.getReturnFlight()).isNull();
+    }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/dump/DumpServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/dump/DumpServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +48,7 @@ class DumpServiceTest {
         when(tripRepository.existsById(tripId)).thenReturn(true);
         when(dumpJobRepository.save(any(DumpJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        DumpSubmitRequest req = new DumpSubmitRequest("오사카 3박4일 여행입니다.", null, null);
+        DumpSubmitRequest req = new DumpSubmitRequest("오사카 3박4일 여행입니다.", null, null, null);
         DumpSubmitResponse response = dumpService.submit(tripId, req);
 
         ArgumentCaptor<DumpJob> jobCaptor = ArgumentCaptor.forClass(DumpJob.class);
@@ -69,12 +70,49 @@ class DumpServiceTest {
 
         DumpSubmitRequest.FlightInput dep =
                 new DumpSubmitRequest.FlightInput("ICN", "NRT", "KE703", "2026-07-01T09:00:00+09:00");
-        DumpSubmitRequest req = new DumpSubmitRequest("오사카 3박4일 여행입니다.", dep, null);
+        DumpSubmitRequest req = new DumpSubmitRequest("오사카 3박4일 여행입니다.", dep, null, null);
 
         dumpService.submit(tripId, req);
 
         DumpJob saved = jobCaptor.getValue();
         assertThat(saved.getDepartureFlight()).contains("ICN").contains("KE703");
         assertThat(saved.getReturnFlight()).isNull();
+    }
+
+    @Test
+    void submitStoresStructuredAccommodationsOnDumpJob() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        ArgumentCaptor<DumpJob> jobCaptor = ArgumentCaptor.forClass(DumpJob.class);
+        when(dumpJobRepository.save(jobCaptor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        DumpSubmitRequest.AccommodationInput hotel =
+                new DumpSubmitRequest.AccommodationInput(
+                        "호텔 그란비아 오사카", "오사카", "2026-07-01", "2026-07-03");
+        DumpSubmitRequest req = new DumpSubmitRequest(
+                "오사카 3박4일 여행입니다.", null, null, List.of(hotel));
+
+        dumpService.submit(tripId, req);
+
+        DumpJob saved = jobCaptor.getValue();
+        assertThat(saved.getAccommodationInputs())
+                .contains("호텔 그란비아 오사카")
+                .contains("check_in")
+                .contains("2026-07-01");
+    }
+
+    @Test
+    void submitLeavesAccommodationsNullWhenEmpty() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        ArgumentCaptor<DumpJob> jobCaptor = ArgumentCaptor.forClass(DumpJob.class);
+        when(dumpJobRepository.save(jobCaptor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        DumpSubmitRequest req = new DumpSubmitRequest(
+                "오사카 3박4일 여행입니다.", null, null, List.of());
+
+        dumpService.submit(tripId, req);
+
+        assertThat(jobCaptor.getValue().getAccommodationInputs()).isNull();
     }
 }

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -33,6 +33,7 @@ create table dump_jobs (
   context_summary  text,
   departure_flight jsonb,
   return_flight    jsonb,
+  accommodation_inputs jsonb,
   created_at      timestamptz not null default now(),
   updated_at      timestamptz not null default now()
 );

--- a/shared/docs/migrations/V009__dump_jobs_accommodation_inputs.sql
+++ b/shared/docs/migrations/V009__dump_jobs_accommodation_inputs.sql
@@ -1,0 +1,10 @@
+-- TripKey migration: dump_jobs 숙박 구조화 입력 컬럼
+-- Date: 2026-06-01
+-- Scope: /trips/{tripId}/dump 가 accommodation_inputs(구조화 숙박 리스트)를 받아 비동기 처리 시
+--        AiParseRequest 로 전달하기 위해 DumpJob 에 jsonb 로 영속화한다.
+-- 선례: V008__dump_jobs_flight_inputs.sql (항공편 — 단일 객체 ×2, 본 작업은 리스트).
+-- 적용 대상: Supabase (단일 인스턴스). 적용 방법: SQL Editor 전체 실행 (멱등).
+-- 동기 산출물: schema.sql / postgis-test-schema.sql / DumpJob 엔티티.
+
+alter table public.dump_jobs
+  add column if not exists accommodation_inputs jsonb;

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -35,6 +35,7 @@ create table if not exists public.dump_jobs (
   context_summary  text,                                            -- AI가 파악한 여행 스타일 요약
   departure_flight jsonb,                                           -- 출발 항공편 구조화 입력 (FlightInput JSON)
   return_flight    jsonb,                                           -- 귀국 항공편 구조화 입력 (FlightInput JSON)
+  accommodation_inputs jsonb,                                       -- 숙박 구조화 입력 리스트 (AccommodationInput JSON 배열)
   created_at      timestamptz not null default now(),
   updated_at      timestamptz not null default now()
 );


### PR DESCRIPTION
## 📝 작업 내용

> dump 입력 시 구조화된 숙박 정보를 함께 받아, AI 파싱 단계에서 숙소 카드가
> 자동 생성되도록 합니다. 항공편(#157)과 동일한 흐름이며, 숙박은 여러 개라
> "리스트"로 받는 점만 다릅니다.

**왜 dump 요청에 싣나?**
dump 파싱이 돌 때마다 해당 trip의 카드를 전부 삭제하고 AI 결과로 재생성합니다
(`deleteAllByTripId`). 따라서 보조정보(항공편·숙박)는 dump 요청에 실어 파싱
단계에서 카드가 만들어져야 영속됩니다. (카드 추가 API로 넣으면 재파싱 시 사라짐)

**요청 예시** — `POST /trips/{tripId}/dump`
```jsonc
{
  "dump_text": "...",
  "accommodation_inputs": [          // nullable, 빈 배열 허용
    {
      "name": "호텔 그란비아 오사카",
      "location": "오사카",
      "check_in": "2026-07-01",
      "check_out": "2026-07-03"
    }
  ]
}
```

**변경 요약**
- `dump_jobs.accommodation_inputs` jsonb 컬럼 추가 (마이그레이션 V009)
- 요청 → 저장(직렬화) → AI 파싱 전달(역직렬화)까지 BE 처리 추가
- 빈 리스트/미입력은 저장하지 않음(null)
- AI 엔진은 이미 `accommodation_inputs`를 지원 → AI팀 작업 없음

## 🔗 관련 이슈

closes #170

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서 (shared/docs: 마이그레이션·schema.sql)

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인 (compile + DumpServiceTest·DumpAsyncProcessorTest 통과)
- [x] 기존 기능 회귀 없음 (기존 dump submit·항공편 경로 영향 없음, create 오버로드로 하위호환 유지)
- [x] 하드코딩/임시 주석(TODO·FIXME) 없음
- [x] PR 범위가 하나의 기능 단위로 정리됨

## 👀 리뷰어에게

> - **배포 완료**: `accommodation_inputs jsonb` 컬럼을 Supabase(main/PRODUCTION)에 적용 완료.
> - **항공편(#157)과 차이**: 항공편은 단일 객체 ×2, 숙박은 리스트. 역직렬화에 `TypeReference<List<...>>` 사용.
> - **직렬화 호환**: 요청·AI 전달 DTO 모두 `@JsonProperty` snake_case로 매퍼 설정과 무관하게 라운드트립.
> - **통합 테스트**: Testcontainers(Docker) 필요 — CI에서 검증됩니다.

## 📸 스크린샷

> 없음 (BE 변경, UI 영향 없음)
