### PR TITLE
Feat: 160 덤프 보조정보(항공/숙박) UI 및 API 연동

### DIFF
--- a/apps/frontend/src/components/dump/DumpFlightInfo.tsx
+++ b/apps/frontend/src/components/dump/DumpFlightInfo.tsx
@@ -1,0 +1,59 @@
+import { Input } from '@/components/ui/input';
+
+type FlightSection = {
+  key: 'departure' | 'return';
+  label: string;
+  badgeClass: string;
+};
+
+const sections: FlightSection[] = [
+  {
+    key: 'departure',
+    label: '출발',
+    badgeClass: 'bg-blue-100 text-blue-700',
+  },
+  {
+    key: 'return',
+    label: '귀국',
+    badgeClass: 'bg-red-100 text-red-700',
+  },
+];
+
+const DumpFlightInfo = () => {
+  return (
+    <div className="flex flex-col gap-3">
+      {sections.map((section) => (
+        <div
+          key={section.key}
+          className="rounded-xl border border-gray-200 p-4"
+        >
+          <span
+            className={`inline-block rounded-md px-2 py-0.5 text-xs font-semibold mb-3 ${section.badgeClass}`}
+          >
+            {section.label}
+          </span>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">공항</label>
+              <Input
+                className="h-9 text-sm bg-white"
+                placeholder="예: 인천국제공항"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">항공편</label>
+              <Input className="h-9 text-sm bg-white" placeholder="예: KE123" />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">시간</label>
+              <Input className="h-9 text-sm bg-white" placeholder="예: 09:30" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DumpFlightInfo;

--- a/apps/frontend/src/components/dump/DumpFlightInfo.tsx
+++ b/apps/frontend/src/components/dump/DumpFlightInfo.tsx
@@ -1,5 +1,7 @@
 import { Input } from '@/components/ui/input';
 
+import { useDumpStore } from '../../utils/dump-store';
+
 type FlightSection = {
   key: 'departure' | 'return';
   label: string;
@@ -20,38 +22,63 @@ const sections: FlightSection[] = [
 ];
 
 const DumpFlightInfo = () => {
+  const flightForm = useDumpStore((s) => s.flightForm);
+  const updateFlight = useDumpStore((s) => s.actions.updateFlight);
+
   return (
     <div className="flex flex-col gap-3">
-      {sections.map((section) => (
-        <div
-          key={section.key}
-          className="rounded-xl border border-gray-200 p-4"
-        >
-          <span
-            className={`inline-block rounded-md px-2 py-0.5 text-xs font-semibold mb-3 ${section.badgeClass}`}
+      {sections.map((section) => {
+        const row = flightForm[section.key];
+        return (
+          <div
+            key={section.key}
+            className="rounded-xl border border-gray-200 p-4"
           >
-            {section.label}
-          </span>
-
-          <div className="grid grid-cols-3 gap-3">
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">공항</label>
-              <Input
-                className="h-9 text-sm bg-white"
-                placeholder="예: 인천국제공항"
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">항공편</label>
-              <Input className="h-9 text-sm bg-white" placeholder="예: KE123" />
-            </div>
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">시간</label>
-              <Input className="h-9 text-sm bg-white" placeholder="예: 09:30" />
+            <span
+              className={`inline-block rounded-md px-2 py-0.5 text-xs font-semibold mb-3 ${section.badgeClass}`}
+            >
+              {section.label}
+            </span>
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">공항</label>
+                <Input
+                  className="h-9 text-sm bg-white"
+                  placeholder="예: 인천국제공항"
+                  value={row.airport}
+                  onChange={(e) =>
+                    updateFlight(section.key, 'airport', e.target.value)
+                  }
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">
+                  항공편
+                </label>
+                <Input
+                  className="h-9 text-sm bg-white"
+                  placeholder="예: KE123"
+                  value={row.flightNumber}
+                  onChange={(e) =>
+                    updateFlight(section.key, 'flightNumber', e.target.value)
+                  }
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 mb-1">시간</label>
+                <Input
+                  className="h-9 text-sm bg-white"
+                  placeholder="예: 09:30"
+                  value={row.time}
+                  onChange={(e) =>
+                    updateFlight(section.key, 'time', e.target.value)
+                  }
+                />
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/apps/frontend/src/components/dump/DumpGuideCard.tsx
+++ b/apps/frontend/src/components/dump/DumpGuideCard.tsx
@@ -2,6 +2,8 @@ import { ChevronDown, Home, Plane } from 'lucide-react';
 import { useState } from 'react';
 
 import './DumpGuideCard.css';
+import DumpFlightInfo from './DumpFlightInfo';
+import DumpHotelInfo from './DumpHotelInfo';
 
 const DumpGuideCard = () => {
   const [openFlight, setOpenFlight] = useState(false);
@@ -32,7 +34,7 @@ const DumpGuideCard = () => {
         </button>
         {openFlight && (
           <div className="dump-guide-item__content">
-            {/* 항공편 정보 입력 영역 */}
+            <DumpFlightInfo />
           </div>
         )}
 
@@ -55,7 +57,7 @@ const DumpGuideCard = () => {
         </button>
         {openReservation && (
           <div className="dump-guide-item__content">
-            {/* 숙박 정보 입력 영역 */}
+            <DumpHotelInfo />
           </div>
         )}
       </div>

--- a/apps/frontend/src/components/dump/DumpHotelInfo.tsx
+++ b/apps/frontend/src/components/dump/DumpHotelInfo.tsx
@@ -1,0 +1,103 @@
+import { Plus, X } from 'lucide-react';
+import { useState } from 'react';
+
+import { Input } from '@/components/ui/input';
+
+type Hotel = {
+  id: string;
+  name: string;
+  location: string;
+  checkIn: string;
+  checkOut: string;
+};
+
+const createEmptyHotel = (): Hotel => ({
+  id: crypto.randomUUID(),
+  name: '',
+  location: '',
+  checkIn: '',
+  checkOut: '',
+});
+
+const DumpHotelInfo = () => {
+  const [hotels, setHotels] = useState<Hotel[]>([createEmptyHotel()]);
+
+  const handleAdd = () => {
+    setHotels((prev) => [...prev, createEmptyHotel()]);
+  };
+
+  const handleRemove = (id: string) => {
+    setHotels((prev) => prev.filter((hotel) => hotel.id !== id));
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {hotels.map((hotel, index) => (
+        <div key={hotel.id} className="rounded-xl border border-gray-200 p-4">
+          {/* 상단: 뱃지 + 삭제 버튼 */}
+          <div className="flex items-center justify-between mb-3">
+            <span className="inline-block rounded-md bg-yellow-100 px-2 py-0.5 text-xs font-semibold text-yellow-700">
+              숙소 {index + 1}
+            </span>
+            {hotels.length > 1 && (
+              <button
+                type="button"
+                onClick={() => handleRemove(hotel.id)}
+                className="flex items-center gap-0.5 text-xs text-red-500 hover:text-red-600"
+              >
+                <X size={14} />
+                삭제
+              </button>
+            )}
+          </div>
+
+          {/* 2x2 input grid */}
+          <div className="grid grid-cols-2 gap-x-3 gap-y-4">
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">숙소명</label>
+              <Input
+                className="h-9 text-sm bg-white"
+                placeholder="예: 신주쿠 프린스 호텔"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">위치</label>
+              <Input
+                className="h-9 text-sm bg-white"
+                placeholder="예: 신주쿠역 도보 5분"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">체크인</label>
+              <Input
+                className="h-9 text-sm bg-white"
+                placeholder="예: 5월 10일 15:00"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">
+                체크아웃
+              </label>
+              <Input
+                className="h-9 text-sm bg-white"
+                placeholder="예: 5월 12일 11:00"
+              />
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {/* 숙소 추가 버튼 */}
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="flex items-center justify-center gap-1 rounded-xl border border-dashed border-gray-300 py-3 text-sm text-gray-500 hover:bg-gray-50"
+      >
+        <Plus size={16} />
+        숙소 추가
+      </button>
+    </div>
+  );
+};
+
+export default DumpHotelInfo;

--- a/apps/frontend/src/components/dump/DumpHotelInfo.tsx
+++ b/apps/frontend/src/components/dump/DumpHotelInfo.tsx
@@ -1,40 +1,18 @@
 import { Plus, X } from 'lucide-react';
-import { useState } from 'react';
 
 import { Input } from '@/components/ui/input';
 
-type Hotel = {
-  id: string;
-  name: string;
-  location: string;
-  checkIn: string;
-  checkOut: string;
-};
-
-const createEmptyHotel = (): Hotel => ({
-  id: crypto.randomUUID(),
-  name: '',
-  location: '',
-  checkIn: '',
-  checkOut: '',
-});
+import { useDumpStore } from '../../utils/dump-store';
 
 const DumpHotelInfo = () => {
-  const [hotels, setHotels] = useState<Hotel[]>([createEmptyHotel()]);
-
-  const handleAdd = () => {
-    setHotels((prev) => [...prev, createEmptyHotel()]);
-  };
-
-  const handleRemove = (id: string) => {
-    setHotels((prev) => prev.filter((hotel) => hotel.id !== id));
-  };
+  const hotels = useDumpStore((s) => s.accommodations);
+  const { addAccommodation, removeAccommodation, updateAccommodation } =
+    useDumpStore((s) => s.actions);
 
   return (
     <div className="flex flex-col gap-3">
       {hotels.map((hotel, index) => (
         <div key={hotel.id} className="rounded-xl border border-gray-200 p-4">
-          {/* 상단: 뱃지 + 삭제 버튼 */}
           <div className="flex items-center justify-between mb-3">
             <span className="inline-block rounded-md bg-yellow-100 px-2 py-0.5 text-xs font-semibold text-yellow-700">
               숙소 {index + 1}
@@ -42,7 +20,7 @@ const DumpHotelInfo = () => {
             {hotels.length > 1 && (
               <button
                 type="button"
-                onClick={() => handleRemove(hotel.id)}
+                onClick={() => removeAccommodation(hotel.id)}
                 className="flex items-center gap-0.5 text-xs text-red-500 hover:text-red-600"
               >
                 <X size={14} />
@@ -51,13 +29,16 @@ const DumpHotelInfo = () => {
             )}
           </div>
 
-          {/* 2x2 input grid */}
           <div className="grid grid-cols-2 gap-x-3 gap-y-4">
             <div>
               <label className="block text-xs text-gray-500 mb-1">숙소명</label>
               <Input
                 className="h-9 text-sm bg-white"
                 placeholder="예: 신주쿠 프린스 호텔"
+                value={hotel.name}
+                onChange={(e) =>
+                  updateAccommodation(hotel.id, 'name', e.target.value)
+                }
               />
             </div>
             <div>
@@ -65,6 +46,10 @@ const DumpHotelInfo = () => {
               <Input
                 className="h-9 text-sm bg-white"
                 placeholder="예: 신주쿠역 도보 5분"
+                value={hotel.location}
+                onChange={(e) =>
+                  updateAccommodation(hotel.id, 'location', e.target.value)
+                }
               />
             </div>
             <div>
@@ -72,6 +57,10 @@ const DumpHotelInfo = () => {
               <Input
                 className="h-9 text-sm bg-white"
                 placeholder="예: 5월 10일 15:00"
+                value={hotel.checkIn}
+                onChange={(e) =>
+                  updateAccommodation(hotel.id, 'checkIn', e.target.value)
+                }
               />
             </div>
             <div>
@@ -81,16 +70,19 @@ const DumpHotelInfo = () => {
               <Input
                 className="h-9 text-sm bg-white"
                 placeholder="예: 5월 12일 11:00"
+                value={hotel.checkOut}
+                onChange={(e) =>
+                  updateAccommodation(hotel.id, 'checkOut', e.target.value)
+                }
               />
             </div>
           </div>
         </div>
       ))}
 
-      {/* 숙소 추가 버튼 */}
       <button
         type="button"
-        onClick={handleAdd}
+        onClick={addAccommodation}
         className="flex items-center justify-center gap-1 rounded-xl border border-dashed border-gray-300 py-3 text-sm text-gray-500 hover:bg-gray-50"
       >
         <Plus size={16} />

--- a/apps/frontend/src/components/dump/DumpInputGuide.tsx
+++ b/apps/frontend/src/components/dump/DumpInputGuide.tsx
@@ -1,0 +1,77 @@
+import {
+  ArrowLeftRight,
+  Calendar,
+  Clock,
+  Lightbulb,
+  MapPin,
+  Sparkles,
+  Utensils,
+  type LucideIcon,
+} from 'lucide-react';
+
+type AiInfoItem = {
+  icon: LucideIcon;
+  label: string;
+};
+
+const aiInfoItems: AiInfoItem[] = [
+  { icon: MapPin, label: '장소' },
+  { icon: Calendar, label: '일정' },
+  { icon: Clock, label: '시간' },
+  { icon: Utensils, label: '맛집' },
+  { icon: ArrowLeftRight, label: '이동' },
+];
+
+const tips: string[] = [
+  '방문하고 싶은 장소와 시간대를 자유롭게 적어주세요',
+  '꼭 가고 싶은 맛집이나 카페가 있다면 함께 적어주세요',
+  '여행 스타일이나 선호하는 분위기도 알려주시면 좋아요',
+];
+
+const DumpInputGuide = () => {
+  return (
+    <div className="flex flex-col gap-3">
+      {/* AI 정리 정보 카드 */}
+      <div className="rounded-2xl border border-gray-200 bg-white p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Sparkles size={16} className="text-gray-500" />
+          <h3 className="text-sm font-semibold text-gray-700">
+            AI가 이런 정보도 함께 정리해요
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {aiInfoItems.map(({ icon: Icon, label }) => (
+            <span
+              key={label}
+              className="inline-flex items-center gap-1 rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600"
+            >
+              <Icon size={14} className="text-gray-500" />
+              {label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* 입력 팁 카드 */}
+      <div className="rounded-2xl bg-purple-50 p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Lightbulb size={16} className="text-purple-600" />
+          <h3 className="text-sm font-semibold text-purple-700">입력 팁</h3>
+        </div>
+        <ul className="flex flex-col gap-1.5">
+          {tips.map((tip) => (
+            <li
+              key={tip}
+              className="flex items-start gap-2 text-xs text-gray-700"
+            >
+              <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-gray-500" />
+              {tip}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default DumpInputGuide;

--- a/apps/frontend/src/components/ui/input.tsx
+++ b/apps/frontend/src/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/apps/frontend/src/components/ui/input.tsx
+++ b/apps/frontend/src/components/ui/input.tsx
@@ -1,19 +1,23 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+const Input = ({
+  className,
+  type,
+  ...props
+}: React.ComponentProps<'input'>) => {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
         className
       )}
       {...props}
     />
-  )
-}
+  );
+};
 
-export { Input }
+export { Input };

--- a/apps/frontend/src/pages/DumpPage.tsx
+++ b/apps/frontend/src/pages/DumpPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import DumpForm from '../components/dump/DumpForm';
 import DumpGuideCard from '../components/dump/DumpGuideCard';
+import DumpInputGuide from '../components/dump/DumpInputGuide';
 import TripSummaryCard from '../components/grouping/TripSummaryCard';
 import Header from '../components/header/Header';
 import EmptyView from '../components/progress/EmptyView';
@@ -147,6 +148,8 @@ const DumpPage = () => {
             dumpTextCount={dumpTextCount}
             onTextChange={handleDumpTextChange}
           />
+
+          <DumpInputGuide />
         </section>
 
         <aside className="dump-sidebar">

--- a/apps/frontend/src/types/dump.ts
+++ b/apps/frontend/src/types/dump.ts
@@ -5,8 +5,8 @@ export type DumpErrorCode =
 
 export type DumpSubmitRequest = {
   dump_text: string;
-  departure_flight?: FlightInput; // 모두 optional — 백엔드도 nullable
-  return_flight?: FlightInput; // 이번엔 미전송(아래 매핑 참고)
+  departure_flight?: FlightInput;
+  return_flight?: FlightInput;
   accommodation_inputs?: AccommodationInput[];
 };
 

--- a/apps/frontend/src/types/dump.ts
+++ b/apps/frontend/src/types/dump.ts
@@ -5,6 +5,9 @@ export type DumpErrorCode =
 
 export type DumpSubmitRequest = {
   dump_text: string;
+  departure_flight?: FlightInput; // 모두 optional — 백엔드도 nullable
+  return_flight?: FlightInput; // 이번엔 미전송(아래 매핑 참고)
+  accommodation_inputs?: AccommodationInput[];
 };
 
 export type DumpSubmitResponse = {
@@ -15,4 +18,18 @@ export type DumpSubmitResponse = {
 export type ErrorResponse = {
   code: DumpErrorCode;
   message: string;
+};
+
+export type FlightInput = {
+  departure_airport?: string;
+  arrival_airport?: string;
+  flight_number?: string;
+  datetime?: string;
+};
+
+export type AccommodationInput = {
+  name?: string;
+  location?: string;
+  check_in?: string;
+  check_out?: string;
 };

--- a/apps/frontend/src/utils/dump-store.ts
+++ b/apps/frontend/src/utils/dump-store.ts
@@ -1,19 +1,54 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
+import type { FlightInput, AccommodationInput } from '../types/dump';
+
 import { DUMP_TEXT } from './constants';
 import { submitDumpText, parseDumpApiError } from './dump-api';
 
 type RequestStatus = 'idle' | 'loading' | 'success' | 'error';
 
+type FlightRow = { airport: string; flightNumber: string; time: string };
+type FlightForm = { departure: FlightRow; return: FlightRow };
+type Accommodation = {
+  id: string;
+  name: string;
+  location: string;
+  checkIn: string;
+  checkOut: string;
+};
+
+const emptyRow = (): FlightRow => ({ airport: '', flightNumber: '', time: '' });
+const emptyAccommodation = (): Accommodation => ({
+  id: crypto.randomUUID(),
+  name: '',
+  location: '',
+  checkIn: '',
+  checkOut: '',
+});
+
 type DumpStore = {
   dumpText: string;
+  flightForm: FlightForm;
+  accommodations: Accommodation[];
   requestStatus: RequestStatus;
   errorMessage: string | null;
   jobId: string | null;
 
   actions: {
     setDumpText: (text: string) => void;
+    updateFlight: (
+      section: 'departure' | 'return',
+      field: keyof FlightRow,
+      value: string
+    ) => void;
+    addAccommodation: () => void;
+    removeAccommodation: (id: string) => void;
+    updateAccommodation: (
+      id: string,
+      field: keyof Omit<Accommodation, 'id'>,
+      value: string
+    ) => void;
     resetDump: () => void;
     clearJob: () => void;
     submitDump: (tripId: string) => Promise<boolean>;
@@ -24,6 +59,8 @@ export const useDumpStore = create<DumpStore>()(
   persist(
     (set, get) => ({
       dumpText: '',
+      flightForm: { departure: emptyRow(), return: emptyRow() },
+      accommodations: [emptyAccommodation()],
       requestStatus: 'idle',
       errorMessage: null,
       jobId: null,
@@ -33,9 +70,40 @@ export const useDumpStore = create<DumpStore>()(
           set({ dumpText: text });
         },
 
+        updateFlight: (section, field, value) => {
+          set((s) => ({
+            flightForm: {
+              ...s.flightForm,
+              [section]: { ...s.flightForm[section], [field]: value },
+            },
+          }));
+        },
+
+        addAccommodation: () => {
+          set((s) => ({
+            accommodations: [...s.accommodations, emptyAccommodation()],
+          }));
+        },
+
+        removeAccommodation: (id) => {
+          set((s) => ({
+            accommodations: s.accommodations.filter((a) => a.id !== id),
+          }));
+        },
+
+        updateAccommodation: (id, field, value) => {
+          set((s) => ({
+            accommodations: s.accommodations.map((a) =>
+              a.id === id ? { ...a, [field]: value } : a
+            ),
+          }));
+        },
+
         resetDump: () => {
           set({
             dumpText: '',
+            flightForm: { departure: emptyRow(), return: emptyRow() },
+            accommodations: [emptyAccommodation()],
             requestStatus: 'idle',
             errorMessage: null,
             jobId: null,
@@ -51,7 +119,7 @@ export const useDumpStore = create<DumpStore>()(
         },
 
         submitDump: async (tripId: string) => {
-          const { dumpText, requestStatus } = get();
+          const { dumpText, flightForm, accommodations, requestStatus } = get();
 
           if (requestStatus === 'loading') {
             return false;
@@ -62,16 +130,35 @@ export const useDumpStore = create<DumpStore>()(
             errorMessage: null,
           });
 
+          const trim = (v: string) => v.trim();
+
+          const flight: FlightInput = {
+            departure_airport: trim(flightForm.departure.airport) || undefined,
+            arrival_airport: trim(flightForm.return.airport) || undefined, //귀국 공항
+            flight_number: trim(flightForm.departure.flightNumber) || undefined,
+            datetime: trim(flightForm.departure.time) || undefined,
+          };
+          // 4칸 다 비었으면 통째로 생략
+          const departure_flight = Object.values(flight).some(Boolean)
+            ? flight
+            : undefined;
+
+          const accommodation_inputs: AccommodationInput[] = accommodations
+            .map((a) => ({
+              name: trim(a.name) || undefined,
+              location: trim(a.location) || undefined,
+              check_in: trim(a.checkIn) || undefined, // camel → snake
+              check_out: trim(a.checkOut) || undefined,
+            }))
+            .filter((a) => Object.values(a).some(Boolean));
+
           try {
             const response = await submitDumpText(tripId, {
               dump_text: dumpText,
+              ...(departure_flight && { departure_flight }),
+              ...(accommodation_inputs.length && { accommodation_inputs }),
             });
-
-            set({
-              requestStatus: 'success',
-              jobId: response.job_id,
-            });
-
+            set({ requestStatus: 'success', jobId: response.job_id });
             return true;
           } catch (error) {
             set({
@@ -80,7 +167,6 @@ export const useDumpStore = create<DumpStore>()(
                 parseDumpApiError(error)?.message ??
                 '서버 통신 오류가 발생했습니다.',
             });
-
             return false;
           }
         },
@@ -92,6 +178,8 @@ export const useDumpStore = create<DumpStore>()(
       partialize: (state) => ({
         dumpText:
           state.dumpText.length >= DUMP_TEXT.MIN_LENGTH ? state.dumpText : '',
+        flightForm: state.flightForm,
+        accommodations: state.accommodations,
       }),
     }
   )


### PR DESCRIPTION
## 📝 작업 내용

- 덤프 페이지의 보조정보(항공편/숙박) 입력값이 화면에만 머물고 백엔드로 전송되지 않던 문제를 해결
- 항공/숙박 입력 상태를 dump-store(zustand)로 끌어올려 제어 컴포넌트화 → 토글 닫기/새로고침 시에도 값 유지
- 제출 시 빈 값 제거 + camelCase→snake_case 매핑 후 `departure_flight` / `accommodation_inputs` 전송 (빈 항목은 키 자체 생략)
- 항공편은 현재 UI 제약(섹션당 공항 1칸)으로 출발/귀국 행을 `departure_flight` 1개로 합쳐 전송 (공항1→출발공항, 공항2→도착공항)
- 숙소 추가/삭제 식별용 `id`는 프론트에서 `crypto.randomUUID()`로 생성하는 클라이언트 전용 값으로, 제출 payload에는 포함하지 않음 (백엔드 `AccommodationInput`에 id 필드 없음)


## 🔗 관련 이슈

closes #160 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- 매핑 로직은 `dump-store.ts`의 `submitDump` 한 곳에 모았습니다.

- 숙소 `id`는 React 리스트 key + 추가/삭제 관리용 **클라이언트 전용 값**입니다. `submitDump`에서 매핑할 때 `id`를 빼고 `name/location/check_in/check_out`만 전송합니다.

- **알려진 한계(후속 작업)**: 백엔드는 `return_flight` + 편당 공항 2개(출발/도착)까지 받을 준비가 돼 있으나, 현재 UI가 섹션당 공항 1칸이라 **귀국편(return_flight)은 미전송**입니다. 정식 분리는 항공 UI 개편이 필요해서 백엔드 부분 api 필드 요청드립니다.
- 부수: `datetime` 필드인데 placeholder가 시각만(`09:30`)이라 날짜 미포함 → 추후 `5월 10일 09:30` 날짜 선택할 수 있도록 개선 예정.

## 📸 스크린샷

<img width="628" height="729" alt="image" src="https://github.com/user-attachments/assets/bc7b8603-a259-40de-9f7f-80c1b17b7543" />