### PR TITLE
feat(be)/187/확정 응답 route_legs 노출 + 캐시 전용 조회 GET

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmService.java
@@ -49,7 +49,8 @@ public class ConfirmService {
         return PlacementSaveResponse.of(
                 tripId,
                 verifyResponse.skippedInstanceIds(),
-                verifyResponse.routeWarnings()
+                verifyResponse.routeWarnings(),
+                verifyResponse.routeLegs()
         );
     }
 

--- a/apps/backend/src/main/java/com/tripkey/domain/route/RouteController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/route/RouteController.java
@@ -1,0 +1,24 @@
+package com.tripkey.domain.route;
+
+import com.tripkey.dto.placement.RouteLegsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/trips/{tripId}/route-legs")
+@RequiredArgsConstructor
+public class RouteController {
+
+    private final RouteService routeService;
+
+    @GetMapping
+    public ResponseEntity<RouteLegsResponse> getRouteLegs(@PathVariable UUID tripId) {
+        return ResponseEntity.ok(new RouteLegsResponse(routeService.readCachedLegs(tripId)));
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/route/RouteService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/route/RouteService.java
@@ -1,13 +1,16 @@
 package com.tripkey.domain.route;
 
+import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.placement.RouteLeg;
 import com.tripkey.infra.aiengine.AiEngineClient;
 import com.tripkey.infra.aiengine.dto.AiRouteRequest;
 import com.tripkey.infra.aiengine.dto.AiRouteResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -25,6 +28,7 @@ public class RouteService {
     private final PlaceCardRepository placeCardRepository;
     private final RouteLegCacheRepository routeLegCacheRepository;
     private final AiEngineClient aiEngineClient;
+    private final TripRepository tripRepository;
 
     private static final double COORD_PRECISION = 100_000.0; // 좌표 5자리(약 1m) 반올림
 
@@ -46,6 +50,39 @@ public class RouteService {
                 deduped.putIfAbsent(coordKey, row);
             }
             routeLegCacheRepository.saveAll(deduped.values());
+        }
+        return result;
+    }
+
+    /**
+     * 현재 배치(day/day_order) 기준 인접 카드쌍을 route_legs_cache 에서만 조회해 복원한다.
+     * computeLegs 와 달리 cache miss 시 AI 를 호출하지 않고(매 조회 비용 회피) 해당 구간을 생략하며,
+     * 캐시에 쓰지 않는 순수 읽기 전용이다. 확정 화면 재진입/새로고침에서 이동시간 복원에 사용한다.
+     */
+    @Transactional(readOnly = true)
+    public List<RouteLeg> readCachedLegs(UUID tripId) {
+        if (!tripRepository.existsById(tripId)) {
+            throw new TripNotFoundException(tripId);
+        }
+        Map<Integer, List<PlaceCard>> byDay = groupByDay(tripId);
+        List<RouteLeg> result = new ArrayList<>();
+        for (Map.Entry<Integer, List<PlaceCard>> entry : byDay.entrySet()) {
+            int day = entry.getKey();
+            List<PlaceCard> cards = entry.getValue();
+            for (int i = 0; i + 1 < cards.size(); i++) {
+                PlaceCard from = cards.get(i);
+                PlaceCard to = cards.get(i + 1);
+                Optional<RouteLegCache> cached = routeLegCacheRepository
+                        .findByOriginLatAndOriginLngAndDestLatAndDestLng(
+                                round(from.getLat()), round(from.getLng()),
+                                round(to.getLat()), round(to.getLng()));
+                if (cached.isPresent()) {
+                    RouteLegCache c = cached.get();
+                    result.add(new RouteLeg(day, from.getInstanceId(), to.getInstanceId(),
+                            c.getDurationSeconds(), c.getDistanceMeters(), c.getMode(), c.getSource()));
+                }
+                // cache miss → 생략 (AI 미호출, 캐시 미기록)
+            }
         }
         return result;
     }

--- a/apps/backend/src/main/java/com/tripkey/dto/placement/RouteLegsResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/placement/RouteLegsResponse.java
@@ -1,0 +1,8 @@
+package com.tripkey.dto.placement;
+
+import java.util.List;
+
+public record RouteLegsResponse(
+        List<RouteLeg> routeLegs
+) {
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmServiceTest.java
@@ -12,6 +12,7 @@ import com.tripkey.dto.placement.PlacementDay;
 import com.tripkey.dto.placement.PlacementDayItem;
 import com.tripkey.dto.placement.PlacementSaveRequest;
 import com.tripkey.dto.placement.PlacementSaveResponse;
+import com.tripkey.dto.placement.RouteLeg;
 import com.tripkey.dto.placement.RouteWarning;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -218,6 +219,33 @@ class ConfirmServiceTest {
 
         assertThat(response.skippedInstanceIds()).containsExactly(stale);
         assertThat(response.routeWarnings()).containsExactly(warning);
+    }
+
+    @Test
+    void confirmAndSavePassesThroughVerifyServiceRouteLegs() {
+        UUID tripId = UUID.randomUUID();
+        Trip trip = new Trip((short) 3, (short) 2);
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
+
+        PlaceCard card = placeCard(tripId);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(card));
+
+        RouteLeg leg = new RouteLeg(
+                1, UUID.randomUUID(), UUID.randomUUID(), 2880, 5400, "transit", "google"
+        );
+        when(verifyService.verifyAndSave(eq(tripId), any())).thenReturn(
+                PlacementSaveResponse.of(tripId, List.of(), List.of(), List.of(leg))
+        );
+
+        PlacementSaveRequest request = new PlacementSaveRequest(List.of(
+                new PlacementDay(1, List.of(
+                        new PlacementDayItem(card.getInstanceId(), 1, null)
+                ))
+        ));
+
+        PlacementSaveResponse response = confirmService.confirmAndSave(tripId, request);
+
+        assertThat(response.routeLegs()).containsExactly(leg);
     }
 
     private PlaceCard placeCard(UUID tripId) {

--- a/apps/backend/src/test/java/com/tripkey/domain/route/RouteControllerTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/route/RouteControllerTest.java
@@ -1,0 +1,41 @@
+package com.tripkey.domain.route;
+
+import com.tripkey.dto.placement.RouteLeg;
+import com.tripkey.dto.placement.RouteLegsResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class RouteControllerTest {
+
+    @Mock
+    private RouteService routeService;
+
+    @InjectMocks
+    private RouteController routeController;
+
+    @Test
+    void getRouteLegsReturns200WithWrappedCachedLegs() {
+        UUID tripId = UUID.randomUUID();
+        RouteLeg leg = new RouteLeg(
+                1, UUID.randomUUID(), UUID.randomUUID(), 900, 3000, "walking", "google");
+        lenient().when(routeService.readCachedLegs(tripId)).thenReturn(List.of(leg));
+
+        ResponseEntity<RouteLegsResponse> response = routeController.getRouteLegs(tripId);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().routeLegs()).containsExactly(leg);
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/route/RouteServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/route/RouteServiceTest.java
@@ -1,7 +1,9 @@
 package com.tripkey.domain.route;
 
+import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.placement.RouteLeg;
 import com.tripkey.infra.aiengine.AiEngineClient;
 import com.tripkey.infra.aiengine.dto.AiRouteRequest;
@@ -21,8 +23,10 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +37,7 @@ class RouteServiceTest {
     @Mock PlaceCardRepository placeCardRepository;
     @Mock RouteLegCacheRepository routeLegCacheRepository;
     @Mock AiEngineClient aiEngineClient;
+    @Mock TripRepository tripRepository;
 
     @InjectMocks RouteService routeService;
 
@@ -213,6 +218,57 @@ class RouteServiceTest {
         List<RouteLeg> legs = routeService.computeLegs(tripId);
 
         assertThat(legs).isEmpty();
+        verify(aiEngineClient, never()).route(any());
+    }
+
+    @Test
+    void readCachedLegsReturnsCachedLegsWithoutCallingAi() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        lenient().when(tripRepository.existsById(tripId)).thenReturn(true);
+        lenient().when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(
+                card(a, 1, 1, 34.70, 135.50),
+                card(b, 1, 2, 34.67, 135.49)
+        ));
+        lenient().when(routeLegCacheRepository.findByOriginLatAndOriginLngAndDestLatAndDestLng(
+                anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(Optional.of(
+                RouteLegCache.of(34.70, 135.50, 34.67, 135.49, 900, 3000, "walking", "google")));
+
+        List<RouteLeg> legs = routeService.readCachedLegs(tripId);
+
+        assertThat(legs).hasSize(1);
+        assertThat(legs.get(0).day()).isEqualTo(1);
+        assertThat(legs.get(0).durationSeconds()).isEqualTo(900);
+        assertThat(legs.get(0).mode()).isEqualTo("walking");
+        verify(aiEngineClient, never()).route(any());
+        verify(routeLegCacheRepository, never()).saveAll(any());
+    }
+
+    @Test
+    void readCachedLegsSkipsCacheMissesWithoutCallingAi() {
+        UUID tripId = UUID.randomUUID();
+        lenient().when(tripRepository.existsById(tripId)).thenReturn(true);
+        lenient().when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(
+                card(UUID.randomUUID(), 1, 1, 34.70, 135.50),
+                card(UUID.randomUUID(), 1, 2, 34.67, 135.49)
+        ));
+        lenient().when(routeLegCacheRepository.findByOriginLatAndOriginLngAndDestLatAndDestLng(
+                anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(Optional.empty());
+
+        List<RouteLeg> legs = routeService.readCachedLegs(tripId);
+
+        assertThat(legs).isEmpty();
+        verify(aiEngineClient, never()).route(any());
+    }
+
+    @Test
+    void readCachedLegsThrowsWhenTripMissing() {
+        UUID tripId = UUID.randomUUID();
+        lenient().when(tripRepository.existsById(tripId)).thenReturn(false);
+
+        assertThatThrownBy(() -> routeService.readCachedLegs(tripId))
+                .isInstanceOf(TripNotFoundException.class);
         verify(aiEngineClient, never()).route(any());
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

> SCR-05 확정 화면의 Day별 이동시간(`DaySummary.totalMove`) 표시를 위해, 이미 계산·캐시된 `route_legs`를
> (A) `POST /confirm` 응답에 포함하고, (B) 재진입·새로고침 대응용 읽기 전용 GET으로 노출 (FE 요청 §1).

- **(A) confirm 응답에 route_legs 포함**: `ConfirmService`가 `verifyService.verifyAndSave`로 route_legs를 이미 best-effort 계산하면서 응답 생성 시 버리고 있었음(3-arg `.of()`) → 4-arg로 `verifyResponse.routeLegs()`를 노출. **추가 계산 없음**, 실패 시 `[]` 폴백 유지.
- **(B) 읽기 전용 조회 GET**: `RouteService.readCachedLegs(tripId)` — 현재 배치(`day`/`day_order`) 기준 인접 카드쌍을 `route_legs_cache`에서만 조회. `computeLegs`와 달리 **cache miss 시 AI 미호출·캐시 미기록**(매 진입 비용 회피), miss 구간은 생략. `GET /trips/{tripId}/route-legs` (`RouteController`) + `RouteLegsResponse` 래퍼 → `{ "route_legs": [...] }`. trip 미존재 시 404.
- `RouteLeg` 스키마는 verify의 것을 그대로 재사용(전역 `SNAKE_CASE` → `from_instance_id`, `duration_seconds` 등).

## 🔗 관련 이슈

closes #187

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? — TDD(RED→GREEN) + 백엔드 전체 `./gradlew test` **168개 통과**. (실서버 수동 E2E는 미실시 — 로직은 단위 테스트로 커버)
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — 전체 168개 통과. `computeLegs`/verify 동작·`RouteLeg` 스키마·캐시 테이블 미변경.
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? — §1(route_legs)만. §2~§6은 별도 이슈(#188~#192).

## 👀 리뷰어에게

> - **(A) 비용**: confirm은 이미 verify를 호출해 route_legs를 계산하고 있었음 → 버리던 값을 노출만 함(신규 호출 없음).
> - **(B) 캐시 전용**: `readCachedLegs`는 의도적으로 AI를 호출하지 않습니다(`computeLegs`와의 차이). 매 화면 진입마다 AI 비용이 들지 않도록, miss 구간은 FE가 합산 시 누락 처리.
> - `RouteService`에 `tripRepository` 의존을 추가(404 일관성, verify/group과 동일). `readCachedLegs`는 `@Transactional(readOnly=true)`.
> - 머지 시 **Squash** 권장 (develop 룰셋: 선형 히스토리 + 승인 1개 필수).

## 📸 스크린샷

없음 (백엔드 로직/엔드포인트 변경)

---

### 변경 파일

| 파일 | 변경 |
|---|---|
| `apps/backend/.../confirm/ConfirmService.java` | confirm 응답에 route_legs 포함 (A) |
| `apps/backend/.../route/RouteService.java` | `readCachedLegs()` + `tripRepository` (B) |
| `apps/backend/.../route/RouteController.java` 🆕 | `GET /trips/{tripId}/route-legs` (B) |
| `apps/backend/.../dto/placement/RouteLegsResponse.java` 🆕 | 응답 래퍼 (B) |
| `ConfirmServiceTest` / `RouteServiceTest` / `RouteControllerTest.java` 🆕 | 테스트 (신규 5) |