### PR TITLE
Feat/be 166 destination search places

### DIFF
--- a/apps/ai-engine/app/api/destinations.py
+++ b/apps/ai-engine/app/api/destinations.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, HTTPException, status
+
+from app.schemas.destination_search import (
+    DestinationSearchRequest,
+    DestinationSearchResponse,
+)
+from app.services.destination_search import search_destinations
+
+router = APIRouter(prefix="/internal/ai", tags=["destinations"])
+
+
+@router.post("/destinations/search", response_model=DestinationSearchResponse)
+async def search(req: DestinationSearchRequest) -> DestinationSearchResponse:
+    try:
+        results = await search_destinations(req.query)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="places_lookup_failed",
+        ) from exc
+    return DestinationSearchResponse(results=results)

--- a/apps/ai-engine/app/main.py
+++ b/apps/ai-engine/app/main.py
@@ -5,6 +5,7 @@ import logging
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
+from app.api.destinations import router as destinations_router
 from app.api.non_blocking_enrichment import router as non_blocking_enrichment_router
 from app.api.parse import router as parse_router
 
@@ -15,6 +16,7 @@ logging.basicConfig(level=logging.INFO)
 app = FastAPI(title="TripKey AI Engine")
 app.include_router(parse_router)
 app.include_router(non_blocking_enrichment_router)
+app.include_router(destinations_router)
 
 
 @app.get("/health")

--- a/apps/ai-engine/app/schemas/destination_search.py
+++ b/apps/ai-engine/app/schemas/destination_search.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+
+
+class DestinationSearchRequest(BaseModel):
+    query: str = Field(..., min_length=1)
+
+
+class Destination(BaseModel):
+    name: str
+    country: str | None = None
+    place_id: str
+
+
+class DestinationSearchResponse(BaseModel):
+    results: list[Destination]

--- a/apps/ai-engine/app/services/destination_search.py
+++ b/apps/ai-engine/app/services/destination_search.py
@@ -1,0 +1,59 @@
+"""Google Places Autocomplete v1 기반 목적지 검색.
+
+설계 노트: 카드 보강용 Places(`places:searchText`)와 분리해 도시/지역 타이프어헤드
+용도로 `places:autocomplete` 를 호출한다. country 는 응답의
+``structuredFormat.secondaryText`` 그대로 사용한다(languageCode=ko 기준 보통 국가명).
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from app.schemas.destination_search import Destination
+
+PLACES_AUTOCOMPLETE_URL = "https://places.googleapis.com/v1/places:autocomplete"
+
+
+def _places_api_key() -> str | None:
+    return os.getenv("GOOGLE_MAPS_API_KEY")
+
+
+async def search_destinations(query: str) -> list[Destination]:
+    api_key = _places_api_key()
+    if not api_key:
+        raise RuntimeError("GOOGLE_MAPS_API_KEY is not configured")
+
+    headers = {
+        "X-Goog-Api-Key": api_key,
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "input": query,
+        "languageCode": "ko",
+        "includedPrimaryTypes": ["(cities)"],
+    }
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.post(PLACES_AUTOCOMPLETE_URL, json=payload, headers=headers)
+
+    response.raise_for_status()
+    data = response.json() or {}
+    suggestions = data.get("suggestions") or []
+
+    results: list[Destination] = []
+    for suggestion in suggestions:
+        prediction = suggestion.get("placePrediction") if isinstance(suggestion, dict) else None
+        if not prediction:
+            continue
+        structured = prediction.get("structuredFormat") or {}
+        main_text = (structured.get("mainText") or {}).get("text")
+        secondary_text = (structured.get("secondaryText") or {}).get("text")
+        place_id = prediction.get("placeId")
+        if not main_text or not place_id:
+            continue
+        results.append(
+            Destination(name=main_text, country=secondary_text, place_id=place_id)
+        )
+    return results

--- a/apps/ai-engine/app/services/destination_search.py
+++ b/apps/ai-engine/app/services/destination_search.py
@@ -17,7 +17,7 @@ PLACES_AUTOCOMPLETE_URL = "https://places.googleapis.com/v1/places:autocomplete"
 
 
 def _places_api_key() -> str | None:
-    return os.getenv("GOOGLE_MAPS_API_KEY")
+    return os.getenv("GOOGLE_PLACES_API_KEY") or os.getenv("GOOGLE_MAPS_API_KEY")
 
 
 async def search_destinations(query: str) -> list[Destination]:

--- a/apps/ai-engine/tests/test_destination_search.py
+++ b/apps/ai-engine/tests/test_destination_search.py
@@ -1,0 +1,81 @@
+import pytest
+import httpx
+
+from app.schemas.destination_search import Destination
+from app.services import destination_search as svc
+
+
+@pytest.mark.asyncio
+async def test_search_destinations_maps_autocomplete_response(monkeypatch):
+    sample_response = {
+        "suggestions": [
+            {
+                "placePrediction": {
+                    "placeId": "ChIJ_osaka",
+                    "structuredFormat": {
+                        "mainText": {"text": "오사카"},
+                        "secondaryText": {"text": "일본"},
+                    },
+                }
+            },
+            {
+                "placePrediction": {
+                    "placeId": "ChIJ_tokyo",
+                    "structuredFormat": {
+                        "mainText": {"text": "도쿄"},
+                        "secondaryText": {"text": "일본"},
+                    },
+                }
+            },
+        ]
+    }
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "test-key")
+
+    async def fake_post(self, url, json, headers):
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json=sample_response, request=request)
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    results = await svc.search_destinations("오사")
+
+    assert results == [
+        Destination(name="오사카", country="일본", place_id="ChIJ_osaka"),
+        Destination(name="도쿄", country="일본", place_id="ChIJ_tokyo"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_destinations_empty_suggestions(monkeypatch):
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "test-key")
+
+    async def fake_post(self, url, json, headers):
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, json={}, request=request)
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    results = await svc.search_destinations("zzz")
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_destinations_raises_on_missing_key(monkeypatch):
+    monkeypatch.setattr(svc, "_places_api_key", lambda: None)
+
+    with pytest.raises(RuntimeError):
+        await svc.search_destinations("오사")
+
+
+@pytest.mark.asyncio
+async def test_search_destinations_raises_on_http_error(monkeypatch):
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "test-key")
+
+    async def fake_post(self, url, json, headers):
+        request = httpx.Request("POST", url)
+        return httpx.Response(500, json={"error": "boom"}, request=request)
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await svc.search_destinations("오사")

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/TripService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/TripService.java
@@ -4,6 +4,8 @@ import com.tripkey.dto.trip.DestinationSearchResponse;
 import com.tripkey.dto.trip.DestinationSearchResponse.DestinationDto;
 import com.tripkey.dto.trip.TripCreateRequest;
 import com.tripkey.dto.trip.TripCreateResponse;
+import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiDestinationSearchResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ public class TripService {
 
     private final TripRepository tripRepository;
     private final TripDestinationRepository tripDestinationRepository;
+    private final AiEngineClient aiEngineClient;
 
     private static final List<DestinationDto> FALLBACK_DESTINATIONS = List.of(
             new DestinationDto("오사카", "일본", null),
@@ -36,12 +39,19 @@ public class TripService {
 
     @Transactional(readOnly = true)
     public DestinationSearchResponse searchDestinations(String query) {
-        // TODO: Google Places API 연동 후 실제 검색으로 교체
-        List<DestinationDto> filtered = FALLBACK_DESTINATIONS.stream()
-                .filter(d -> d.name().contains(query) || d.country().contains(query))
-                .toList();
-
-        return new DestinationSearchResponse(filtered);
+        try {
+            AiDestinationSearchResponse ai = aiEngineClient.searchDestinations(query);
+            List<DestinationDto> results = ai.results().stream()
+                    .map(r -> new DestinationDto(r.name(), r.country(), r.placeId()))
+                    .toList();
+            return new DestinationSearchResponse(results);
+        } catch (Exception e) {
+            log.warn("Destination search via AI engine failed; falling back to local list. query={}", query, e);
+            List<DestinationDto> filtered = FALLBACK_DESTINATIONS.stream()
+                    .filter(d -> d.name().contains(query) || d.country().contains(query))
+                    .toList();
+            return new DestinationSearchResponse(filtered);
+        }
     }
 
     @Transactional

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
@@ -1,6 +1,8 @@
 package com.tripkey.infra.aiengine;
 
 import com.tripkey.infra.aiengine.dto.AiCardParseRequest;
+import com.tripkey.infra.aiengine.dto.AiDestinationSearchRequest;
+import com.tripkey.infra.aiengine.dto.AiDestinationSearchResponse;
 import com.tripkey.infra.aiengine.dto.AiParseRequest;
 import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
@@ -77,6 +79,23 @@ public class AiEngineClient {
                     e);
         } catch (WebClientRequestException e) {
             throw new IllegalStateException("Failed to call ai-engine card parse endpoint", e);
+        }
+    }
+
+    public AiDestinationSearchResponse searchDestinations(String query) {
+        try {
+            AiDestinationSearchResponse response = aiEngineWebClient.post()
+                    .uri("/internal/ai/destinations/search")
+                    .bodyValue(new AiDestinationSearchRequest(query))
+                    .retrieve()
+                    .bodyToMono(AiDestinationSearchResponse.class)
+                    .block();
+            if (response == null) {
+                throw new IllegalStateException("ai-engine returned an empty destination search response body");
+            }
+            return response;
+        } catch (WebClientResponseException | WebClientRequestException e) {
+            throw new IllegalStateException("Failed to call ai-engine destination search endpoint", e);
         }
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiDestinationSearchRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiDestinationSearchRequest.java
@@ -1,0 +1,8 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AiDestinationSearchRequest(
+        @JsonProperty("query") String query
+) {
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiDestinationSearchResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiDestinationSearchResponse.java
@@ -1,0 +1,19 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AiDestinationSearchResponse(
+        List<Destination> results
+) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Destination(
+            String name,
+            String country,
+            @JsonProperty("place_id") String placeId
+    ) {
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/trip/TripServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/trip/TripServiceTest.java
@@ -1,0 +1,70 @@
+package com.tripkey.domain.trip;
+
+import com.tripkey.infra.aiengine.AiEngineClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TripServiceTest {
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private TripDestinationRepository tripDestinationRepository;
+
+    @Mock
+    private AiEngineClient aiEngineClient;
+
+    @InjectMocks
+    private TripService tripService;
+
+    @Test
+    void searchDestinationsReturnsAiEngineResults() {
+        com.tripkey.infra.aiengine.dto.AiDestinationSearchResponse aiResults =
+                new com.tripkey.infra.aiengine.dto.AiDestinationSearchResponse(
+                        java.util.List.of(
+                                new com.tripkey.infra.aiengine.dto.AiDestinationSearchResponse.Destination(
+                                        "오사카", "일본", "ChIJ_osaka")
+                        )
+                );
+        when(aiEngineClient.searchDestinations("오사")).thenReturn(aiResults);
+
+        var response = tripService.searchDestinations("오사");
+
+        org.assertj.core.api.Assertions.assertThat(response.results())
+                .hasSize(1)
+                .extracting(d -> d.name(), d -> d.country(), d -> d.placeId())
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("오사카", "일본", "ChIJ_osaka"));
+    }
+
+    @Test
+    void searchDestinationsFallsBackOnAiEngineFailure() {
+        when(aiEngineClient.searchDestinations("오사"))
+                .thenThrow(new IllegalStateException("ai down"));
+
+        var response = tripService.searchDestinations("오사");
+
+        org.assertj.core.api.Assertions.assertThat(response.results())
+                .isNotEmpty()
+                .allSatisfy(d ->
+                        org.assertj.core.api.Assertions.assertThat(d.name() + d.country())
+                                .contains("오사"));
+    }
+
+    @Test
+    void searchDestinationsReturnsEmptyWhenAiEngineReturnsEmptyResults() {
+        when(aiEngineClient.searchDestinations("zzz"))
+                .thenReturn(new com.tripkey.infra.aiengine.dto.AiDestinationSearchResponse(java.util.List.of()));
+
+        var response = tripService.searchDestinations("zzz");
+
+        org.assertj.core.api.Assertions.assertThat(response.results()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

> SCR-01 온보딩의 여행지 검색을 하드코딩 fallback 목록에서 실제 Google Places Autocomplete 검색으로 교체

- 기존 패턴(Google Places = AI 엔진 소유)과 일관되게, **AI 엔진에 목적지 검색 엔드포인트 신설** + **BE 위임**.
- **AI 엔진**: `POST /internal/ai/destinations/search` — Google Places Autocomplete v1(`places:autocomplete`, `languageCode=ko`, `includedPrimaryTypes=["(cities)"]`) 호출, `structuredFormat` 매핑(name=mainText, country=secondaryText, place_id).
- **BE**: `AiEngineClient.searchDestinations(query)` 로 위임. 실패(timeout/4xx/5xx) 시 기존 `FALLBACK_DESTINATIONS` 12개로 **graceful degradation**.
- **외부 API 시그니처 불변**: `GET /trips/destinations/search?q=`, `DestinationSearchResponse`/`DestinationDto` 그대로 — **FE 영향 없음**.
- Google API 키는 AI 엔진(`GOOGLE_MAPS_API_KEY`)에만 유지(키 일원화, BE 변경 없음).

## 🔗 관련 이슈

closes #166

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? — 단위 테스트(AI 4 + BE 3) + **실제 Google Places 실호출 검증**(오사/Tokyo/파리/빈결과 모두 200 정상 매핑)
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — 외부 시그니처 불변, fallback 경로 보존, 전체 스위트 그린
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요? — `TripService` 의 `// TODO: Google Places API 연동` 주석 제거
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> - **Graceful degradation**: AI 엔진/Places 장애 시 BE가 `Exception` catch → `log.warn` + fallback 12개 목록 반환. 사용자는 결과를 받음. 빈 결과(매칭 0건)는 정상으로 간주 → 폴백 트리거 X(`results:[]` 그대로 반환).
> - **직렬화 호환**: Python `Destination{name, country, place_id}` ↔ BE `AiDestinationSearchResponse.Destination{..., @JsonProperty("place_id") placeId}` ↔ FE `DestinationDto{..., placeId}`. SNAKE_CASE 전략 + @JsonProperty 가 모두 `place_id` 로 수렴 — 매퍼 설정 무관 일치.
> - **실연동 검증 메모**: 검증 중 키가 속한 GCP 프로젝트에 **Places API (New) 가 비활성** 상태였음을 발견 → 활성화 후 실호출 200 정상 확인. (참고: 같은 원인으로 **기존 카드 보강 searchText 도 막혀 있던** 상태였고, 활성화로 함께 해결됨.)
>
> **배포 전 확인:**
> - 별도 DB 마이그레이션 없음.
> - AI 엔진 `GOOGLE_MAPS_API_KEY` 보유 + **Places API (New) 활성화 필수**(이미 활성화 완료).
> - 재배포 순서 무관 — BE 는 실패 시 폴백되므로 AI 엔진 미배포 상태에서도 사용자 불가용 없음.
>
> follow-up(비차단): `country` 가 secondaryText 그대로라 "일본 오사카부"처럼 행정구역이 섞임(국가명만 노출하려면 후속 정제). 라우터 502 변환 TestClient 케이스 추가. quota/캐싱.

## 📸 스크린샷

UI 변경 없음 (Backend/AI Engine 전용).
