### PR TITLE
feat: 162 SCR-05 확정 화면 UI

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import ArrangePage from './pages/ArrangePage';
+import ConfirmPage from './pages/ConfirmPage';
 import DevIndexPage from './pages/DevIndexPage';
 import DumpPage from './pages/DumpPage';
 import GroupingPage from './pages/GroupingPage';
@@ -17,6 +18,7 @@ const App = () => {
         <Route path="/progress" element={<ProgressPageDev />} />
         <Route path="/grouping" element={<GroupingPage />} />
         <Route path="/arrange" element={<ArrangePage />} />
+        <Route path="/confirm" element={<ConfirmPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/apps/frontend/src/components/confirm/AlertCardList.tsx
+++ b/apps/frontend/src/components/confirm/AlertCardList.tsx
@@ -1,0 +1,68 @@
+// AlertCardList — 확정 화면(SCR-05) 좌측 사이드 "Alert Cards".
+// kind 별 색 구분: 실무 알림 / 출발 준비(amber) · AI 인사이트(blue).
+
+import type { ConfirmAlertCard } from '@/dev-fixtures/confirm-mock';
+import { cn } from '@/lib/utils';
+
+type AlertCardListProps = {
+  items: ConfirmAlertCard[];
+};
+
+// 색은 라벨(kind)이 아니라 분류축(category)으로 결정 — 컨트랙트 alert_cards.category 정렬.
+const CATEGORY_STYLE: Record<
+  ConfirmAlertCard['category'],
+  { card: string; chip: string }
+> = {
+  practical: {
+    card: 'bg-amber-50/70 dark:bg-amber-950/20',
+    chip: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  },
+  insight: {
+    card: 'bg-blue-50/60 dark:bg-blue-950/20',
+    chip: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  },
+};
+
+const AlertCardList = ({ items }: AlertCardListProps) => {
+  return (
+    <section className="flex flex-col gap-3">
+      <header className="flex items-center justify-between">
+        <h2 className="text-sm font-bold text-foreground">Alert Cards</h2>
+        <span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-600 tabular-nums dark:bg-blue-950/40 dark:text-blue-300">
+          {items.length}개
+        </span>
+      </header>
+
+      {items.length === 0 ? (
+        <p className="rounded-xl bg-card py-6 text-center text-xs text-muted-foreground ring-1 ring-foreground/10">
+          알림이 없어요.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {items.map((item) => {
+            const style = CATEGORY_STYLE[item.category];
+            return (
+              <li key={item.id}>
+                <article className={cn('rounded-xl p-4', style.card)}>
+                  <span
+                    className={cn(
+                      'inline-flex rounded-md px-2.5 py-1 text-xs font-semibold',
+                      style.chip
+                    )}
+                  >
+                    {item.kind}
+                  </span>
+                  <p className="mt-2 text-sm leading-relaxed text-foreground/80">
+                    {item.body}
+                  </p>
+                </article>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default AlertCardList;

--- a/apps/frontend/src/components/confirm/ContextCardList.tsx
+++ b/apps/frontend/src/components/confirm/ContextCardList.tsx
@@ -1,0 +1,95 @@
+// ContextCardList — 확정 화면(SCR-05) 본문 "카드 맥락 기반 일정".
+// Day 의 카드들을 번호 + 제목/시간/위치 + 사용자 맥락 + AI 팁으로 펼쳐서 보여준다.
+
+import PlaceCardBadge from '@/components/grouping/PlaceCardBadge';
+import type { ConfirmCardViewModel } from '@/dev-fixtures/confirm-mock';
+
+type ContextCardListProps = {
+  cards: ConfirmCardViewModel[];
+};
+
+const ContextCardList = ({ cards }: ContextCardListProps) => {
+  return (
+    <section className="flex flex-col gap-3">
+      <header className="flex items-center justify-between">
+        <h3 className="text-sm font-bold text-foreground">
+          카드 맥락 기반 일정
+        </h3>
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {cards.length}개 카드
+        </span>
+      </header>
+
+      {cards.length === 0 ? (
+        <p className="rounded-2xl bg-card py-8 text-center text-sm text-muted-foreground ring-1 ring-foreground/10">
+          이 Day 에 배치된 카드가 없어요.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {cards.map((card) => (
+            <li key={card.id}>
+              <ContextCard {...card} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+const ContextCard = ({
+  order,
+  name,
+  badges = [],
+  timeLabel,
+  region,
+  userNote,
+  aiTip,
+}: ConfirmCardViewModel) => {
+  const meta = [timeLabel, region].filter(Boolean).join(' · ');
+
+  return (
+    <article className="flex gap-4 rounded-2xl bg-card p-5 ring-1 ring-foreground/10">
+      <span
+        aria-hidden="true"
+        className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-foreground text-xs font-bold text-background"
+      >
+        {order}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="truncate text-sm font-semibold text-foreground">
+            {name}
+          </p>
+          {badges.map((badge, index) => (
+            <PlaceCardBadge key={index} {...badge} />
+          ))}
+        </div>
+        {meta && <p className="mt-0.5 text-xs text-muted-foreground">{meta}</p>}
+
+        {userNote && (
+          <div className="mt-3 rounded-lg bg-indigo-50 px-3 py-2 text-xs dark:bg-indigo-950/40">
+            <p className="font-semibold text-indigo-700 dark:text-indigo-300">
+              사용자 맥락
+            </p>
+            <p className="mt-0.5 text-indigo-900 dark:text-indigo-100">
+              {userNote}
+            </p>
+          </div>
+        )}
+
+        {aiTip && (
+          <div className="mt-2 rounded-lg bg-amber-50 px-3 py-2 text-xs dark:bg-amber-950/30">
+            <p className="font-semibold text-amber-700 dark:text-amber-300">
+              AI 팁
+            </p>
+            <p className="mt-0.5 text-amber-900 dark:text-amber-100">{aiTip}</p>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+};
+
+export default ContextCardList;

--- a/apps/frontend/src/components/confirm/DayChecklist.tsx
+++ b/apps/frontend/src/components/confirm/DayChecklist.tsx
@@ -1,0 +1,92 @@
+// DayChecklist — 확정 화면(SCR-05) 우측 사이드의 "Day 체크리스트".
+// 선택된 Day 한정 To-do / 연결 카드 재확인 항목.
+
+import { Pencil } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import type { ConfirmDayChecklistItem } from '@/dev-fixtures/confirm-mock';
+import { cn } from '@/lib/utils';
+
+type DayChecklistProps = {
+  items: ConfirmDayChecklistItem[];
+};
+
+const buildInitialChecked = (items: ConfirmDayChecklistItem[]) =>
+  Object.fromEntries(items.map((item) => [item.id, item.done]));
+
+const DayChecklist = ({ items }: DayChecklistProps) => {
+  const [checked, setChecked] = useState<Record<string, boolean>>(() =>
+    buildInitialChecked(items)
+  );
+
+  // Day 탭이 바뀌면 items 가 바뀌므로 새 Day 기준으로 초기화.
+  useEffect(() => {
+    setChecked(buildInitialChecked(items));
+  }, [items]);
+
+  const toggle = (id: string) =>
+    setChecked((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  return (
+    <section className="rounded-2xl bg-card p-5 ring-1 ring-foreground/10">
+      <header className="flex items-center justify-between">
+        <h3 className="text-sm font-bold text-foreground">Day 체크리스트</h3>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+          >
+            <Pencil className="size-3.5" aria-hidden="true" />
+            편집
+          </button>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {items.length}개
+          </span>
+        </div>
+      </header>
+
+      {items.length === 0 ? (
+        <p className="py-6 text-center text-xs text-muted-foreground">
+          체크리스트가 없어요.
+        </p>
+      ) : (
+        <ul className="mt-3 flex flex-col gap-2">
+          {items.map((item) => {
+            const isChecked = checked[item.id] ?? false;
+            return (
+              <li key={item.id}>
+                <label className="flex w-full cursor-pointer items-start gap-3 rounded-lg bg-muted/40 px-3 py-2">
+                  <Checkbox
+                    checked={isChecked}
+                    onCheckedChange={() => toggle(item.id)}
+                    className="mt-0.5"
+                  />
+                  <div className="min-w-0">
+                    <p
+                      className={cn(
+                        'text-sm',
+                        isChecked
+                          ? 'text-muted-foreground line-through'
+                          : 'text-foreground'
+                      )}
+                    >
+                      {item.label}
+                    </p>
+                    {item.hint && (
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {item.hint}
+                      </p>
+                    )}
+                  </div>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default DayChecklist;

--- a/apps/frontend/src/components/confirm/DaySummary.tsx
+++ b/apps/frontend/src/components/confirm/DaySummary.tsx
@@ -1,0 +1,44 @@
+// DaySummary — 확정 화면(SCR-05) 선택된 Day 의 요약 카드.
+// 제목/설명 + 총 이동시간 / 총 소요시간.
+
+type DaySummaryProps = {
+  title: string;
+  summary: string;
+  totalMove: string;
+  totalSpend: string;
+};
+
+const DaySummary = ({
+  title,
+  summary,
+  totalMove,
+  totalSpend,
+}: DaySummaryProps) => {
+  return (
+    <section className="rounded-2xl bg-card p-6 ring-1 ring-foreground/10">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold tracking-widest text-muted-foreground">
+            DAY SUMMARY
+          </p>
+          <h3 className="mt-1 text-lg font-bold text-foreground">{title}</h3>
+          <p className="mt-1 text-sm text-muted-foreground">{summary}</p>
+        </div>
+
+        <div className="flex shrink-0 gap-2">
+          <Stat label="총 이동시간" value={totalMove} />
+          <Stat label="총 소요시간" value={totalSpend} />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const Stat = ({ label, value }: { label: string; value: string }) => (
+  <div className="rounded-lg bg-muted px-3 py-2 text-center">
+    <p className="text-[11px] text-muted-foreground">{label}</p>
+    <p className="mt-0.5 text-sm font-bold text-foreground">{value}</p>
+  </div>
+);
+
+export default DaySummary;

--- a/apps/frontend/src/components/confirm/DayTabs.tsx
+++ b/apps/frontend/src/components/confirm/DayTabs.tsx
@@ -1,0 +1,49 @@
+// DayTabs — 확정 화면(SCR-05) Day 1~N 탭. 우측에 지도 보기 버튼(탭과 동일 스타일).
+
+import type { ConfirmDayViewModel } from '@/dev-fixtures/confirm-mock';
+import { cn } from '@/lib/utils';
+
+type DayTabsProps = {
+  days: Pick<ConfirmDayViewModel, 'id' | 'dayLabel'>[];
+  activeIndex: number;
+  onSelect: (index: number) => void;
+};
+
+const DayTabs = ({ days, activeIndex, onSelect }: DayTabsProps) => {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div role="tablist" className="flex items-center gap-2">
+        {days.map((day, index) => {
+          const active = index === activeIndex;
+          return (
+            <button
+              key={day.id}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => onSelect(index)}
+              className={cn(
+                'rounded-full px-4 py-1.5 text-sm',
+                active
+                  ? 'bg-foreground text-background'
+                  : 'bg-background text-muted-foreground ring-1 ring-foreground/10'
+              )}
+            >
+              {day.dayLabel}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 지도 보기 — Day 탭과 동일 pill 스타일. 동작은 추후 연결 */}
+      <button
+        type="button"
+        className="rounded-full bg-background px-4 py-1.5 text-sm text-muted-foreground ring-1 ring-foreground/10"
+      >
+        지도 보기
+      </button>
+    </div>
+  );
+};
+
+export default DayTabs;

--- a/apps/frontend/src/components/confirm/SaveShareCard.tsx
+++ b/apps/frontend/src/components/confirm/SaveShareCard.tsx
@@ -1,0 +1,35 @@
+// SaveShareCard — 확정 화면(SCR-05) 우측 사이드 하단. 저장/공유 액션 카드.
+// 버튼 동작은 추후 연결 (UI 만).
+
+import { Download, Share2 } from 'lucide-react';
+
+const SaveShareCard = () => {
+  return (
+    <section className="rounded-2xl bg-card p-5 ring-1 ring-foreground/10">
+      <h3 className="text-sm font-bold text-foreground">이 화면의 정체성</h3>
+      <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+        05는 일정표를 예쁘게 보여주는 단계가 아니라, 확정 직전에 놓치기 쉬운
+        실무 항목과 카드 맥락을 다시 묶어주는 단계예요.
+      </p>
+
+      <div className="mt-4 flex gap-2">
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background"
+        >
+          <Download className="size-4" aria-hidden="true" />
+          저장하기
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+        >
+          <Share2 className="size-4" aria-hidden="true" />
+          공유하기
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default SaveShareCard;

--- a/apps/frontend/src/components/confirm/TripChecklist.tsx
+++ b/apps/frontend/src/components/confirm/TripChecklist.tsx
@@ -1,0 +1,67 @@
+// TripChecklist — 확정 화면(SCR-05) 좌측 사이드의 "여행 전반 체크리스트".
+// 출국 전까지 처리해야 할 실무 항목(여권/항공권/숙소 바우처/보험 등) 목록.
+
+import { Pencil } from 'lucide-react';
+import { useState } from 'react';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import type { ConfirmChecklistItem } from '@/dev-fixtures/confirm-mock';
+import { cn } from '@/lib/utils';
+
+type TripChecklistProps = {
+  items: ConfirmChecklistItem[];
+};
+
+const TripChecklist = ({ items }: TripChecklistProps) => {
+  const [checked, setChecked] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(items.map((item) => [item.id, item.done]))
+  );
+
+  const toggle = (id: string) =>
+    setChecked((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  return (
+    <section className="flex flex-col gap-3">
+      <header className="flex items-center justify-between">
+        <h2 className="text-sm font-bold text-foreground">
+          여행 전반 체크리스트
+        </h2>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+        >
+          <Pencil className="size-3.5" aria-hidden="true" />
+          편집
+        </button>
+      </header>
+
+      <ul className="flex flex-col gap-2">
+        {items.map((item) => {
+          const isChecked = checked[item.id] ?? false;
+          return (
+            <li key={item.id}>
+              <label className="flex w-full cursor-pointer items-center gap-3 rounded-xl bg-card px-3.5 py-2.5 ring-1 ring-foreground/10 transition-colors hover:bg-muted/40">
+                <Checkbox
+                  checked={isChecked}
+                  onCheckedChange={() => toggle(item.id)}
+                />
+                <span
+                  className={cn(
+                    'text-sm',
+                    isChecked
+                      ? 'text-muted-foreground line-through'
+                      : 'text-foreground'
+                  )}
+                >
+                  {item.label}
+                </span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default TripChecklist;

--- a/apps/frontend/src/components/confirm/TripHeroCard.tsx
+++ b/apps/frontend/src/components/confirm/TripHeroCard.tsx
@@ -1,0 +1,48 @@
+// TripHeroCard — 확정 화면(SCR-05) 중앙 상단 히어로 카드.
+// 여행 제목/메타 + 4-stat 그리드(여행 리듬/이동 성향/숙소 전략/남은 변수).
+
+import type { ConfirmStat } from '@/dev-fixtures/confirm-mock';
+
+type TripHeroCardProps = {
+  title: string;
+  destinations: string[];
+  travelers: number;
+  durationLabel: string;
+  stats: ConfirmStat[];
+};
+
+const TripHeroCard = ({
+  title,
+  destinations,
+  travelers,
+  durationLabel,
+  stats,
+}: TripHeroCardProps) => {
+  const meta = [destinations.join(', '), `${travelers}명`, durationLabel]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <section className="rounded-2xl bg-primary px-8 py-7 text-primary-foreground">
+      <p className="text-xs font-semibold tracking-widest opacity-80">
+        FINAL REVIEW
+      </p>
+      <h2 className="mt-2 text-2xl font-bold">{title}</h2>
+      <p className="mt-1 text-sm opacity-80">{meta}</p>
+
+      <div className="mt-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-xl bg-primary-foreground/10 px-4 py-3"
+          >
+            <p className="text-xs opacity-75">{stat.label}</p>
+            <p className="mt-1 text-sm font-semibold">{stat.value}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default TripHeroCard;

--- a/apps/frontend/src/components/header/Header.tsx
+++ b/apps/frontend/src/components/header/Header.tsx
@@ -20,7 +20,7 @@ const STEPS: Step[] = [
   { id: 'dump', label: '덤프', path: '/dump' },
   { id: 'organize', label: '정리', path: '/grouping' },
   { id: 'arrange', label: '배치', path: '/arrange' },
-  { id: 'confirm', label: '확정' },
+  { id: 'confirm', label: '확정', path: '/confirm' },
 ];
 
 export type HeaderProps = {

--- a/apps/frontend/src/components/ui/checkbox.tsx
+++ b/apps/frontend/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import { CheckIcon } from 'lucide-react';
+import { Checkbox as CheckboxPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Checkbox = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) => {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer relative flex size-4 shrink-0 items-center justify-center rounded-lg border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary',
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <CheckIcon />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+};
+
+export { Checkbox };

--- a/apps/frontend/src/dev-fixtures/confirm-mock.ts
+++ b/apps/frontend/src/dev-fixtures/confirm-mock.ts
@@ -1,0 +1,244 @@
+// SCR-05 (확정 전 최종 점검) mock 데이터. 화면 조회용 GET API가 생기면 mapper 로 교체.
+// 카드/일정/alert 는 기존 cards·days API 로 커버. 체크리스트는 alert_cards(practical) 파생(연동 post-MVP).
+// hero stats(4종)·실제 Day 이동시간(Maps 연동)은 컨트랙트에 없음 — MVP 범위 밖.
+import type { PlaceCardBadgeSpec } from '@/types/grouping';
+
+export type ConfirmStat = {
+  label: string;
+  value: string;
+};
+
+export type ConfirmAlertKind = '실무 알림' | '출발 준비' | 'AI 인사이트';
+
+export type ConfirmAlertCard = {
+  id: string;
+  /** 표시용 라벨 */
+  kind: ConfirmAlertKind;
+  /** 색/분류 축 — 컨트랙트 alert_cards.category 정렬. practical=amber, insight=blue */
+  category: 'practical' | 'insight';
+  body: string;
+};
+
+export type ConfirmChecklistItem = {
+  id: string;
+  label: string;
+  done: boolean;
+};
+
+// 확정 화면의 카드 1장. 배치(SCR-04) ScheduledCardViewModel + 사용자 맥락/AI 팁.
+export type ConfirmCardViewModel = {
+  id: string;
+  /** 좌측 동그라미 번호 (1, 2, 3 …) */
+  order: number;
+  name: string;
+  badges?: PlaceCardBadgeSpec[];
+  /** 시간 라벨 (예: "16:00") */
+  timeLabel?: string;
+  /** 지역 라벨 (예: "오사카") */
+  region?: string;
+  /** 사용자 맥락 — 보라색 칩 안 본문 */
+  userNote?: string;
+  /** AI 팁 — 노란색 칩 안 본문 */
+  aiTip?: string;
+};
+
+export type ConfirmDayChecklistItem = {
+  id: string;
+  label: string;
+  /** "To-do" 또는 연결된 카드 이름 같은 보조 라벨 */
+  hint?: string;
+  done: boolean;
+};
+
+// 확정 화면의 Day 한 칸. 배치(SCR-04) DayColumnViewModel 의 (id, dayLabel) 확장.
+export type ConfirmDayViewModel = {
+  id: string;
+  /** "Day 1" — 탭 라벨 */
+  dayLabel: string;
+  /** Day Summary 카드의 큰 제목 ("Day 1 - 오사카 도착과 시내 적응") */
+  title: string;
+  /** Day Summary 카드의 한두 줄 설명 */
+  summary: string;
+  /** 총 이동시간 (예: "48분") */
+  totalMove: string;
+  /** 총 소요시간 (예: "6시간 30분") */
+  totalSpend: string;
+  /** 카드 맥락 기반 일정 — 본문 메인 리스트 */
+  contextCards: ConfirmCardViewModel[];
+  /** Day 체크리스트 — 우측 사이드 */
+  dayChecklist: ConfirmDayChecklistItem[];
+};
+
+export type ConfirmViewModel = {
+  /** Header(상단 공통)에 넘기는 여행 메타 — 배치 fixture 의 summary 와 동일 구조 */
+  summary: {
+    destination: string;
+    extraDestinations: number;
+    travelers: number;
+    dateRange: string;
+  };
+  /** 보라색 히어로 카드 */
+  hero: {
+    title: string;
+    destinations: string[];
+    travelers: number;
+    durationLabel: string;
+    stats: ConfirmStat[];
+  };
+  /** 좌측 사이드 — 여행 전반 체크리스트 */
+  tripChecklist: ConfirmChecklistItem[];
+  /** 좌측 사이드 — Alert Cards */
+  alertCards: ConfirmAlertCard[];
+  /** Day 탭 + 본문 */
+  days: ConfirmDayViewModel[];
+};
+
+export const CONFIRM_FIXTURE: ConfirmViewModel = {
+  summary: {
+    destination: '교토',
+    extraDestinations: 2,
+    travelers: 2,
+    dateRange: '5월 10일 ~ 5월 14일',
+  },
+  hero: {
+    title: '간사이 봄 여행',
+    destinations: ['오사카', '교토', '나라'],
+    travelers: 2,
+    durationLabel: '4박 5일',
+    stats: [
+      { label: '여행 리듬', value: '오전 집중형' },
+      { label: '이동 성향', value: '환승 적게' },
+      { label: '숙소 전략', value: '오사카/교토 분산' },
+      { label: '남은 변수', value: '교통 1건 확정 필요' },
+    ],
+  },
+  tripChecklist: [
+    { id: 'passport', label: '여권 유효기간 확인', done: false },
+    { id: 'flight', label: '항공권 출력 / 모바일 저장', done: false },
+    { id: 'voucher', label: '숙소 바우처 준비', done: false },
+    { id: 'insurance', label: '여행자 보험 가입', done: false },
+    { id: 'pass', label: '교통패스 예약', done: false },
+    { id: 'fx', label: '환전', done: false },
+  ],
+  alertCards: [
+    {
+      id: 'a1',
+      kind: '실무 알림',
+      category: 'practical',
+      body: '교토역 → 오사카 이동 수단이 아직 확정되지 않았어요. 짐이 많다면 환승이 적은 경로가 더 적합해요.',
+    },
+    {
+      id: 'a2',
+      kind: '출발 준비',
+      category: 'practical',
+      body: '간사이 공항 출발 동선은 숙소 체크아웃 시간과 함께 다시 확인하는 편이 안전해요.',
+    },
+    {
+      id: 'a3',
+      kind: 'AI 인사이트',
+      category: 'insight',
+      body: '유니버설 스튜디오 재팬, 아라시야마 대나무숲, 후시미 이나리처럼 이른 시간 가치가 큰 장소가 섞여 있어 오전 집중형 일정으로 보입니다.',
+    },
+    {
+      id: 'a4',
+      kind: 'AI 인사이트',
+      category: 'insight',
+      body: '숙소와 공항/교통 카드는 중복 배치가 가능하므로 Day 재조정 여지가 남아 있어요.',
+    },
+  ],
+  days: [
+    {
+      id: 'day-1',
+      dayLabel: 'Day 1',
+      title: 'Day 1 - 오사카 도착과 시내 적응',
+      summary:
+        '오사카 도착 후 시내 흐름을 익히는 날이에요. 식사와 전망, 체크인을 부드럽게 연결했습니다.',
+      totalMove: '48분',
+      totalSpend: '6시간 30분',
+      contextCards: [
+        {
+          id: 'c1',
+          order: 1,
+          name: '난바 체크인',
+          badges: [{ kind: 'category', category: 'lodging' }],
+          timeLabel: '16:00',
+          region: '오사카',
+          userNote: '오사카 숙소로 난바 근처를 잡았어요',
+        },
+        {
+          id: 'c2',
+          order: 2,
+          name: '도톤보리 맛집 투어',
+          badges: [{ kind: 'category', category: 'food' }],
+          timeLabel: '18:00',
+          region: '오사카',
+          userNote: '도톤보리 맛집 여러 곳 둘러볼 예정',
+          aiTip: '저녁 시간대는 웨이팅이 길 수 있어요',
+        },
+        {
+          id: 'c3',
+          order: 3,
+          name: '하루카스 300 전망대',
+          badges: [{ kind: 'category', category: 'place' }],
+          timeLabel: '20:00',
+          region: '오사카',
+          aiTip: '날씨 맑은 날 방문 추천',
+        },
+      ],
+      dayChecklist: [
+        {
+          id: 'd1-cash',
+          label: '현금 인출 여부 확인',
+          hint: 'To-do',
+          done: false,
+        },
+        {
+          id: 'd1-checkin',
+          label: '숙소 체크인 시간 재확인',
+          hint: '난바 체크인',
+          done: false,
+        },
+      ],
+    },
+    {
+      id: 'day-2',
+      dayLabel: 'Day 2',
+      title: 'Day 2 - 교토 핵심 동선',
+      summary: '교토 시내 주요 사찰과 거리를 도보 중심으로 둘러보는 날.',
+      totalMove: '1시간 10분',
+      totalSpend: '7시간',
+      contextCards: [],
+      dayChecklist: [],
+    },
+    {
+      id: 'day-3',
+      dayLabel: 'Day 3',
+      title: 'Day 3 - 아라시야마',
+      summary: '오전 일찍 아라시야마로 이동, 대나무숲 → 도게쓰교 코스.',
+      totalMove: '1시간 30분',
+      totalSpend: '6시간',
+      contextCards: [],
+      dayChecklist: [],
+    },
+    {
+      id: 'day-4',
+      dayLabel: 'Day 4',
+      title: 'Day 4 - 나라 당일치기',
+      summary: '나라 공원과 도다이지 중심의 짧은 당일 코스.',
+      totalMove: '2시간',
+      totalSpend: '5시간 30분',
+      contextCards: [],
+      dayChecklist: [],
+    },
+    {
+      id: 'day-5',
+      dayLabel: 'Day 5',
+      title: 'Day 5 - 출국',
+      summary: '간사이 공항으로 이동, 마지막 쇼핑과 출국.',
+      totalMove: '1시간',
+      totalSpend: '3시간',
+      contextCards: [],
+      dayChecklist: [],
+    },
+  ],
+};

--- a/apps/frontend/src/pages/ConfirmPage.tsx
+++ b/apps/frontend/src/pages/ConfirmPage.tsx
@@ -1,0 +1,96 @@
+// 화면 조회용 GET API가 없어 mock 으로 렌더한다.
+
+import { useState } from 'react';
+
+import AlertCardList from '@/components/confirm/AlertCardList';
+import ContextCardList from '@/components/confirm/ContextCardList';
+import DayChecklist from '@/components/confirm/DayChecklist';
+import DaySummary from '@/components/confirm/DaySummary';
+import DayTabs from '@/components/confirm/DayTabs';
+import SaveShareCard from '@/components/confirm/SaveShareCard';
+import TripChecklist from '@/components/confirm/TripChecklist';
+import TripHeroCard from '@/components/confirm/TripHeroCard';
+import Header from '@/components/header/Header';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { CONFIRM_FIXTURE } from '@/dev-fixtures/confirm-mock';
+
+const ConfirmPage = () => {
+  const { summary, hero, tripChecklist, alertCards, days } = CONFIRM_FIXTURE;
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const activeDay = days[activeIndex];
+
+  return (
+    <div className="flex min-h-screen flex-col bg-muted">
+      <Header
+        currentStepId="confirm"
+        destination={summary.destination}
+        extraDestinations={summary.extraDestinations}
+        travelers={summary.travelers}
+        dateRange={summary.dateRange}
+        actions={
+          <Button variant="outline" size="sm">
+            배치로 돌아가기
+          </Button>
+        }
+      />
+
+      <main className="grid flex-1 grid-cols-[300px_minmax(0,1fr)]">
+        <aside className="flex flex-col gap-6 border-r border-border bg-card px-8 py-10">
+          <div>
+            <p className="text-xs font-semibold tracking-widest text-primary">
+              FINAL REVIEW
+            </p>
+            <h1 className="mt-1 text-xl font-bold tracking-tight text-foreground">
+              확정 전 최종 점검
+            </h1>
+            <p className="mt-1 text-xs text-muted-foreground">
+              03과 04에서 수집된 카드 맥락, To-do, alert를 한 번에 점검하는
+              화면이에요.
+            </p>
+          </div>
+
+          <Separator />
+
+          <TripChecklist items={tripChecklist} />
+
+          <Separator />
+
+          <AlertCardList items={alertCards} />
+        </aside>
+
+        <section className="flex flex-col gap-8 px-8 py-10">
+          <TripHeroCard {...hero} />
+
+          <DayTabs
+            days={days}
+            activeIndex={activeIndex}
+            onSelect={setActiveIndex}
+          />
+
+          {activeDay && (
+            <>
+              <DaySummary
+                title={activeDay.title}
+                summary={activeDay.summary}
+                totalMove={activeDay.totalMove}
+                totalSpend={activeDay.totalSpend}
+              />
+
+              <div className="grid grid-cols-[minmax(0,1fr)_320px] items-start gap-6">
+                <ContextCardList cards={activeDay.contextCards} />
+                <div className="flex flex-col gap-6">
+                  <DayChecklist items={activeDay.dayChecklist} />
+                  <SaveShareCard />
+                </div>
+              </div>
+            </>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default ConfirmPage;

--- a/apps/frontend/src/pages/DevIndexPage.tsx
+++ b/apps/frontend/src/pages/DevIndexPage.tsx
@@ -37,6 +37,12 @@ const pages: DevNavEntry[] = [
     title: 'Arrange Page (SCR-04)',
     description: '일정 배치 페이지 — Day 칸반 보드 (목데이터 UI)',
   },
+  {
+    kind: 'link',
+    path: '/confirm',
+    title: 'Confirm Page (SCR-05)',
+    description: '확정 전 최종 점검 페이지 (mock 데이터 기반 UI)',
+  },
 ];
 
 const DevIndexPage = () => {


### PR DESCRIPTION
## 📝 작업 내용

> SCR-05 "확정 전 최종 점검" 화면 UI를 mock 데이터 기반으로 구현.

- **좌측 사이드** — FINAL REVIEW 헤딩 / 여행 전반 체크리스트(`TripChecklist`) / Alert Cards(`AlertCardList`, category별 색 구분)
- **우측 메인**
  - `TripHeroCard` — 여행 제목·메타 + 4-stat(여행 리듬/이동 성향/숙소 전략/남은 변수)
  - `DayTabs` — Day 1~N 탭(좌) + 지도 보기 버튼(우)
  - `DaySummary` — 선택 Day 제목·설명 + 총 이동시간/소요시간
  - `ContextCardList` — 카드 맥락 일정(번호·시간·지역·사용자 맥락·AI 팁)
  - `DayChecklist` + `SaveShareCard`(저장/공유) — 우측 컬럼

**기타**
- 라우트(`/confirm`) + Header 확정 단계 + DevIndex 링크 연결
- shadcn `checkbox`추가
 
## 🔗 관련 이슈

closes #162 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [ x 기존 기능이 깨지지 않았나요? (회귀 확인)
- [ ] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- **동작 미연결(UI only) 버튼**: 배치로 돌아가기 / 지도 보기 / 편집(체크리스트 2곳) / 저장하기·공유하기 — 의도된 stub, onClick 추후 연결
- **체크박스 상태**는 로컬 useState라 새로고침·Day 전환 시 초기화

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.
<img width="1821" height="1220" alt="image" src="https://github.com/user-attachments/assets/2d62fb4a-d16c-49ca-8b69-bce990cd6628" />