### PR TITLE
Feat/be 167 route travel time

### DIFF
--- a/apps/ai-engine/app/api/route.py
+++ b/apps/ai-engine/app/api/route.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from app.schemas.route import RouteRequest, RouteResponse
+from app.services.route_optimizer import optimize_routes
+
+router = APIRouter(prefix="/internal/ai", tags=["route"])
+
+
+@router.post("/route", response_model=RouteResponse)
+async def compute_route(req: RouteRequest) -> RouteResponse:
+    # leg 단위로 폴백이 적용되므로 전체 502 없이 항상 200 + 결과 반환
+    return await optimize_routes(req)

--- a/apps/ai-engine/app/fallback/estimated_route.py
+++ b/apps/ai-engine/app/fallback/estimated_route.py
@@ -1,0 +1,36 @@
+"""Google Routes 실패·좌표 누락 시 haversine 직선거리 기반 추정 폴백."""
+
+from __future__ import annotations
+
+import math
+
+from app.schemas.route import RouteLeg, RouteLegResult
+
+# 도로 우회 보정 계수 및 평균 이동 속도(m/s). 직선거리 기반의 보수적 추정값.
+_DETOUR_FACTOR = 1.3
+_AVG_SPEED_MPS = 30_000 / 3600  # 30 km/h
+
+
+def _haversine_meters(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    radius = 6_371_000.0
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    d_lat = math.radians(lat2 - lat1)
+    d_lng = math.radians(lng2 - lng1)
+    a = math.sin(d_lat / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(d_lng / 2) ** 2
+    return radius * 2 * math.asin(math.sqrt(a))
+
+
+def estimate_leg(leg: RouteLeg) -> RouteLegResult:
+    straight = _haversine_meters(
+        leg.origin.lat, leg.origin.lng, leg.destination.lat, leg.destination.lng
+    )
+    distance = int(round(straight * _DETOUR_FACTOR))
+    duration = int(round(distance / _AVG_SPEED_MPS)) if distance > 0 else 0
+    return RouteLegResult(
+        from_instance_id=leg.from_instance_id,
+        to_instance_id=leg.to_instance_id,
+        duration_seconds=duration,
+        distance_meters=distance,
+        mode="estimated",
+        source="estimated",
+    )

--- a/apps/ai-engine/app/main.py
+++ b/apps/ai-engine/app/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 
 from app.api.non_blocking_enrichment import router as non_blocking_enrichment_router
 from app.api.parse import router as parse_router
+from app.api.route import router as route_router
 
 load_dotenv()
 
@@ -15,6 +16,7 @@ logging.basicConfig(level=logging.INFO)
 app = FastAPI(title="TripKey AI Engine")
 app.include_router(parse_router)
 app.include_router(non_blocking_enrichment_router)
+app.include_router(route_router)
 
 
 @app.get("/health")

--- a/apps/ai-engine/app/schemas/route.py
+++ b/apps/ai-engine/app/schemas/route.py
@@ -1,32 +1,42 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from typing import Literal
 
+from pydantic import BaseModel, ConfigDict, Field
 
-class Coord(BaseModel):
-    lat: float
-    lng: float
+from app.schemas.parse import Coordinates
+
+TravelMode = Literal["walking", "transit", "driving", "estimated"]
+RouteSource = Literal["google", "estimated"]
 
 
 class RouteLeg(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     from_instance_id: str = Field(..., min_length=1)
     to_instance_id: str = Field(..., min_length=1)
-    origin: Coord
-    destination: Coord
+    origin: Coordinates
+    destination: Coordinates
 
 
 class RouteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     legs: list[RouteLeg]
 
 
 class RouteLegResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     from_instance_id: str
     to_instance_id: str
     duration_seconds: int
     distance_meters: int
-    mode: str        # walking | transit | driving | estimated
-    source: str      # google | estimated
+    mode: TravelMode
+    source: RouteSource
 
 
 class RouteResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     legs: list[RouteLegResult]

--- a/apps/ai-engine/app/schemas/route.py
+++ b/apps/ai-engine/app/schemas/route.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class Coord(BaseModel):
+    lat: float
+    lng: float
+
+
+class RouteLeg(BaseModel):
+    from_instance_id: str = Field(..., min_length=1)
+    to_instance_id: str = Field(..., min_length=1)
+    origin: Coord
+    destination: Coord
+
+
+class RouteRequest(BaseModel):
+    legs: list[RouteLeg]
+
+
+class RouteLegResult(BaseModel):
+    from_instance_id: str
+    to_instance_id: str
+    duration_seconds: int
+    distance_meters: int
+    mode: str        # walking | transit | driving | estimated
+    source: str      # google | estimated
+
+
+class RouteResponse(BaseModel):
+    legs: list[RouteLegResult]

--- a/apps/ai-engine/app/services/route_optimizer.py
+++ b/apps/ai-engine/app/services/route_optimizer.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 
 import httpx
@@ -15,6 +16,8 @@ import httpx
 from app.fallback.estimated_route import estimate_leg
 from app.schemas.parse import Coordinates
 from app.schemas.route import RouteLeg, RouteLegResult, RouteRequest, RouteResponse
+
+logger = logging.getLogger(__name__)
 
 COMPUTE_ROUTES_URL = "https://routes.googleapis.com/directions/v2:computeRoutes"
 
@@ -56,7 +59,8 @@ async def _call_routes_api(
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(COMPUTE_ROUTES_URL, json=payload, headers=headers)
         response.raise_for_status()
-    except httpx.HTTPError:
+    except httpx.HTTPError as exc:
+        logger.warning("Routes lookup failed | travel_mode=%s | error=%s", travel_mode, exc)
         return None
 
     routes = (response.json() or {}).get("routes") or []
@@ -77,6 +81,11 @@ async def _optimize_leg(leg: RouteLeg, api_key: str) -> RouteLegResult:
         if result is not None:
             candidates.append((mode, result))
     if not candidates:
+        logger.warning(
+            "No route candidates, falling back to estimate | from=%s | to=%s",
+            leg.from_instance_id,
+            leg.to_instance_id,
+        )
         return estimate_leg(leg)
     best_mode, best = min(candidates, key=lambda c: c[1]["duration_seconds"])
     return RouteLegResult(
@@ -93,5 +102,21 @@ async def optimize_routes(request: RouteRequest) -> RouteResponse:
     api_key = _places_api_key()
     if not api_key:
         return RouteResponse(legs=[estimate_leg(leg) for leg in request.legs])
-    results = await asyncio.gather(*(_optimize_leg(leg, api_key) for leg in request.legs))
-    return RouteResponse(legs=list(results))
+    results = await asyncio.gather(
+        *(_optimize_leg(leg, api_key) for leg in request.legs),
+        return_exceptions=True,
+    )
+
+    legs: list[RouteLegResult] = []
+    for leg, result in zip(request.legs, results):
+        if isinstance(result, Exception):
+            logger.warning(
+                "Leg optimization failed, falling back to estimate | from=%s | to=%s | error=%s",
+                leg.from_instance_id,
+                leg.to_instance_id,
+                result,
+            )
+            legs.append(estimate_leg(leg))
+            continue
+        legs.append(result)
+    return RouteResponse(legs=legs)

--- a/apps/ai-engine/app/services/route_optimizer.py
+++ b/apps/ai-engine/app/services/route_optimizer.py
@@ -1,0 +1,97 @@
+"""인접 카드 leg별 Google Routes(computeRoutes) 호출 + 최적 모드 선택.
+
+설계 노트: 기존 destination_search/core_parse 와 동일하게 googlemaps 라이브러리
+대신 httpx 로 신형 Routes v1 REST 를 직접 호출한다. walking/transit/driving 을
+모두 조회해 duration 최소 모드 1개를 반환하고, 실패한 leg 는 직선거리 추정 폴백.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import httpx
+
+from app.fallback.estimated_route import estimate_leg
+from app.schemas.parse import Coordinates
+from app.schemas.route import RouteLeg, RouteLegResult, RouteRequest, RouteResponse
+
+COMPUTE_ROUTES_URL = "https://routes.googleapis.com/directions/v2:computeRoutes"
+
+# Google travelMode -> 응답에 노출할 소문자 모드명
+_MODE_NAMES = {"WALK": "walking", "TRANSIT": "transit", "DRIVE": "driving"}
+_TRAVEL_MODES = ("WALK", "TRANSIT", "DRIVE")
+
+
+def _places_api_key() -> str | None:
+    return os.getenv("GOOGLE_PLACES_API_KEY") or os.getenv("GOOGLE_MAPS_API_KEY")
+
+
+def _parse_duration_seconds(raw: str | None) -> int | None:
+    # Routes API 는 "1320s" 형태로 반환
+    if not raw or not raw.endswith("s"):
+        return None
+    try:
+        return int(float(raw[:-1]))
+    except ValueError:
+        return None
+
+
+async def _call_routes_api(
+    origin: Coordinates, destination: Coordinates, travel_mode: str, api_key: str
+) -> dict | None:
+    headers = {
+        "X-Goog-Api-Key": api_key,
+        "X-Goog-FieldMask": "routes.duration,routes.distanceMeters",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "origin": {"location": {"latLng": {"latitude": origin.lat, "longitude": origin.lng}}},
+        "destination": {
+            "location": {"latLng": {"latitude": destination.lat, "longitude": destination.lng}}
+        },
+        "travelMode": travel_mode,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(COMPUTE_ROUTES_URL, json=payload, headers=headers)
+        response.raise_for_status()
+    except httpx.HTTPError:
+        return None
+
+    routes = (response.json() or {}).get("routes") or []
+    if not routes:
+        return None
+    first = routes[0]
+    duration = _parse_duration_seconds(first.get("duration"))
+    distance = first.get("distanceMeters")
+    if duration is None or distance is None:
+        return None
+    return {"duration_seconds": duration, "distance_meters": int(distance)}
+
+
+async def _optimize_leg(leg: RouteLeg, api_key: str) -> RouteLegResult:
+    candidates: list[tuple[str, dict]] = []
+    for mode in _TRAVEL_MODES:
+        result = await _call_routes_api(leg.origin, leg.destination, mode, api_key)
+        if result is not None:
+            candidates.append((mode, result))
+    if not candidates:
+        return estimate_leg(leg)
+    best_mode, best = min(candidates, key=lambda c: c[1]["duration_seconds"])
+    return RouteLegResult(
+        from_instance_id=leg.from_instance_id,
+        to_instance_id=leg.to_instance_id,
+        duration_seconds=best["duration_seconds"],
+        distance_meters=best["distance_meters"],
+        mode=_MODE_NAMES[best_mode],
+        source="google",
+    )
+
+
+async def optimize_routes(request: RouteRequest) -> RouteResponse:
+    api_key = _places_api_key()
+    if not api_key:
+        return RouteResponse(legs=[estimate_leg(leg) for leg in request.legs])
+    results = await asyncio.gather(*(_optimize_leg(leg, api_key) for leg in request.legs))
+    return RouteResponse(legs=list(results))

--- a/apps/ai-engine/tests/test_route_optimizer.py
+++ b/apps/ai-engine/tests/test_route_optimizer.py
@@ -26,3 +26,20 @@ def test_route_leg_rejects_empty_instance_id() -> None:
             origin=Coordinates(lat=34.70, lng=135.50),
             destination=Coordinates(lat=34.67, lng=135.49),
         )
+
+
+from app.fallback.estimated_route import estimate_leg
+
+
+def test_estimate_leg_returns_estimated_source() -> None:
+    leg = RouteLeg(
+        from_instance_id="a", to_instance_id="b",
+        origin=Coordinates(lat=34.70, lng=135.50),
+        destination=Coordinates(lat=34.67, lng=135.49),
+    )
+    result = estimate_leg(leg)
+    assert result.source == "estimated"
+    assert result.mode == "estimated"
+    assert result.distance_meters > 0
+    assert result.duration_seconds > 0
+    assert result.from_instance_id == "a"

--- a/apps/ai-engine/tests/test_route_optimizer.py
+++ b/apps/ai-engine/tests/test_route_optimizer.py
@@ -43,3 +43,4 @@ def test_estimate_leg_returns_estimated_source() -> None:
     assert result.distance_meters > 0
     assert result.duration_seconds > 0
     assert result.from_instance_id == "a"
+    assert result.to_instance_id == "b"

--- a/apps/ai-engine/tests/test_route_optimizer.py
+++ b/apps/ai-engine/tests/test_route_optimizer.py
@@ -7,7 +7,7 @@ os.environ.setdefault("GOOGLE_MAPS_API_KEY", "test-maps-key")
 from pydantic import ValidationError
 
 from app.schemas.parse import Coordinates
-from app.schemas.route import RouteLeg, RouteLegResult, RouteRequest, RouteResponse
+from app.schemas.route import RouteLeg, RouteRequest
 
 
 def test_schema_roundtrip() -> None:
@@ -47,7 +47,6 @@ def test_estimate_leg_returns_estimated_source() -> None:
 
 
 from app.services import route_optimizer
-from app.schemas.route import RouteRequest
 
 
 @pytest.mark.asyncio

--- a/apps/ai-engine/tests/test_route_optimizer.py
+++ b/apps/ai-engine/tests/test_route_optimizer.py
@@ -4,13 +4,25 @@ import pytest
 
 os.environ.setdefault("GOOGLE_MAPS_API_KEY", "test-maps-key")
 
-from app.schemas.route import Coord, RouteLeg, RouteLegResult, RouteRequest, RouteResponse
+from pydantic import ValidationError
+
+from app.schemas.parse import Coordinates
+from app.schemas.route import RouteLeg, RouteLegResult, RouteRequest, RouteResponse
 
 
 def test_schema_roundtrip() -> None:
     req = RouteRequest(legs=[RouteLeg(
         from_instance_id="a", to_instance_id="b",
-        origin=Coord(lat=34.70, lng=135.50),
-        destination=Coord(lat=34.67, lng=135.49),
+        origin=Coordinates(lat=34.70, lng=135.50),
+        destination=Coordinates(lat=34.67, lng=135.49),
     )])
     assert req.legs[0].origin.lat == 34.70
+
+
+def test_route_leg_rejects_empty_instance_id() -> None:
+    with pytest.raises(ValidationError):
+        RouteLeg(
+            from_instance_id="", to_instance_id="b",
+            origin=Coordinates(lat=34.70, lng=135.50),
+            destination=Coordinates(lat=34.67, lng=135.49),
+        )

--- a/apps/ai-engine/tests/test_route_optimizer.py
+++ b/apps/ai-engine/tests/test_route_optimizer.py
@@ -44,3 +44,62 @@ def test_estimate_leg_returns_estimated_source() -> None:
     assert result.duration_seconds > 0
     assert result.from_instance_id == "a"
     assert result.to_instance_id == "b"
+
+
+from app.services import route_optimizer
+from app.schemas.route import RouteRequest
+
+
+@pytest.mark.asyncio
+async def test_optimize_picks_min_duration_mode(monkeypatch) -> None:
+    async def fake_call(origin, destination, travel_mode, api_key):
+        table = {
+            "WALK": {"duration_seconds": 3000, "distance_meters": 4000},
+            "TRANSIT": {"duration_seconds": 1320, "distance_meters": 5400},
+            "DRIVE": {"duration_seconds": 1500, "distance_meters": 5200},
+        }
+        return table[travel_mode]
+
+    monkeypatch.setattr(route_optimizer, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_optimizer, "_call_routes_api", fake_call)
+
+    req = RouteRequest(legs=[RouteLeg(
+        from_instance_id="a", to_instance_id="b",
+        origin=Coordinates(lat=34.70, lng=135.50),
+        destination=Coordinates(lat=34.67, lng=135.49),
+    )])
+    resp = await route_optimizer.optimize_routes(req)
+
+    leg = resp.legs[0]
+    assert leg.mode == "transit"
+    assert leg.source == "google"
+    assert leg.duration_seconds == 1320
+
+
+@pytest.mark.asyncio
+async def test_optimize_falls_back_when_google_returns_nothing(monkeypatch) -> None:
+    async def fake_call(origin, destination, travel_mode, api_key):
+        return None
+
+    monkeypatch.setattr(route_optimizer, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_optimizer, "_call_routes_api", fake_call)
+
+    req = RouteRequest(legs=[RouteLeg(
+        from_instance_id="a", to_instance_id="b",
+        origin=Coordinates(lat=34.70, lng=135.50),
+        destination=Coordinates(lat=34.67, lng=135.49),
+    )])
+    resp = await route_optimizer.optimize_routes(req)
+    assert resp.legs[0].source == "estimated"
+
+
+@pytest.mark.asyncio
+async def test_optimize_falls_back_when_no_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(route_optimizer, "_places_api_key", lambda: None)
+    req = RouteRequest(legs=[RouteLeg(
+        from_instance_id="a", to_instance_id="b",
+        origin=Coordinates(lat=34.70, lng=135.50),
+        destination=Coordinates(lat=34.67, lng=135.49),
+    )])
+    resp = await route_optimizer.optimize_routes(req)
+    assert resp.legs[0].source == "estimated"

--- a/apps/ai-engine/tests/test_route_optimizer.py
+++ b/apps/ai-engine/tests/test_route_optimizer.py
@@ -120,3 +120,31 @@ async def test_optimize_falls_back_when_no_api_key(monkeypatch) -> None:
     )])
     resp = await route_optimizer.optimize_routes(req)
     assert resp.legs[0].source == "estimated"
+
+
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_route_endpoint_returns_legs(monkeypatch) -> None:
+    async def fake_call(origin, destination, travel_mode, api_key):
+        return {"duration_seconds": 600, "distance_meters": 2000}
+
+    monkeypatch.setattr(route_optimizer, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_optimizer, "_call_routes_api", fake_call)
+
+    from app.main import app
+
+    body = {"legs": [{
+        "from_instance_id": "a", "to_instance_id": "b",
+        "origin": {"lat": 34.70, "lng": 135.50},
+        "destination": {"lat": 34.67, "lng": 135.49},
+    }]}
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/internal/ai/route", json=body)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["legs"][0]["from_instance_id"] == "a"
+    assert data["legs"][0]["source"] == "google"

--- a/apps/ai-engine/tests/test_route_optimizer.py
+++ b/apps/ai-engine/tests/test_route_optimizer.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+os.environ.setdefault("GOOGLE_MAPS_API_KEY", "test-maps-key")
+
+from app.schemas.route import Coord, RouteLeg, RouteLegResult, RouteRequest, RouteResponse
+
+
+def test_schema_roundtrip() -> None:
+    req = RouteRequest(legs=[RouteLeg(
+        from_instance_id="a", to_instance_id="b",
+        origin=Coord(lat=34.70, lng=135.50),
+        destination=Coord(lat=34.67, lng=135.49),
+    )])
+    assert req.legs[0].origin.lat == 34.70

--- a/apps/ai-engine/tests/test_route_optimizer.py
+++ b/apps/ai-engine/tests/test_route_optimizer.py
@@ -94,6 +94,23 @@ async def test_optimize_falls_back_when_google_returns_nothing(monkeypatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_optimize_falls_back_when_leg_raises(monkeypatch) -> None:
+    async def boom(origin, destination, travel_mode, api_key):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(route_optimizer, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_optimizer, "_call_routes_api", boom)
+
+    req = RouteRequest(legs=[RouteLeg(
+        from_instance_id="a", to_instance_id="b",
+        origin=Coordinates(lat=34.70, lng=135.50),
+        destination=Coordinates(lat=34.67, lng=135.49),
+    )])
+    resp = await route_optimizer.optimize_routes(req)
+    assert resp.legs[0].source == "estimated"
+
+
+@pytest.mark.asyncio
 async def test_optimize_falls_back_when_no_api_key(monkeypatch) -> None:
     monkeypatch.setattr(route_optimizer, "_places_api_key", lambda: None)
     req = RouteRequest(legs=[RouteLeg(

--- a/apps/backend/src/main/java/com/tripkey/domain/route/RouteLegCache.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/route/RouteLegCache.java
@@ -1,0 +1,67 @@
+package com.tripkey.domain.route;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "route_legs_cache")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RouteLegCache {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "origin_lat", nullable = false)
+    private double originLat;
+
+    @Column(name = "origin_lng", nullable = false)
+    private double originLng;
+
+    @Column(name = "dest_lat", nullable = false)
+    private double destLat;
+
+    @Column(name = "dest_lng", nullable = false)
+    private double destLng;
+
+    @Column(name = "duration_seconds", nullable = false)
+    private int durationSeconds;
+
+    @Column(name = "distance_meters", nullable = false)
+    private int distanceMeters;
+
+    @Column(name = "mode", nullable = false)
+    private String mode;
+
+    @Column(name = "source", nullable = false)
+    private String source;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    public static RouteLegCache of(double originLat, double originLng, double destLat, double destLng,
+                                   int durationSeconds, int distanceMeters, String mode, String source) {
+        RouteLegCache c = new RouteLegCache();
+        c.originLat = originLat;
+        c.originLng = originLng;
+        c.destLat = destLat;
+        c.destLng = destLng;
+        c.durationSeconds = durationSeconds;
+        c.distanceMeters = distanceMeters;
+        c.mode = mode;
+        c.source = source;
+        return c;
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/route/RouteLegCacheRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/route/RouteLegCacheRepository.java
@@ -1,0 +1,11 @@
+package com.tripkey.domain.route;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RouteLegCacheRepository extends JpaRepository<RouteLegCache, Long> {
+
+    Optional<RouteLegCache> findByOriginLatAndOriginLngAndDestLatAndDestLng(
+            double originLat, double originLng, double destLat, double destLng);
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/route/RouteService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/route/RouteService.java
@@ -1,0 +1,123 @@
+package com.tripkey.domain.route;
+
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.dto.placement.RouteLeg;
+import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiRouteRequest;
+import com.tripkey.infra.aiengine.dto.AiRouteResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RouteService {
+
+    private final PlaceCardRepository placeCardRepository;
+    private final RouteLegCacheRepository routeLegCacheRepository;
+    private final AiEngineClient aiEngineClient;
+
+    @Transactional
+    public List<RouteLeg> computeLegs(UUID tripId) {
+        Map<Integer, List<PlaceCard>> byDay = groupByDay(tripId);
+        List<RouteLeg> result = new ArrayList<>();
+        for (Map.Entry<Integer, List<PlaceCard>> entry : byDay.entrySet()) {
+            result.addAll(computeDayLegs(entry.getKey(), entry.getValue()));
+        }
+        return result;
+    }
+
+    private Map<Integer, List<PlaceCard>> groupByDay(UUID tripId) {
+        Map<Integer, List<PlaceCard>> byDay = new TreeMap<>();
+        for (PlaceCard card : placeCardRepository.findAllByTripId(tripId)) {
+            if (Boolean.TRUE.equals(card.getIsExcluded())) continue;
+            if (card.getDay() == null) continue;
+            if (card.getLat() == null || card.getLng() == null) continue;
+            byDay.computeIfAbsent(card.getDay(), k -> new ArrayList<>()).add(card);
+        }
+        for (List<PlaceCard> cards : byDay.values()) {
+            cards.sort(Comparator.comparing(c -> c.getDayOrder() == null ? Short.MAX_VALUE : c.getDayOrder()));
+        }
+        return byDay;
+    }
+
+    private List<RouteLeg> computeDayLegs(int day, List<PlaceCard> cards) {
+        List<PlaceCard[]> pairs = new ArrayList<>();
+        for (int i = 0; i + 1 < cards.size(); i++) {
+            pairs.add(new PlaceCard[]{cards.get(i), cards.get(i + 1)});
+        }
+
+        Map<String, RouteLeg> resolved = new LinkedHashMap<>();
+        List<AiRouteRequest.Leg> misses = new ArrayList<>();
+        for (PlaceCard[] pair : pairs) {
+            PlaceCard from = pair[0];
+            PlaceCard to = pair[1];
+            String key = from.getInstanceId() + "->" + to.getInstanceId();
+            Optional<RouteLegCache> cached = routeLegCacheRepository
+                    .findByOriginLatAndOriginLngAndDestLatAndDestLng(
+                            round(from.getLat()), round(from.getLng()),
+                            round(to.getLat()), round(to.getLng()));
+            if (cached.isPresent()) {
+                RouteLegCache c = cached.get();
+                resolved.put(key, new RouteLeg(day, from.getInstanceId(), to.getInstanceId(),
+                        c.getDurationSeconds(), c.getDistanceMeters(), c.getMode(), c.getSource()));
+            } else {
+                misses.add(new AiRouteRequest.Leg(
+                        from.getInstanceId().toString(), to.getInstanceId().toString(),
+                        new AiRouteRequest.Coord(round(from.getLat()), round(from.getLng())),
+                        new AiRouteRequest.Coord(round(to.getLat()), round(to.getLng()))));
+            }
+        }
+
+        if (!misses.isEmpty()) {
+            AiRouteResponse response = aiEngineClient.route(new AiRouteRequest(misses));
+            for (AiRouteResponse.Leg leg : response.legs()) {
+                UUID fromId = UUID.fromString(leg.fromInstanceId());
+                UUID toId = UUID.fromString(leg.toInstanceId());
+                String key = fromId + "->" + toId;
+                resolved.put(key, new RouteLeg(day, fromId, toId,
+                        leg.durationSeconds(), leg.distanceMeters(), leg.mode(), leg.source()));
+                if ("google".equals(leg.source())) {
+                    AiRouteRequest.Leg req = findRequestLeg(misses, leg.fromInstanceId(), leg.toInstanceId());
+                    if (req != null) {
+                        routeLegCacheRepository.save(RouteLegCache.of(
+                                req.origin().lat(), req.origin().lng(),
+                                req.destination().lat(), req.destination().lng(),
+                                leg.durationSeconds(), leg.distanceMeters(), leg.mode(), leg.source()));
+                    }
+                }
+            }
+        }
+
+        List<RouteLeg> ordered = new ArrayList<>();
+        for (PlaceCard[] pair : pairs) {
+            String key = pair[0].getInstanceId() + "->" + pair[1].getInstanceId();
+            RouteLeg leg = resolved.get(key);
+            if (leg != null) ordered.add(leg);
+        }
+        return ordered;
+    }
+
+    private static AiRouteRequest.Leg findRequestLeg(List<AiRouteRequest.Leg> legs, String from, String to) {
+        for (AiRouteRequest.Leg leg : legs) {
+            if (leg.fromInstanceId().equals(from) && leg.toInstanceId().equals(to)) {
+                return leg;
+            }
+        }
+        return null;
+    }
+
+    private static double round(double value) {
+        return Math.round(value * 100_000.0) / 100_000.0;
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/route/RouteService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/route/RouteService.java
@@ -28,7 +28,7 @@ public class RouteService {
 
     private static final double COORD_PRECISION = 100_000.0; // 좌표 5자리(약 1m) 반올림
 
-    // 의도적으로 @Transactional 미적용: AI 엔진 HTTP 호출 동안 DB 커넥션을 점유하지 않기 위함. 캐시 read/save 는 각 repository 호출의 기본 트랜잭션으로 처리.
+    // @Transactional 미선언: 호출자(VerifyService.verifyAndSave)의 트랜잭션에 참여한다. 카드 read 와 캐시 saveAll 만 수행하며, 라우트 계산은 부가정보이므로 호출자에서 best-effort 로 감싼다.
     public List<RouteLeg> computeLegs(UUID tripId) {
         Map<Integer, List<PlaceCard>> byDay = groupByDay(tripId);
         List<RouteLeg> result = new ArrayList<>();
@@ -36,8 +36,16 @@ public class RouteService {
         for (Map.Entry<Integer, List<PlaceCard>> entry : byDay.entrySet()) {
             result.addAll(computeDayLegs(entry.getKey(), entry.getValue(), cacheRows));
         }
+        // route_legs_cache 의 unique (origin_lat, origin_lng, dest_lat, dest_lng) 제약 위반을 막기 위해
+        // 동일 좌표 튜플의 캐시 행은 첫 번째만 남기고 dedupe 한다. (result 의 RouteLeg 는 그대로 유지)
         if (!cacheRows.isEmpty()) {
-            routeLegCacheRepository.saveAll(cacheRows);
+            Map<String, RouteLegCache> deduped = new LinkedHashMap<>();
+            for (RouteLegCache row : cacheRows) {
+                String coordKey = row.getOriginLat() + "," + row.getOriginLng()
+                        + "," + row.getDestLat() + "," + row.getDestLng();
+                deduped.putIfAbsent(coordKey, row);
+            }
+            routeLegCacheRepository.saveAll(deduped.values());
         }
         return result;
     }

--- a/apps/backend/src/main/java/com/tripkey/domain/route/RouteService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/route/RouteService.java
@@ -8,7 +8,6 @@ import com.tripkey.infra.aiengine.dto.AiRouteRequest;
 import com.tripkey.infra.aiengine.dto.AiRouteResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -27,12 +26,18 @@ public class RouteService {
     private final RouteLegCacheRepository routeLegCacheRepository;
     private final AiEngineClient aiEngineClient;
 
-    @Transactional
+    private static final double COORD_PRECISION = 100_000.0; // 좌표 5자리(약 1m) 반올림
+
+    // 의도적으로 @Transactional 미적용: AI 엔진 HTTP 호출 동안 DB 커넥션을 점유하지 않기 위함. 캐시 read/save 는 각 repository 호출의 기본 트랜잭션으로 처리.
     public List<RouteLeg> computeLegs(UUID tripId) {
         Map<Integer, List<PlaceCard>> byDay = groupByDay(tripId);
         List<RouteLeg> result = new ArrayList<>();
+        List<RouteLegCache> cacheRows = new ArrayList<>();
         for (Map.Entry<Integer, List<PlaceCard>> entry : byDay.entrySet()) {
-            result.addAll(computeDayLegs(entry.getKey(), entry.getValue()));
+            result.addAll(computeDayLegs(entry.getKey(), entry.getValue(), cacheRows));
+        }
+        if (!cacheRows.isEmpty()) {
+            routeLegCacheRepository.saveAll(cacheRows);
         }
         return result;
     }
@@ -51,7 +56,7 @@ public class RouteService {
         return byDay;
     }
 
-    private List<RouteLeg> computeDayLegs(int day, List<PlaceCard> cards) {
+    private List<RouteLeg> computeDayLegs(int day, List<PlaceCard> cards, List<RouteLegCache> cacheRows) {
         List<PlaceCard[]> pairs = new ArrayList<>();
         for (int i = 0; i + 1 < cards.size(); i++) {
             pairs.add(new PlaceCard[]{cards.get(i), cards.get(i + 1)});
@@ -90,7 +95,7 @@ public class RouteService {
                 if ("google".equals(leg.source())) {
                     AiRouteRequest.Leg req = findRequestLeg(misses, leg.fromInstanceId(), leg.toInstanceId());
                     if (req != null) {
-                        routeLegCacheRepository.save(RouteLegCache.of(
+                        cacheRows.add(RouteLegCache.of(
                                 req.origin().lat(), req.origin().lng(),
                                 req.destination().lat(), req.destination().lng(),
                                 leg.durationSeconds(), leg.distanceMeters(), leg.mode(), leg.source()));
@@ -118,6 +123,6 @@ public class RouteService {
     }
 
     private static double round(double value) {
-        return Math.round(value * 100_000.0) / 100_000.0;
+        return Math.round(value * COORD_PRECISION) / COORD_PRECISION;
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/verify/VerifyService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/verify/VerifyService.java
@@ -3,11 +3,13 @@ package com.tripkey.domain.verify;
 import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.route.RouteService;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.placement.PlacementDay;
 import com.tripkey.dto.placement.PlacementDayItem;
 import com.tripkey.dto.placement.PlacementSaveRequest;
 import com.tripkey.dto.placement.PlacementSaveResponse;
+import com.tripkey.dto.placement.RouteLeg;
 import com.tripkey.dto.placement.RouteWarning;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +30,7 @@ public class VerifyService {
     private final TripRepository tripRepository;
     private final PlaceCardRepository placeCardRepository;
     private final RouteValidator routeValidator;
+    private final RouteService routeService;
 
     /**
      * Snapshot semantics — request 는 trip 의 Day 배치 전체 상태를 나타낸다.
@@ -73,7 +76,8 @@ public class VerifyService {
 
         placeCardRepository.flush();
         List<RouteWarning> routeWarnings = routeValidator.validate(tripId);
+        List<RouteLeg> routeLegs = routeService.computeLegs(tripId);
 
-        return PlacementSaveResponse.of(tripId, skippedInstanceIds, routeWarnings);
+        return PlacementSaveResponse.of(tripId, skippedInstanceIds, routeWarnings, routeLegs);
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/verify/VerifyService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/verify/VerifyService.java
@@ -12,6 +12,7 @@ import com.tripkey.dto.placement.PlacementSaveResponse;
 import com.tripkey.dto.placement.RouteLeg;
 import com.tripkey.dto.placement.RouteWarning;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class VerifyService {
@@ -76,7 +78,14 @@ public class VerifyService {
 
         placeCardRepository.flush();
         List<RouteWarning> routeWarnings = routeValidator.validate(tripId);
-        List<RouteLeg> routeLegs = routeService.computeLegs(tripId);
+        // route leg 계산은 부가정보(best-effort). ai-engine 장애/타임아웃 시에도 Day 배치 저장은 성공해야 한다.
+        List<RouteLeg> routeLegs;
+        try {
+            routeLegs = routeService.computeLegs(tripId);
+        } catch (Exception e) {
+            log.warn("route leg 계산 실패, 빈 결과로 대체합니다. tripId={}", tripId, e);
+            routeLegs = List.of();
+        }
 
         return PlacementSaveResponse.of(tripId, skippedInstanceIds, routeWarnings, routeLegs);
     }

--- a/apps/backend/src/main/java/com/tripkey/dto/placement/PlacementSaveResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/placement/PlacementSaveResponse.java
@@ -7,17 +7,24 @@ public record PlacementSaveResponse(
         boolean saved,
         UUID tripId,
         List<UUID> skippedInstanceIds,
-        List<RouteWarning> routeWarnings
+        List<RouteWarning> routeWarnings,
+        List<RouteLeg> routeLegs
 ) {
-    public static PlacementSaveResponse of(UUID tripId, List<UUID> skippedInstanceIds, List<RouteWarning> routeWarnings) {
-        return new PlacementSaveResponse(true, tripId, skippedInstanceIds, routeWarnings);
+    public static PlacementSaveResponse of(UUID tripId, List<UUID> skippedInstanceIds,
+                                           List<RouteWarning> routeWarnings, List<RouteLeg> routeLegs) {
+        return new PlacementSaveResponse(true, tripId, skippedInstanceIds, routeWarnings, routeLegs);
+    }
+
+    public static PlacementSaveResponse of(UUID tripId, List<UUID> skippedInstanceIds,
+                                           List<RouteWarning> routeWarnings) {
+        return of(tripId, skippedInstanceIds, routeWarnings, List.of());
     }
 
     public static PlacementSaveResponse of(UUID tripId, List<UUID> skippedInstanceIds) {
-        return of(tripId, skippedInstanceIds, List.of());
+        return of(tripId, skippedInstanceIds, List.of(), List.of());
     }
 
     public static PlacementSaveResponse of(UUID tripId) {
-        return of(tripId, List.of(), List.of());
+        return of(tripId, List.of(), List.of(), List.of());
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/placement/RouteLeg.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/placement/RouteLeg.java
@@ -1,0 +1,14 @@
+package com.tripkey.dto.placement;
+
+import java.util.UUID;
+
+public record RouteLeg(
+        Integer day,
+        UUID fromInstanceId,
+        UUID toInstanceId,
+        Integer durationSeconds,
+        Integer distanceMeters,
+        String mode,
+        String source
+) {
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
@@ -6,6 +6,8 @@ import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
+import com.tripkey.infra.aiengine.dto.AiRouteRequest;
+import com.tripkey.infra.aiengine.dto.AiRouteResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -34,6 +36,23 @@ public class AiEngineClient {
             return response;
         } catch (WebClientResponseException | WebClientRequestException e) {
             throw new IllegalStateException("Failed to call ai-engine parse endpoint", e);
+        }
+    }
+
+    public AiRouteResponse route(AiRouteRequest request) {
+        try {
+            AiRouteResponse response = aiEngineWebClient.post()
+                    .uri("/internal/ai/route")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(AiRouteResponse.class)
+                    .block();
+            if (response == null) {
+                throw new IllegalStateException("ai-engine returned an empty route response body");
+            }
+            return response;
+        } catch (WebClientResponseException | WebClientRequestException e) {
+            throw new IllegalStateException("Failed to call ai-engine route endpoint", e);
         }
     }
 

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiRouteRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiRouteRequest.java
@@ -1,0 +1,17 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record AiRouteRequest(List<Leg> legs) {
+
+    public record Coord(double lat, double lng) {}
+
+    public record Leg(
+            @JsonProperty("from_instance_id") String fromInstanceId,
+            @JsonProperty("to_instance_id") String toInstanceId,
+            Coord origin,
+            Coord destination
+    ) {}
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiRouteResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiRouteResponse.java
@@ -1,0 +1,17 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record AiRouteResponse(List<Leg> legs) {
+
+    public record Leg(
+            @JsonProperty("from_instance_id") String fromInstanceId,
+            @JsonProperty("to_instance_id") String toInstanceId,
+            @JsonProperty("duration_seconds") int durationSeconds,
+            @JsonProperty("distance_meters") int distanceMeters,
+            String mode,
+            String source
+    ) {}
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/route/RouteLegCacheIntegrationTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/route/RouteLegCacheIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.tripkey.domain.route;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = NONE)
+@Testcontainers
+class RouteLegCacheIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgis/postgis:16-3.4").asCompatibleSubstituteFor("postgres"))
+            .withInitScript("postgis-test-schema.sql");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        r.add("spring.datasource.username", POSTGRES::getUsername);
+        r.add("spring.datasource.password", POSTGRES::getPassword);
+        r.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    }
+
+    @Autowired
+    private RouteLegCacheRepository routeLegCacheRepository;
+
+    @Test
+    void persistsAndReadsBackCacheRow() {
+        RouteLegCache saved = routeLegCacheRepository.save(
+                RouteLegCache.of(34.70000, 135.50000, 34.67000, 135.49000,
+                        1320, 5400, "transit", "google"));
+
+        Optional<RouteLegCache> found = routeLegCacheRepository
+                .findByOriginLatAndOriginLngAndDestLatAndDestLng(34.70000, 135.50000, 34.67000, 135.49000);
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(saved.getId());
+        assertThat(found.get().getMode()).isEqualTo("transit");
+        assertThat(found.get().getDurationSeconds()).isEqualTo(1320);
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/route/RouteServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/route/RouteServiceTest.java
@@ -8,12 +8,14 @@ import com.tripkey.infra.aiengine.dto.AiRouteRequest;
 import com.tripkey.infra.aiengine.dto.AiRouteResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -161,6 +163,43 @@ class RouteServiceTest {
         assertThat(legs).hasSize(1);
         assertThat(legs.get(0).mode()).isEqualTo("walking");
         verify(aiEngineClient, never()).route(any());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void dedupesCacheRowsWithSameCoordinates() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        UUID c = UUID.randomUUID();
+        UUID d = UUID.randomUUID();
+        // day 1: A(coordsX) -> B(coordsY), day 2: C(coordsX) -> D(coordsY)
+        // 좌표는 A=C, B=D 로 동일하지만 instanceId 는 모두 다름.
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(
+                card(a, 1, 1, 34.70, 135.50),
+                card(b, 1, 2, 34.67, 135.49),
+                card(c, 2, 1, 34.70, 135.50),
+                card(d, 2, 2, 34.67, 135.49)
+        ));
+        when(routeLegCacheRepository.findByOriginLatAndOriginLngAndDestLatAndDestLng(
+                anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(Optional.empty());
+        when(aiEngineClient.route(any())).thenAnswer(inv -> {
+            AiRouteRequest req = inv.getArgument(0);
+            return new AiRouteResponse(req.legs().stream()
+                    .map(l -> new AiRouteResponse.Leg(l.fromInstanceId(), l.toInstanceId(), 600, 2000, "walking", "google"))
+                    .toList());
+        });
+
+        List<RouteLeg> legs = routeService.computeLegs(tripId);
+
+        // 두 day 각각 RouteLeg 1개씩 = 총 2개 (result leg 는 dedupe 되지 않음)
+        assertThat(legs).hasSize(2);
+
+        // 캐시 행은 동일 좌표 튜플이므로 1개로 dedupe 되어 저장
+        ArgumentCaptor<Iterable<RouteLegCache>> captor = ArgumentCaptor.forClass(Iterable.class);
+        verify(routeLegCacheRepository).saveAll(captor.capture());
+        Collection<RouteLegCache> saved = (Collection<RouteLegCache>) captor.getValue();
+        assertThat(saved).hasSize(1);
     }
 
     @Test

--- a/apps/backend/src/test/java/com/tripkey/domain/route/RouteServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/route/RouteServiceTest.java
@@ -1,0 +1,126 @@
+package com.tripkey.domain.route;
+
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.dto.placement.RouteLeg;
+import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiRouteRequest;
+import com.tripkey.infra.aiengine.dto.AiRouteResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RouteServiceTest {
+
+    @Mock PlaceCardRepository placeCardRepository;
+    @Mock RouteLegCacheRepository routeLegCacheRepository;
+    @Mock AiEngineClient aiEngineClient;
+
+    @InjectMocks RouteService routeService;
+
+    private PlaceCard card(UUID id, int day, int order, Double lat, Double lng) {
+        PlaceCard c = newPlaceCard();
+        setField(c, "instanceId", id);
+        setField(c, "day", day);
+        setField(c, "dayOrder", (short) order);
+        setField(c, "lat", lat);
+        setField(c, "lng", lng);
+        setField(c, "category", "place");
+        setField(c, "isExcluded", false);
+        return c;
+    }
+
+    private static PlaceCard newPlaceCard() {
+        try {
+            Constructor<PlaceCard> ctor = PlaceCard.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            return ctor.newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field f = PlaceCard.class.getDeclaredField(name);
+            f.setAccessible(true);
+            f.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void computesLegFromAiWhenCacheMisses() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(
+                card(a, 1, 1, 34.70, 135.50),
+                card(b, 1, 2, 34.67, 135.49)
+        ));
+        when(routeLegCacheRepository.findByOriginLatAndOriginLngAndDestLatAndDestLng(
+                anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(Optional.empty());
+        when(aiEngineClient.route(any(AiRouteRequest.class))).thenReturn(new AiRouteResponse(List.of(
+                new AiRouteResponse.Leg(a.toString(), b.toString(), 1320, 5400, "transit", "google")
+        )));
+
+        List<RouteLeg> legs = routeService.computeLegs(tripId);
+
+        assertThat(legs).hasSize(1);
+        assertThat(legs.get(0).mode()).isEqualTo("transit");
+        assertThat(legs.get(0).durationSeconds()).isEqualTo(1320);
+        assertThat(legs.get(0).day()).isEqualTo(1);
+        verify(routeLegCacheRepository).save(any(RouteLegCache.class));
+    }
+
+    @Test
+    void usesCacheWithoutCallingAi() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(
+                card(a, 1, 1, 34.70, 135.50),
+                card(b, 1, 2, 34.67, 135.49)
+        ));
+        when(routeLegCacheRepository.findByOriginLatAndOriginLngAndDestLatAndDestLng(
+                anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(Optional.of(
+                RouteLegCache.of(34.70, 135.50, 34.67, 135.49, 900, 3000, "walking", "google")));
+
+        List<RouteLeg> legs = routeService.computeLegs(tripId);
+
+        assertThat(legs).hasSize(1);
+        assertThat(legs.get(0).mode()).isEqualTo("walking");
+        verify(aiEngineClient, never()).route(any());
+    }
+
+    @Test
+    void skipsCardsWithoutCoordinates() {
+        UUID tripId = UUID.randomUUID();
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(
+                card(UUID.randomUUID(), 1, 1, null, null),
+                card(UUID.randomUUID(), 1, 2, 34.67, 135.49)
+        ));
+
+        List<RouteLeg> legs = routeService.computeLegs(tripId);
+
+        assertThat(legs).isEmpty();
+        verify(aiEngineClient, never()).route(any());
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/route/RouteServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/route/RouteServiceTest.java
@@ -87,7 +87,60 @@ class RouteServiceTest {
         assertThat(legs.get(0).mode()).isEqualTo("transit");
         assertThat(legs.get(0).durationSeconds()).isEqualTo(1320);
         assertThat(legs.get(0).day()).isEqualTo(1);
-        verify(routeLegCacheRepository).save(any(RouteLegCache.class));
+        verify(routeLegCacheRepository).saveAll(any());
+    }
+
+    @Test
+    void returnsEstimatedLegButDoesNotCacheIt() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(
+                card(a, 1, 1, 34.70, 135.50),
+                card(b, 1, 2, 34.67, 135.49)
+        ));
+        when(routeLegCacheRepository.findByOriginLatAndOriginLngAndDestLatAndDestLng(
+                anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(Optional.empty());
+        when(aiEngineClient.route(any(AiRouteRequest.class))).thenReturn(new AiRouteResponse(List.of(
+                new AiRouteResponse.Leg(a.toString(), b.toString(), 1800, 6000, "estimated", "estimated")
+        )));
+
+        List<RouteLeg> legs = routeService.computeLegs(tripId);
+
+        assertThat(legs).hasSize(1);
+        assertThat(legs.get(0).mode()).isEqualTo("estimated");
+        assertThat(legs.get(0).source()).isEqualTo("estimated");
+        verify(routeLegCacheRepository, never()).saveAll(any());
+        verify(routeLegCacheRepository, never()).save(any());
+    }
+
+    @Test
+    void ordersLegsByDayAscending() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        UUID c = UUID.randomUUID();
+        UUID d = UUID.randomUUID();
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(
+                card(a, 2, 1, 35.10, 136.50),
+                card(b, 2, 2, 35.12, 136.52),
+                card(c, 1, 1, 34.70, 135.50),
+                card(d, 1, 2, 34.67, 135.49)
+        ));
+        when(routeLegCacheRepository.findByOriginLatAndOriginLngAndDestLatAndDestLng(
+                anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(Optional.empty());
+        when(aiEngineClient.route(any())).thenAnswer(inv -> {
+            AiRouteRequest req = inv.getArgument(0);
+            return new AiRouteResponse(req.legs().stream()
+                    .map(l -> new AiRouteResponse.Leg(l.fromInstanceId(), l.toInstanceId(), 600, 2000, "walking", "google"))
+                    .toList());
+        });
+
+        List<RouteLeg> legs = routeService.computeLegs(tripId);
+
+        assertThat(legs).hasSize(2);
+        assertThat(legs.get(0).day()).isEqualTo(1);
+        assertThat(legs.get(1).day()).isEqualTo(2);
     }
 
     @Test

--- a/apps/backend/src/test/java/com/tripkey/domain/verify/VerifyServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/verify/VerifyServiceTest.java
@@ -35,6 +35,9 @@ class VerifyServiceTest {
     @Mock
     private RouteValidator routeValidator;
 
+    @Mock
+    private com.tripkey.domain.route.RouteService routeService;
+
     @InjectMocks
     private VerifyService verifyService;
 

--- a/apps/backend/src/test/java/com/tripkey/domain/verify/VerifyServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/verify/VerifyServiceTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -284,6 +285,23 @@ class VerifyServiceTest {
         );
 
         assertThat(response.routeWarnings()).isEmpty();
+    }
+
+    @Test
+    void verifySucceedsWhenRouteServiceFails() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+        // ai-engine 장애 시뮬레이션: route 계산이 예외를 던져도 저장은 성공해야 한다.
+        when(routeService.computeLegs(any())).thenThrow(new IllegalStateException("ai-engine down"));
+
+        PlacementSaveResponse response = verifyService.verifyAndSave(
+                tripId, new PlacementSaveRequest(List.of())
+        );
+
+        assertThat(response).isNotNull();
+        assertThat(response.saved()).isTrue();
+        assertThat(response.routeLegs()).isEmpty();
     }
 
     private PlaceCard placeCard(UUID tripId) {

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -120,3 +120,17 @@ create table enrichment_outbox (
   next_attempt_at timestamptz not null default now()
 );
 create index idx_enrichment_outbox_pending on enrichment_outbox (created_at) where status = 'pending';
+
+create table route_legs_cache (
+  id               bigserial   primary key,
+  origin_lat       double precision not null,
+  origin_lng       double precision not null,
+  dest_lat         double precision not null,
+  dest_lng         double precision not null,
+  duration_seconds integer     not null,
+  distance_meters  integer     not null,
+  mode             text        not null,
+  source           text        not null,
+  created_at       timestamptz not null default now(),
+  constraint uq_route_legs unique (origin_lat, origin_lng, dest_lat, dest_lng)
+);

--- a/shared/docs/migrations/V010__route_legs_cache.sql
+++ b/shared/docs/migrations/V010__route_legs_cache.sql
@@ -1,0 +1,13 @@
+create table if not exists public.route_legs_cache (
+  id               bigserial   primary key,
+  origin_lat       double precision not null,
+  origin_lng       double precision not null,
+  dest_lat         double precision not null,
+  dest_lng         double precision not null,
+  duration_seconds integer     not null,
+  distance_meters  integer     not null,
+  mode             text        not null,
+  source           text        not null,
+  created_at       timestamptz not null default now(),
+  constraint uq_route_legs unique (origin_lat, origin_lng, dest_lat, dest_lng)
+);

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -148,3 +148,18 @@ create table if not exists public.enrichment_outbox (
 );
 create index if not exists idx_enrichment_outbox_pending
   on public.enrichment_outbox (created_at) where status = 'pending';
+
+-- 카드 간 이동시간·이동수단 캐시 (#167, AI 엔진 Routes 결과 캐싱)
+create table if not exists public.route_legs_cache (
+  id               bigserial   primary key,
+  origin_lat       double precision not null,
+  origin_lng       double precision not null,
+  dest_lat         double precision not null,
+  dest_lng         double precision not null,
+  duration_seconds integer     not null,
+  distance_meters  integer     not null,
+  mode             text        not null,
+  source           text        not null,
+  created_at       timestamptz not null default now(),
+  constraint uq_route_legs unique (origin_lat, origin_lng, dest_lat, dest_lng)
+);


### PR DESCRIPTION
## 📝 작업 내용

> verify(Day 배치 저장) 시 인접 카드 간 **실제 이동시간·이동수단**(도보/대중교통/자동차)을 Google Routes로 계산해 응답에 노출합니다. 기존엔 직선거리 경고(`RouteValidator`)만 있었고 실제 이동 시간/수단은 없었습니다.

- AI 엔진(`POST /internal/ai/route`): leg 좌표 리스트를 받아 walking/transit/driving을 비교해 **최단 소요시간 1개 모드**를 반환. Google 실패·좌표 누락 시 **직선거리 기반 추정**(`mode=estimated`)으로 leg별 폴백 → 항상 200 반환
- BE(`RouteService`): verify 시 Day별 인접 카드쌍(leg)을 만들어 **DB 캐시(`route_legs_cache`)** 조회 → 미스만 Day 단위로 1회 AI 호출 → `google` 결과만 캐싱 → `PlacementSaveResponse.routeLegs`로 노출
- 기존 `RouteValidator` 직선거리/활동시간 경고는 **그대로 유지**(보강 방식)

**데이터 흐름**
```
VerifyService.verifyAndSave()
 → RouteValidator.validate()            (기존 경고, 유지)
 → RouteService.computeLegs(tripId)      (신규)
     Day별 인접 leg 구성 → 캐시 조회 → 미스만 AI 호출(Day 단위 1회)
     → google 결과만 캐시 저장 → 집계
 → PlacementSaveResponse { ..., routeWarnings, routeLegs }   ← routeLegs 신규
```

**응답 예시** — `routeLegs[]`
```jsonc
{
  "day": 1,
  "fromInstanceId": "…",
  "toInstanceId": "…",
  "durationSeconds": 1320,
  "distanceMeters": 5400,
  "mode": "transit",      // walking | transit | driving | estimated
  "source": "google"      // google | estimated
}
```

## 🔗 관련 이슈

closes #167

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서 (shared/docs: 마이그레이션 V010 · schema.sql)

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인 (ai-engine pytest 8건 / RouteServiceTest 6건 / VerifyServiceTest 13건 / RouteLegCache 통합테스트(Testcontainers) 통과)
- [x] 기존 기능 회귀 없음 (RouteValidator·verify 기존 흐름 보존, PlacementSaveResponse 기존 팩토리 하위호환 유지)
- [x] 하드코딩/임시 주석(TODO·FIXME) 없음
- [x] PR 범위가 하나의 기능 단위로 정리됨

## 👀 리뷰어에게

> - **배포 완료**: `route_legs_cache` 테이블을 Supabase(main/PRODUCTION)에 적용 완료 (마이그레이션 `V010`). BE가 `ddl-auto=validate`라 스키마가 일치해야 하며, 적용 완료 상태입니다. AI 엔진은 기존 `GOOGLE_MAPS_API_KEY` 재사용(추가 키 없음).
> - **best-effort 처리**: ai-engine 장애/타임아웃 시에도 Day 배치 저장은 성공하도록 `RouteService.computeLegs` 호출을 `VerifyService`에서 try/catch로 감싸 빈 `routeLegs`로 폴백합니다. 이동정보는 부가정보라는 판단.
> - **캐시 정책**: 좌표 소수점 5자리 반올림을 키로 사용. `google` 결과만 캐싱하고 `estimated`는 캐싱하지 않아 다음 verify에서 Google 재시도. 동일 verify 내 동일 좌표 leg는 saveAll 전 dedupe(unique 제약 위반 방지).
> - **AI 엔진**: googlemaps 레거시 lib 대신 기존 패턴(httpx + 신형 v1 REST, `X-Goog-Api-Key`)으로 Routes API(`computeRoutes`) 호출. leg별 폴백 + `asyncio.gather(return_exceptions=True)` 안전망.
> - **스코프**: 이슈의 `clustering.py`는 이동시간 계산에 불필요하여 제외(빈 파일 유지). FE의 SCR-04 이동시간 표시 UI는 별도 이슈.
> - **통합 테스트**: Testcontainers(Docker) 필요 — 로컬/CI에서 검증됩니다.

## 📸 스크린샷

> 없음 (BE/AI 변경, UI 영향 없음)
