### PR TITLE
fix(be): 좌표 없는 confirmed 카드를 입력 필요로 강등

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -309,6 +309,8 @@ public class PlaceCard {
                 ? normalizeFlightDatetime(dto.flightDatetime())
                 : this.flightDatetime;
         this.flightRole = dto.flightRole() != null ? normalizeFlightRole(dto.flightRole()) : this.flightRole;
+
+        demoteWhenCoordinatesMissing();
     }
 
     public boolean isConfirmedParseResult(AiPlaceCardDto dto) {
@@ -347,6 +349,26 @@ public class PlaceCard {
 
     private void recomputeActionType() {
         this.actionType = computeActionType(this.classification, this.placementStatus);
+    }
+
+    /**
+     * AI 파싱 결과에 좌표가 없으면 사용자가 직접 풀 수 있도록 입력 필요 상태로 강등한다.
+     * confirmed 카드만 대상이며(질문/blocked 카드는 보존), transport(항공편 등)는 좌표가 없어도 정상이라 면제한다.
+     * 강등 후 undecided + needs_input 이 되어 notes 재파싱(self-heal) 경로가 열린다.
+     */
+    private void demoteWhenCoordinatesMissing() {
+        if (!"confirmed".equals(this.classification)) {
+            return;
+        }
+        if ("transport".equals(this.category)) {
+            return;
+        }
+        if (this.lat != null && this.lng != null) {
+            return;
+        }
+        this.classification = "undecided";
+        this.placementStatus = "needs_input";
+        recomputeActionType();
     }
 
     public static PlaceCard createFromAiResponse(UUID tripId, AiPlaceCardDto dto, String source) {
@@ -388,6 +410,8 @@ public class PlaceCard {
         card.flightDatetime = normalizeFlightDatetime(dto.flightDatetime());
         card.flightRole = normalizeFlightRole(dto.flightRole());
         card.searchAlias = trimToNull(dto.searchAlias());
+
+        card.demoteWhenCoordinatesMissing();
         return card;
     }
 

--- a/apps/backend/src/test/java/com/tripkey/domain/place/CardInputParsingProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/CardInputParsingProcessorTest.java
@@ -68,7 +68,7 @@ class CardInputParsingProcessorTest {
     }
 
     @Test
-    void parseAndEnrichMarksConfirmedCardFailedWhenPlaceLookupMisses() {
+    void parseAndEnrichDemotesToInputRequiredWhenPlaceLookupMisses() {
         UUID tripId = UUID.randomUUID();
         UUID instanceId = UUID.randomUUID();
         Trip trip = new Trip((short) 3, (short) 2);
@@ -81,13 +81,16 @@ class CardInputParsingProcessorTest {
 
         processor.parseAndEnrich(tripId, instanceId, "도톤보리 글리코 사인으로 가자");
 
-        assertThat(card.getClassification()).isEqualTo("confirmed");
-        assertThat(card.getPlacementStatus()).isEqualTo("ready_partial");
+        // 좌표 없이 confirmed 로 돌아오면 입력 필요로 강등해 재파싱(self-heal) 경로를 다시 연다.
+        assertThat(card.getClassification()).isEqualTo("undecided");
+        assertThat(card.getPlacementStatus()).isEqualTo("needs_input");
+        assertThat(card.getActionType()).isEqualTo("input_required");
         assertThat(card.getProcessingStatus()).isEqualTo("failed");
         assertThat(card.getPlaceId()).isNull();
         assertThat(card.getLat()).isNull();
         assertThat(card.getLng()).isNull();
         assertThat(card.getAddress()).isNull();
+        assertThat(card.canStartNaturalLanguageParsingFromNotes()).isTrue();
         verify(placeCardRepository).save(card);
     }
 

--- a/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/PlaceCardTest.java
@@ -22,7 +22,7 @@ class PlaceCardTest {
                 false,
                 false,
                 (short) 90,
-                null,
+                new AiPlaceCardDto.Coordinates(34.6687, 135.5031),
                 "오사카 중앙구",
                 null,
                 null,
@@ -342,6 +342,116 @@ class PlaceCardTest {
         card.markProcessing();
         card.markFailed();
         assertThat(card.getProcessingStatus()).isEqualTo("failed");
+    }
+
+    @Test
+    void createFromAiResponseDemotesConfirmedWithoutCoordinates() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                "place-1", "모호한 장소", "food", "confirmed", "ready_partial",
+                false, false, (short) 90, null, "오사카",
+                null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
+
+        assertThat(card.getClassification()).isEqualTo("undecided");
+        assertThat(card.getPlacementStatus()).isEqualTo("needs_input");
+        assertThat(card.getActionType()).isEqualTo("input_required");
+    }
+
+    @Test
+    void createFromAiResponseKeepsConfirmedWhenCoordinatesPresent() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                "place-1", "도톤보리", "food", "confirmed", "ready_partial",
+                false, false, (short) 90,
+                new AiPlaceCardDto.Coordinates(34.6687, 135.5031), "오사카",
+                null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
+
+        assertThat(card.getClassification()).isEqualTo("confirmed");
+        assertThat(card.getPlacementStatus()).isEqualTo("ready_partial");
+        assertThat(card.getActionType()).isEqualTo("review_only");
+        assertThat(card.getLat()).isEqualTo(34.6687);
+        assertThat(card.getLng()).isEqualTo(135.5031);
+    }
+
+    @Test
+    void createFromAiResponseExemptsTransportWithoutCoordinates() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                null, "김포-오사카 항공편", "transport", "confirmed", "ready",
+                false, true, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
+
+        assertThat(card.getClassification()).isEqualTo("confirmed");
+        assertThat(card.getActionType()).isEqualTo("review_only");
+    }
+
+    @Test
+    void createFromAiResponseDoesNotDemoteOpenQuestionWithoutCoordinates() {
+        AiPlaceCardDto dto = new AiPlaceCardDto(
+                null, "오사카 어디?", "place", "open_question", "ready_partial",
+                false, false, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        PlaceCard card = PlaceCard.createFromAiResponse(UUID.randomUUID(), dto, "ai_parse");
+
+        assertThat(card.getClassification()).isEqualTo("open_question");
+    }
+
+    @Test
+    void applyCardLevelParseResultDemotesWhenCoordinatesMissing() {
+        PlaceCard card = sampleCard();
+        AiPlaceCardDto parsed = new AiPlaceCardDto(
+                "place-1", "모호한 장소", "food", "confirmed", "ready_partial",
+                false, false, (short) 90, null, "오사카",
+                null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        card.applyCardLevelParseResult(parsed);
+
+        assertThat(card.getClassification()).isEqualTo("undecided");
+        assertThat(card.getPlacementStatus()).isEqualTo("needs_input");
+        assertThat(card.getActionType()).isEqualTo("input_required");
+    }
+
+    @Test
+    void applyCardLevelParseResultKeepsConfirmedWhenCoordinatesPresent() {
+        PlaceCard card = sampleCard();
+        AiPlaceCardDto parsed = new AiPlaceCardDto(
+                "place-1", "도톤보리", "food", "confirmed", "ready_partial",
+                false, false, (short) 90,
+                new AiPlaceCardDto.Coordinates(34.6687, 135.5031), "오사카",
+                null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        card.applyCardLevelParseResult(parsed);
+
+        assertThat(card.getClassification()).isEqualTo("confirmed");
+        assertThat(card.getPlacementStatus()).isEqualTo("ready_partial");
+        assertThat(card.getProcessingStatus()).isEqualTo("completed");
+        assertThat(card.getLat()).isEqualTo(34.6687);
+        assertThat(card.getLng()).isEqualTo(135.5031);
+    }
+
+    @Test
+    void applyCardLevelParseResultExemptsTransport() {
+        PlaceCard card = sampleCard();
+        AiPlaceCardDto parsed = new AiPlaceCardDto(
+                null, "김포-오사카 항공편", "transport", "confirmed", "ready",
+                false, true, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        card.applyCardLevelParseResult(parsed);
+
+        assertThat(card.getClassification()).isEqualTo("confirmed");
+        assertThat(card.getActionType()).isEqualTo("review_only");
     }
 
     private static PlaceCard sampleCard() {


### PR DESCRIPTION
## 📝 작업 내용

> SCR-04에서 좌표(lat/lng) 없는 `confirmed` 카드가 배치 불가로 고착돼 사용자가 스스로 풀 수 없던 막다른 상태 해소

- AI 파싱 결과에 `coordinates`가 없으면 `confirmed` 카드를 `undecided`/`needs_input`(`action_type=input_required`)로 강등 (제안 B).
- 적용 위치: `PlaceCard.createFromAiResponse`(dump 초기 파싱), `PlaceCard.applyCardLevelParseResult`(notes 재파싱) — 좌표 세팅 직후 강등 + action_type 재계산.
- 좌표 없이 재파싱이 또 돌아와도 `needs_input` 유지 → notes 재파싱(self-heal) 루프 복구.
- **미변경**: `transport`(항공편 등 좌표 없이 정상)·`open_question`/`unassigned`·좌표 있는 카드, `GroupService.getGroups04` unavailable 분기, enum/DTO.

## 🔗 관련 이슈

closes #180

<!-- 이슈 생성 후 번호 기입. 드래프트: docs/ISSUE_input-required-missing-coords.md -->

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? — 단위/통합 테스트 그린 (백엔드 `./gradlew test` 163개 통과). **실서버 수동 E2E는 미실시**(로직은 단위 테스트로 커버).
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — 백엔드 전체 163개 통과. 좌표 있는 카드 / `open_question` / `transport` 미변경 가드 테스트 포함.
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? — `PlaceCard` 강등 규칙 + 테스트만.

## 👀 리뷰어에게

> - **강등 스코프**: `PlaceCard.demoteWhenCoordinatesMissing()` — `confirmed` + 비-`transport` + 좌표 null 일 때만 강등. `open_question`/`unassigned`는 분류 보존(스코프 가드 테스트 있음).
> - **transport 면제는 제품 결정**: 항공편은 좌표 없이 `confirmed`가 정상이라 "입력 필요" 강등에서 제외. FE 원 요청은 카테고리 무관이었으나 합의로 제외 — 항공편 처리 기대치가 다르면 알려주세요.
> - **self-heal 경로**: `applyCardLevelParseResult`에서 재파싱이 좌표 없이 `confirmed`로 와도 `needs_input` 유지 → `canStartNaturalLanguageParsingFromNotes` 충족 → 재시도 가능. (`CardInputParsingProcessorTest` 갱신으로 검증)
> - **의도적 미변경**: `getGroups04`의 unavailable 분기는 그대로 — 좌표가 생기면 자연히 available 로 이동.
> - **제안 A 미구현**: `addCard`/구조화 수정 시 지오코딩 트리거는 범위에서 제외(B 우선).

### 변경 파일

| 파일 | 변경 |
|---|---|
| `apps/backend/.../place/PlaceCard.java` | `demoteWhenCoordinatesMissing()` 헬퍼 + 호출 2곳 (+24) |
| `apps/backend/.../place/PlaceCardTest.java` | 신규 테스트 7 + 기존 좌표 보정 |
| `apps/backend/.../place/CardInputParsingProcessorTest.java` | 재파싱 좌표 미스 케이스 → 강등 동작으로 갱신 |

- 커밋: `2e2f876` `fix(be): 좌표 없는 confirmed 카드를 입력 필요로 강등`


## 📸 스크린샷

없음 (백엔드 로직 변경)

---
