### PR TITLE
Feat/be 171 trip detail api

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/trip/Trip.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/Trip.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
@@ -24,12 +25,20 @@ public class Trip {
     @Column(name = "companion_count", nullable = false)
     private Short companionCount;
 
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
     @Column(name = "confirmed_at")
     private OffsetDateTime confirmedAt;
 
-    public Trip(Short travelDays, Short companionCount) {
+    public Trip(Short travelDays, Short companionCount, LocalDate startDate) {
         this.travelDays = travelDays;
         this.companionCount = companionCount;
+        this.startDate = startDate;
+    }
+
+    public Trip(Short travelDays, Short companionCount) {
+        this(travelDays, companionCount, null);
     }
 
     public void confirm() {

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/TripController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/TripController.java
@@ -3,11 +3,14 @@ package com.tripkey.domain.trip;
 import com.tripkey.dto.trip.DestinationSearchResponse;
 import com.tripkey.dto.trip.TripCreateRequest;
 import com.tripkey.dto.trip.TripCreateResponse;
+import com.tripkey.dto.trip.TripDetailResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/trips")
@@ -26,5 +29,10 @@ public class TripController {
     public ResponseEntity<TripCreateResponse> create(@Valid @RequestBody TripCreateRequest request) {
         TripCreateResponse response = tripService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{tripId}")
+    public ResponseEntity<TripDetailResponse> getTrip(@PathVariable UUID tripId) {
+        return ResponseEntity.ok(tripService.getTripDetail(tripId));
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/TripService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/TripService.java
@@ -1,15 +1,18 @@
 package com.tripkey.domain.trip;
 
+import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.dto.trip.DestinationSearchResponse;
 import com.tripkey.dto.trip.DestinationSearchResponse.DestinationDto;
 import com.tripkey.dto.trip.TripCreateRequest;
 import com.tripkey.dto.trip.TripCreateResponse;
+import com.tripkey.dto.trip.TripDetailResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -42,6 +45,18 @@ public class TripService {
                 .toList();
 
         return new DestinationSearchResponse(filtered);
+    }
+
+    @Transactional(readOnly = true)
+    public TripDetailResponse getTripDetail(UUID tripId) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new TripNotFoundException(tripId));
+        List<String> destinations = tripDestinationRepository
+                .findByTripTripIdOrderBySortOrder(tripId)
+                .stream()
+                .map(TripDestination::getName)
+                .toList();
+        return TripDetailResponse.of(trip, destinations);
     }
 
     @Transactional

--- a/apps/backend/src/main/java/com/tripkey/domain/trip/TripService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/trip/TripService.java
@@ -63,7 +63,8 @@ public class TripService {
     public TripCreateResponse create(TripCreateRequest request) {
         Trip trip = new Trip(
                 request.travelDays(),
-                request.companionCount()
+                request.companionCount(),
+                request.startDate()
         );
         tripRepository.save(trip);
 

--- a/apps/backend/src/main/java/com/tripkey/dto/trip/TripCreateRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/trip/TripCreateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record TripCreateRequest(
@@ -19,6 +20,8 @@ public record TripCreateRequest(
         @NotNull(message = "동행 인원을 입력해주세요")
         @Min(value = 1, message = "동행 인원은 1명 이상이어야 해요")
         @Max(value = 20, message = "동행 인원은 20명 이하여야 해요")
-        Short companionCount
+        Short companionCount,
+
+        LocalDate startDate
 ) {
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/trip/TripDetailResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/trip/TripDetailResponse.java
@@ -1,0 +1,27 @@
+package com.tripkey.dto.trip;
+
+import com.tripkey.domain.trip.Trip;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record TripDetailResponse(
+        UUID tripId,
+        Short travelDays,
+        Short companionCount,
+        List<String> destinations,
+        boolean confirmed,
+        OffsetDateTime createdAt
+) {
+    public static TripDetailResponse of(Trip trip, List<String> destinations) {
+        return new TripDetailResponse(
+                trip.getTripId(),
+                trip.getTravelDays(),
+                trip.getCompanionCount(),
+                destinations,
+                trip.getConfirmedAt() != null,
+                trip.getCreatedAt()
+        );
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/trip/TripDetailResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/trip/TripDetailResponse.java
@@ -2,6 +2,7 @@ package com.tripkey.dto.trip;
 
 import com.tripkey.domain.trip.Trip;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -12,7 +13,8 @@ public record TripDetailResponse(
         Short companionCount,
         List<String> destinations,
         boolean confirmed,
-        OffsetDateTime createdAt
+        OffsetDateTime createdAt,
+        LocalDate startDate
 ) {
     public static TripDetailResponse of(Trip trip, List<String> destinations) {
         return new TripDetailResponse(
@@ -21,7 +23,8 @@ public record TripDetailResponse(
                 trip.getCompanionCount(),
                 destinations,
                 trip.getConfirmedAt() != null,
-                trip.getCreatedAt()
+                trip.getCreatedAt(),
+                trip.getStartDate()
         );
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
+++ b/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -129,7 +130,8 @@ class JsonNamingStrategyTest {
                 (short) 2,
                 List.of("교토", "오사카"),
                 false,
-                OffsetDateTime.parse("2026-05-31T10:00:00+09:00")
+                OffsetDateTime.parse("2026-05-31T10:00:00+09:00"),
+                LocalDate.parse("2026-05-10")
         );
 
         String json = objectMapper.writeValueAsString(response);
@@ -141,6 +143,8 @@ class JsonNamingStrategyTest {
                 .contains("destinations")
                 .contains("confirmed")
                 .contains("created_at")
+                .contains("start_date")
+                .doesNotContain("startDate")
                 .doesNotContain("tripId")
                 .doesNotContain("travelDays")
                 .doesNotContain("companionCount")

--- a/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
+++ b/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
@@ -3,6 +3,7 @@ package com.tripkey.common.json;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tripkey.dto.dump.ParseJobStatusResponse;
 import com.tripkey.dto.trip.TripCreateResponse;
+import com.tripkey.dto.trip.TripDetailResponse;
 import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
 import org.junit.jupiter.api.Test;
@@ -118,5 +119,31 @@ class JsonNamingStrategyTest {
                 .doesNotContain("userContext")
                 .doesNotContain("blockedReason")
                 .doesNotContain("relatedInstanceIds");
+    }
+
+    @Test
+    void serializesTripDetailResponseFieldsAsSnakeCase() throws Exception {
+        TripDetailResponse response = new TripDetailResponse(
+                UUID.randomUUID(),
+                (short) 5,
+                (short) 2,
+                List.of("교토", "오사카"),
+                false,
+                OffsetDateTime.parse("2026-05-31T10:00:00+09:00")
+        );
+
+        String json = objectMapper.writeValueAsString(response);
+
+        assertThat(json)
+                .contains("trip_id")
+                .contains("travel_days")
+                .contains("companion_count")
+                .contains("destinations")
+                .contains("confirmed")
+                .contains("created_at")
+                .doesNotContain("tripId")
+                .doesNotContain("travelDays")
+                .doesNotContain("companionCount")
+                .doesNotContain("createdAt");
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/trip/TripControllerTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/trip/TripControllerTest.java
@@ -1,0 +1,41 @@
+package com.tripkey.domain.trip;
+
+import com.tripkey.dto.trip.TripDetailResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TripControllerTest {
+
+    @Mock
+    private TripService tripService;
+
+    @InjectMocks
+    private TripController tripController;
+
+    @Test
+    void getTripReturns200WithBody() {
+        UUID id = UUID.randomUUID();
+        TripDetailResponse body = new TripDetailResponse(
+                id, (short) 5, (short) 2, List.of("교토"), false,
+                OffsetDateTime.parse("2026-05-31T10:00:00+09:00"));
+        when(tripService.getTripDetail(id)).thenReturn(body);
+
+        ResponseEntity<TripDetailResponse> response = tripController.getTrip(id);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(body);
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/trip/TripControllerTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/trip/TripControllerTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -30,7 +31,8 @@ class TripControllerTest {
         UUID id = UUID.randomUUID();
         TripDetailResponse body = new TripDetailResponse(
                 id, (short) 5, (short) 2, List.of("교토"), false,
-                OffsetDateTime.parse("2026-05-31T10:00:00+09:00"));
+                OffsetDateTime.parse("2026-05-31T10:00:00+09:00"),
+                LocalDate.parse("2026-05-10"));
         when(tripService.getTripDetail(id)).thenReturn(body);
 
         ResponseEntity<TripDetailResponse> response = tripController.getTrip(id);

--- a/apps/backend/src/test/java/com/tripkey/domain/trip/TripServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/trip/TripServiceTest.java
@@ -1,0 +1,100 @@
+package com.tripkey.domain.trip;
+
+import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.dto.trip.TripDetailResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TripServiceTest {
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private TripDestinationRepository tripDestinationRepository;
+
+    @InjectMocks
+    private TripService tripService;
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field f = target.getClass().getDeclaredField(name);
+            f.setAccessible(true);
+            f.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Trip trip(UUID id, short days, short companions, OffsetDateTime confirmedAt, OffsetDateTime createdAt) {
+        Trip t = new Trip(days, companions);
+        setField(t, "tripId", id);
+        setField(t, "confirmedAt", confirmedAt);
+        setField(t, "createdAt", createdAt);
+        return t;
+    }
+
+    // TripDestination constructor takes (Trip, String, Short) — cast int literals to Short
+    private TripDestination destination(Trip trip, String name, int sortOrder) {
+        return new TripDestination(trip, name, (short) sortOrder);
+    }
+
+    @Test
+    void getTripDetailMapsTripAndOrderedDestinations() {
+        UUID id = UUID.randomUUID();
+        OffsetDateTime created = OffsetDateTime.parse("2026-05-31T10:00:00+09:00");
+        Trip t = trip(id, (short) 5, (short) 2, null, created);
+        when(tripRepository.findById(id)).thenReturn(Optional.of(t));
+        when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(id)).thenReturn(List.of(
+                destination(t, "교토", 0),
+                destination(t, "오사카", 1)
+        ));
+
+        TripDetailResponse response = tripService.getTripDetail(id);
+
+        assertThat(response.tripId()).isEqualTo(id);
+        assertThat(response.travelDays()).isEqualTo((short) 5);
+        assertThat(response.companionCount()).isEqualTo((short) 2);
+        assertThat(response.destinations()).containsExactly("교토", "오사카");
+        assertThat(response.confirmed()).isFalse();
+        assertThat(response.createdAt()).isEqualTo(created);
+    }
+
+    @Test
+    void getTripDetailMarksConfirmedWhenConfirmedAtPresent() {
+        UUID id = UUID.randomUUID();
+        Trip t = trip(id, (short) 3, (short) 1,
+                OffsetDateTime.parse("2026-05-31T12:00:00+09:00"),
+                OffsetDateTime.parse("2026-05-31T10:00:00+09:00"));
+        when(tripRepository.findById(id)).thenReturn(Optional.of(t));
+        when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(id)).thenReturn(List.of());
+
+        TripDetailResponse response = tripService.getTripDetail(id);
+
+        assertThat(response.confirmed()).isTrue();
+        assertThat(response.destinations()).isEmpty();
+    }
+
+    @Test
+    void getTripDetailThrowsWhenTripMissing() {
+        UUID id = UUID.randomUUID();
+        when(tripRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tripService.getTripDetail(id))
+                .isInstanceOf(TripNotFoundException.class);
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/trip/TripServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/trip/TripServiceTest.java
@@ -1,14 +1,17 @@
 package com.tripkey.domain.trip;
 
 import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.dto.trip.TripCreateRequest;
 import com.tripkey.dto.trip.TripDetailResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -96,5 +99,20 @@ class TripServiceTest {
 
         assertThatThrownBy(() -> tripService.getTripDetail(id))
                 .isInstanceOf(TripNotFoundException.class);
+    }
+
+    @Test
+    void createPersistsStartDate() {
+        LocalDate start = LocalDate.parse("2026-05-10");
+        TripCreateRequest request = new TripCreateRequest(
+                List.of("교토"), (short) 5, (short) 2, start);
+        when(tripRepository.save(org.mockito.ArgumentMatchers.any(Trip.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        tripService.create(request);
+
+        ArgumentCaptor<Trip> captor = ArgumentCaptor.forClass(Trip.class);
+        org.mockito.Mockito.verify(tripRepository).save(captor.capture());
+        assertThat(captor.getValue().getStartDate()).isEqualTo(start);
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/trip/TripServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/trip/TripServiceTest.java
@@ -43,8 +43,9 @@ class TripServiceTest {
         }
     }
 
-    private Trip trip(UUID id, short days, short companions, OffsetDateTime confirmedAt, OffsetDateTime createdAt) {
-        Trip t = new Trip(days, companions);
+    private Trip trip(UUID id, short days, short companions, OffsetDateTime confirmedAt,
+                      OffsetDateTime createdAt, LocalDate startDate) {
+        Trip t = new Trip(days, companions, startDate);
         setField(t, "tripId", id);
         setField(t, "confirmedAt", confirmedAt);
         setField(t, "createdAt", createdAt);
@@ -60,7 +61,7 @@ class TripServiceTest {
     void getTripDetailMapsTripAndOrderedDestinations() {
         UUID id = UUID.randomUUID();
         OffsetDateTime created = OffsetDateTime.parse("2026-05-31T10:00:00+09:00");
-        Trip t = trip(id, (short) 5, (short) 2, null, created);
+        Trip t = trip(id, (short) 5, (short) 2, null, created, LocalDate.parse("2026-05-10"));
         when(tripRepository.findById(id)).thenReturn(Optional.of(t));
         when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(id)).thenReturn(List.of(
                 destination(t, "교토", 0),
@@ -75,6 +76,7 @@ class TripServiceTest {
         assertThat(response.destinations()).containsExactly("교토", "오사카");
         assertThat(response.confirmed()).isFalse();
         assertThat(response.createdAt()).isEqualTo(created);
+        assertThat(response.startDate()).isEqualTo(LocalDate.parse("2026-05-10"));
     }
 
     @Test
@@ -82,7 +84,7 @@ class TripServiceTest {
         UUID id = UUID.randomUUID();
         Trip t = trip(id, (short) 3, (short) 1,
                 OffsetDateTime.parse("2026-05-31T12:00:00+09:00"),
-                OffsetDateTime.parse("2026-05-31T10:00:00+09:00"));
+                OffsetDateTime.parse("2026-05-31T10:00:00+09:00"), null);
         when(tripRepository.findById(id)).thenReturn(Optional.of(t));
         when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(id)).thenReturn(List.of());
 
@@ -90,6 +92,7 @@ class TripServiceTest {
 
         assertThat(response.confirmed()).isTrue();
         assertThat(response.destinations()).isEmpty();
+        assertThat(response.startDate()).isNull();
     }
 
     @Test

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -12,6 +12,7 @@ create table trips (
   has_flight         boolean,
   has_accommodation  boolean,
   confirmed_at       timestamptz,
+  start_date         date,
   created_at         timestamptz not null default now(),
   updated_at         timestamptz not null default now()
 );

--- a/shared/docs/migrations/V011__trips_start_date.sql
+++ b/shared/docs/migrations/V011__trips_start_date.sql
@@ -1,0 +1,2 @@
+alter table public.trips
+  add column if not exists start_date date;

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -12,6 +12,7 @@ create table if not exists public.trips (
   has_flight         boolean,                                     -- 항공권 보유 여부 (온보딩 응답)
   has_accommodation  boolean,                                     -- 숙소 보유 여부 (온보딩 응답)
   confirmed_at       timestamptz,                                 -- 일정 확정 시각 (SCR-05)
+  start_date         date,                                        -- 여행 시작일 (#171 2단계, nullable)
   created_at         timestamptz not null default now(),
   updated_at         timestamptz not null default now()
 );


### PR DESCRIPTION
## 📝 작업 내용

> `tripId`로 여행 메타(여행지·인원·일수·**시작일**·확정여부·생성시각)를 한 번에 내려주는 조회 API를 추가하고, 여행 **시작일(start_date)** 저장을 지원합니다(옵션 A). FE가 새로고침·직접진입·링크공유 시 메타가 소실되던 문제를 해소하고, Day 날짜 라벨/기간 계산에 필요한 시작일을 BE가 보장합니다.

**1단계 — 조회 API**
- `GET /v1/trips/{tripId}` 엔드포인트 추가 (context-path `/v1` + 컨트롤러 `/trips/{tripId}`)
- `TripDetailResponse` record DTO 신설 (snake_case 자동 직렬화)
- `TripService.getTripDetail(UUID)` — 404는 기존 `TripNotFoundException` 재사용
- 목적지는 기존 `findByTripTripIdOrderBySortOrder`로 `sort_order` 정렬 조회

**2단계 — 시작일 저장 (옵션 A)**
- `trips.start_date`(nullable date) 컬럼 추가 (마이그레이션 V011)
- `Trip.startDate` 필드 + 3-arg 생성자 오버로드(2-arg 유지 → 하위호환)
- `TripCreateRequest.start_date`(선택 입력) → `TripService.create`가 저장
- `TripDetailResponse.start_date` 노출
- **전 구간 nullable**: 기존 trip·시작일 미입력도 정상(null), FE 온보딩 준비 시점에 맞춰 입력 전달 가능 → BE 단독 배포 가능

**응답 예시** — `GET /v1/trips/{tripId}` → 200
```json
{
  "trip_id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
  "travel_days": 5,
  "companion_count": 2,
  "destinations": ["교토", "오사카", "나라"],
  "confirmed": false,
  "created_at": "2026-05-31T10:00:00+09:00",
  "start_date": "2026-05-10"
}
```
- `confirmed` = `Trip.confirmedAt != null`
- `destinations` = `trip_destinations`의 `sort_order` ASC `name` 배열 (빈 배열 허용)
- `start_date` = `Trip.startDate` (nullable — 미입력 시 null)
- 없는 `tripId` → 404 `{"code":"TRIP_NOT_FOUND", ...}` (기존 `GlobalExceptionHandler`)

**생성 요청** — `POST /v1/trips` 에 `start_date`(선택) 추가
```json
{ "destinations": ["교토"], "travel_days": 5, "companion_count": 2, "start_date": "2026-05-10" }
```

## 🔗 관련 이슈

closes #171

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서 (shared/docs: 마이그레이션 V011 · schema.sql)

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인 (전체 `./gradlew test` 145건 통과: TripServiceTest·TripControllerTest·JsonNamingStrategyTest 포함)
- [x] 기존 기능 회귀 없음 (`new Trip(Short,Short)` 호출부 다수 — 생성자 오버로드로 전부 그대로 컴파일, `/trips/destinations/search`·`POST /trips`와 라우팅 충돌 없음)
- [x] 하드코딩/임시 주석(TODO·FIXME) 없음
- [x] PR 범위가 하나의 기능 단위로 정리됨

## 👀 리뷰어에게

> - **배포 완료**: `trips.start_date` 컬럼(마이그레이션 V011)을 Supabase(main/PRODUCTION)에 적용 완료. BE가 `ddl-auto=validate`라 스키마 일치가 필요하며, 적용 완료 상태입니다.
> - **마이그레이션 번호 V011 (V010 갭은 의도적)**: 이 브랜치엔 V010 파일이 없습니다. V010(route_legs_cache)은 미머지된 #167 PR에 있고 Supabase엔 이미 적용돼 있어, 다음 번호로 V011을 사용했습니다. 두 마이그레이션은 서로 다른 객체라 머지 순서와 무관하게 공존합니다. (Flyway 런타임/순차검증 없음 — 수동 배포)
> - **경로**: `GET /v1/trips/{tripId}`. `/v1`은 `application.yml`의 `context-path`에서 자동 적용 → 컨트롤러엔 미기재(중복 방지). FE 요청·기존 모든 API와 일치.
> - **snake_case**: 전역 `property-naming-strategy: SNAKE_CASE` → DTO는 평범한 camelCase record(`@JsonProperty` 불필요). `JsonNamingStrategyTest`로 `trip_id`/`start_date` 등 실제 직렬화 검증.
> - **전 구간 nullable**: `start_date`는 컬럼·요청·응답 모두 nullable. 기존 데이터·미입력 케이스 안전, FE 온보딩 입력 위젯 준비 전에도 머지 가능.
> - (스코프 밖) 비-UUID 경로(`/v1/trips/not-a-uuid`)는 Spring 기본 400 반환 — `@PathVariable UUID` 기존 엔드포인트 전반 공통 사항이라 별도 이슈 권장.

## 📸 스크린샷

> 없음 (BE 변경, UI 영향 없음)
