### PR TITLE
Fix: 파싱 폴링 타임아웃 60초→120초 상향

### DIFF
--- a/apps/frontend/src/hooks/useParseJobStatus.ts
+++ b/apps/frontend/src/hooks/useParseJobStatus.ts
@@ -8,7 +8,7 @@ import {
 import { fetchParseJobStatus } from '../utils/progress-api';
 
 const POLLING_INTERVAL_MS = 1500;
-const POLLING_TIMEOUT_MS = 60_000;
+const POLLING_TIMEOUT_MS = 120_000;
 const MAX_CONSECUTIVE_ERRORS = 3;
 
 // jobId === null 이면 폴링을 멈추고 idle 로 돌아간다. (clearJob() 호출 시 동작)


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 파싱 폴링 타임아웃이 60초로 백엔드 AI 응답 타임아웃(90초)보다 짧아, 정상 처리 중에도 조기 `parse-error`로 빠지던 문제를 수정 (60초 → 120초)

## 🔗 관련 이슈

closes #178 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- `useParseJobStatus.ts`의 `POLLING_TIMEOUT_MS` 상수 한 줄 변경 (60_000 → 120_000)

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.