### PR TITLE
Refactor: 여행지 입력 포커스 시 추천 도시 목록 노출

### DIFF
--- a/apps/frontend/src/components/onboarding/DestinationDropdown.css
+++ b/apps/frontend/src/components/onboarding/DestinationDropdown.css
@@ -11,6 +11,8 @@
   border-radius: 8px;
   background: white;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  max-height: 220px;
+  overflow-y: auto;
 }
 
 .destination-dropdown li {

--- a/apps/frontend/src/components/onboarding/DestinationDropdown.tsx
+++ b/apps/frontend/src/components/onboarding/DestinationDropdown.tsx
@@ -2,6 +2,7 @@ import './DestinationDropdown.css';
 
 import { useState, useEffect } from 'react';
 
+import { RECOMMENDED_DESTINATIONS } from '../../dev-fixtures/allowed-destinations';
 import type { Destination } from '../../types/onboarding';
 import { searchDestinations } from '../../utils/onboarding-api';
 import { useOnboardingStore } from '../../utils/onboarding-store';
@@ -10,6 +11,7 @@ const DestinationDropdown = ({ placeholder }: { placeholder?: string }) => {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Destination[]>([]);
   const [showHint, setShowHint] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
 
   const setForm = useOnboardingStore((s) => s.actions.setForm);
   const destinations = useOnboardingStore((s) => s.form.destinations);
@@ -42,6 +44,7 @@ const DestinationDropdown = ({ placeholder }: { placeholder?: string }) => {
   const handleBlur = () => {
     // 드롭다운 항목 클릭 시 onMouseDown preventDefault 로 blur가 미뤄지므로,
     // 여기까지 도달했다는 건 사용자가 선택 없이 input 밖을 눌렀다는 뜻.
+    setIsFocused(false);
     if (query.trim().length > 0 && destinations.length === 0) {
       setShowHint(true);
     }
@@ -60,13 +63,13 @@ const DestinationDropdown = ({ placeholder }: { placeholder?: string }) => {
         value={query}
         onChange={(e) => handleChange(e.target.value)}
         onBlur={handleBlur}
+        onFocus={() => setIsFocused(true)}
       />
-      {results.length > 0 && (
+      {results.length > 0 ? (
         <ul className="destination-dropdown">
           {results.map((item) => (
             <li
               key={item.place_id}
-              // input blur보다 클릭이 먼저 처리되도록 mousedown 기본 동작 차단
               onMouseDown={(e) => e.preventDefault()}
               onClick={() => handleSelect(item)}
             >
@@ -77,6 +80,33 @@ const DestinationDropdown = ({ placeholder }: { placeholder?: string }) => {
             </li>
           ))}
         </ul>
+      ) : (
+        isFocused &&
+        query.trim().length === 0 && (
+          <ul className="destination-dropdown">
+            {RECOMMENDED_DESTINATIONS.filter(
+              (c) => !destinations.includes(c.name)
+            ) // 이미 선택한 건 제외
+              .map((c) => (
+                <li
+                  key={c.name}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() =>
+                    handleSelect({
+                      name: c.name,
+                      country: c.country,
+                      place_id: c.name,
+                    })
+                  }
+                >
+                  <span>{c.name}</span>
+                  <span className="destination-dropdown__country">
+                    {c.country}
+                  </span>
+                </li>
+              ))}
+          </ul>
+        )
       )}
       {showHint && (
         <p className="destination-dropdown__hint" role="status">

--- a/apps/frontend/src/components/onboarding/DestinationInput.css
+++ b/apps/frontend/src/components/onboarding/DestinationInput.css
@@ -3,6 +3,7 @@
 }
 
 .destination-input__box {
+  position: relative;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;

--- a/apps/frontend/src/components/onboarding/DestinationInput.tsx
+++ b/apps/frontend/src/components/onboarding/DestinationInput.tsx
@@ -1,6 +1,6 @@
 import './DestinationInput.css';
 
-import { DEV_ALLOWED_DESTINATIONS } from '../../dev-fixtures/allowed-destinations';
+import { RECOMMENDED_DESTINATIONS } from '../../dev-fixtures/allowed-destinations';
 import { useOnboardingStore } from '../../utils/onboarding-store';
 
 import DestinationDropdown from './DestinationDropdown';
@@ -32,7 +32,7 @@ const DestinationInput = ({ placeholder }: { placeholder?: string }) => {
           <span className="destination-input__dev-badge">개발용 임시</span>
           <span className="destination-input__dev-text">
             백엔드 등록 도시(한글 완전일치만 검색됨):{' '}
-            {DEV_ALLOWED_DESTINATIONS.join(' · ')}
+            {RECOMMENDED_DESTINATIONS.map((d) => d.name).join(' · ')}
           </span>
         </aside>
       )}

--- a/apps/frontend/src/components/onboarding/DestinationInput.tsx
+++ b/apps/frontend/src/components/onboarding/DestinationInput.tsx
@@ -29,9 +29,9 @@ const DestinationInput = ({ placeholder }: { placeholder?: string }) => {
 
       {import.meta.env.MODE === 'development' && (
         <aside className="destination-input__dev-notice" role="note">
-          <span className="destination-input__dev-badge">개발용 임시</span>
+          <span className="destination-input__dev-badge">등록 도시</span>
           <span className="destination-input__dev-text">
-            백엔드 등록 도시(한글 완전일치만 검색됨):{' '}
+            (한글 완전일치만 검색됨):{' '}
             {RECOMMENDED_DESTINATIONS.map((d) => d.name).join(' · ')}
           </span>
         </aside>

--- a/apps/frontend/src/dev-fixtures/allowed-destinations.ts
+++ b/apps/frontend/src/dev-fixtures/allowed-destinations.ts
@@ -3,17 +3,17 @@
 // 검색 가능한지 사용자(개발 단계)에게 안내하기 위해 프론트가 임시로 들고 있는
 // 목록이다. 정공법은 백엔드에 `/cities?available=true` 같은 엔드포인트를 만들어
 // 받아오는 것 — 백엔드 작업이 완료되면 이 파일은 삭제하고 fetch 로 교체한다.
-export const DEV_ALLOWED_DESTINATIONS = [
-  '오사카',
-  '도쿄',
-  '교토',
-  '후쿠오카',
-  '방콕',
-  '하노이',
-  '다낭',
-  '싱가포르',
-  '타이베이',
-  '파리',
-  '런던',
-  '뉴욕',
+export const RECOMMENDED_DESTINATIONS = [
+  { name: '오사카', country: '일본' },
+  { name: '도쿄', country: '일본' },
+  { name: '교토', country: '일본' },
+  { name: '후쿠오카', country: '일본' },
+  { name: '방콕', country: '태국' },
+  { name: '하노이', country: '베트남' },
+  { name: '다낭', country: '베트남' },
+  { name: '싱가포르', country: '싱가포르' },
+  { name: '타이베이', country: '대만' },
+  { name: '파리', country: '프랑스' },
+  { name: '런던', country: '영국' },
+  { name: '뉴욕', country: '미국' },
 ] as const;


### PR DESCRIPTION
## 📝 작업 내용

> 온보딩 여행지 입력칸을 포커스하면 추천 도시 목록이 뜨도록 추가하고, 안내 문구·드롭다운 위치를 정리

- 백엔드 서버 연결 오류 시 동작하지 않던 여행지 input을, 프론트엔드 추천 도시 목록으로 보완해 입력 가능하도록 수정하였고 입력 완료 후 요약카드에서 에러메시지 표시 가능하도록 함.

- 입력칸 포커스 시 추천 도시 목록을 드롭다운으로 노출 사용자가 어색함이 없도록 UI 수정.

- 추천 목록이 개발용 안내 문구를 덮도록 드롭다운 위치 기준 정리 및 문구 수정.

## 🔗 관련 이슈

closes #161 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.
없음.

## 📸 스크린샷

> <img width="631" height="334" alt="image" src="https://github.com/user-attachments/assets/011b2ab1-046f-4a1b-8fbc-4afbad8dcd29" />