### PR TITLE
feat(be): #188 scope=day 알림 조회 시 합성(route_warnings → alert)

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/place/CardService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/CardService.java
@@ -8,17 +8,20 @@ import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.dump.DumpJob;
 import com.tripkey.domain.dump.DumpJobRepository;
 import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.domain.verify.RouteValidator;
 import com.tripkey.dto.card.AlertCardDto;
 import com.tripkey.dto.card.CardAddRequest;
 import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.card.CardPatchRequest;
 import com.tripkey.dto.card.CardsResponse;
+import com.tripkey.dto.placement.RouteWarning;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -32,6 +35,7 @@ public class CardService {
     private final DumpJobRepository dumpJobRepository;
     private final CardInputParsingProcessor cardInputParsingProcessor;
     private final AlertCardRepository alertCardRepository;
+    private final RouteValidator routeValidator;
 
     @Transactional(readOnly = true)
     public CardsResponse getCards(UUID tripId) {
@@ -49,9 +53,14 @@ public class CardService {
                 .map(DumpJob::getContextSummary)
                 .orElse(null);
 
-        List<AlertCardDto> alertCards = alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId).stream()
-                .map(CardService::toAlertCardDto)
-                .toList();
+        List<AlertCardDto> alertCards = new ArrayList<>(
+                alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId).stream()
+                        .map(CardService::toAlertCardDto)
+                        .toList());
+        // Day 단위 conflict(route_warnings)를 scope=day 알림으로 조회 시점에 합성한다(미저장 → 항상 현재 배치 반영).
+        routeValidator.validate(tripId).stream()
+                .map(CardService::toDayAlertDto)
+                .forEach(alertCards::add);
 
         return new CardsResponse(cards, contextSummary, alertCards);
     }
@@ -166,5 +175,24 @@ public class CardService {
                 entity.getDay() == null ? null : entity.getDay().intValue(),
                 entity.getMessage(),
                 entity.relatedInstanceUuids());
+    }
+
+    private static AlertCardDto toDayAlertDto(RouteWarning warning) {
+        return new AlertCardDto(
+                dayAlertId(warning),
+                warning.type(),
+                "route",
+                "day",
+                warning.day(),
+                warning.message(),
+                warning.instanceIds());
+    }
+
+    private static String dayAlertId(RouteWarning warning) {
+        List<UUID> ids = warning.instanceIds();
+        if ("distance".equals(warning.type()) && ids != null && ids.size() >= 2) {
+            return "route:distance:" + warning.day() + ":" + ids.get(0) + ":" + ids.get(1);
+        }
+        return "route:" + warning.type() + ":" + warning.day();
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
@@ -8,10 +8,13 @@ import com.tripkey.domain.alert.AlertCard;
 import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.dump.DumpJobRepository;
 import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.domain.verify.RouteValidator;
+import com.tripkey.dto.card.AlertCardDto;
 import com.tripkey.dto.card.CardAddRequest;
 import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.card.CardPatchRequest;
 import com.tripkey.dto.card.CardsResponse;
+import com.tripkey.dto.placement.RouteWarning;
 import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,6 +52,9 @@ class CardServiceTest {
     
     @Mock
     private AlertCardRepository alertCardRepository;
+
+    @Mock
+    private RouteValidator routeValidator;
 
     @InjectMocks
     private CardService cardService;
@@ -127,6 +134,62 @@ class CardServiceTest {
 
         assertThat(response.alertCards()).hasSize(1);
         assertThat(response.alertCards().get(0).relatedInstanceIds()).isEmpty();
+    }
+
+    @Test
+    void getCardsIncludesDayScopeAlertsFromRouteWarnings() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+        when(dumpJobRepository.findFirstByTripIdOrderByCreatedAtDesc(tripId)).thenReturn(Optional.empty());
+        when(alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId)).thenReturn(List.of());
+        lenient().when(routeValidator.validate(tripId)).thenReturn(List.of(
+                RouteWarning.distance(1, a, b, 12_000),
+                RouteWarning.duration(2, List.of(a, b), 700)
+        ));
+
+        CardsResponse response = cardService.getCards(tripId);
+
+        assertThat(response.alertCards()).hasSize(2);
+        assertThat(response.alertCards()).allMatch(ac -> "day".equals(ac.scope()));
+        assertThat(response.alertCards()).allMatch(ac -> "route".equals(ac.category()));
+
+        AlertCardDto distance = response.alertCards().stream()
+                .filter(ac -> "distance".equals(ac.type())).findFirst().orElseThrow();
+        assertThat(distance.day()).isEqualTo(1);
+        assertThat(distance.relatedInstanceIds()).containsExactly(a, b);
+        assertThat(distance.id()).isEqualTo("route:distance:1:" + a + ":" + b);
+
+        AlertCardDto duration = response.alertCards().stream()
+                .filter(ac -> "duration".equals(ac.type())).findFirst().orElseThrow();
+        assertThat(duration.day()).isEqualTo(2);
+        assertThat(duration.id()).isEqualTo("route:duration:2");
+    }
+
+    @Test
+    void getCardsMergesStoredAlertsWithDayScopeRouteAlerts() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+        when(dumpJobRepository.findFirstByTripIdOrderByCreatedAtDesc(tripId)).thenReturn(Optional.empty());
+        AlertCard tripAlert = AlertCard.fromAiResponse(
+                new AiParseResponse.AlertCard(
+                        "alert-1", "festival", "insight", "trip", null, "축제 기간입니다", List.of()),
+                tripId, UUID.randomUUID());
+        when(alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId)).thenReturn(List.of(tripAlert));
+        lenient().when(routeValidator.validate(tripId)).thenReturn(List.of(
+                RouteWarning.distance(1, a, b, 12_000)));
+
+        CardsResponse response = cardService.getCards(tripId);
+
+        assertThat(response.alertCards()).hasSize(2);
+        assertThat(response.alertCards().get(0).id()).isEqualTo("alert-1");
+        assertThat(response.alertCards().get(0).scope()).isEqualTo("trip");
+        assertThat(response.alertCards().get(1).scope()).isEqualTo("day");
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용

> SCR-05 확정 화면 Day 체크리스트(`DayChecklist`)의 서버 소스를 위해, Day 단위 conflict(거리/소요 임계 초과)를
> `scope="day"` 알림으로 `GET /cards`에 노출 (FE 요청 §2).

- `CardService.getCards`에서 `RouteValidator.validate(tripId)`의 Day 단위 `RouteWarning`(거리 >10km, Day 소요 >600분)을 `scope="day"` `AlertCardDto`로 매핑해 **저장된 alert(AI scope=trip)와 합쳐** 반환.
- **조회 시 합성(compute-on-read)** — 저장하지 않으므로 생명주기/중복/스테일 관리가 필요 없고 항상 현재 배치를 반영. DB 마이그레이션·repo·verify 변경 없음.
- 결정적 id(`route:distance:{day}:{a}:{b}` / `route:duration:{day}`), `category="route"` 마커로 AI alert와 구분. FE는 `scope`/`day`로 Day별 분기.

## 🔗 관련 이슈

closes #188

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? — TDD(RED→GREEN) + 백엔드 전체 `./gradlew test` **165개 통과**. (실서버 수동 E2E는 미실시 — 로직은 단위 테스트로 커버)
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — 전체 165개 통과. 기존 `getCards`(AI alert) 동작 유지, verify/`alert_cards` 테이블 미변경.
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? — §2만. §3~§6은 별도 이슈(#189~#192).

## 👀 리뷰어에게

> - **접근법 결정**: FE 이슈 원안은 "warning을 alert로 **저장** + 생명주기 관리"였으나, 코드 검토 결과 `GET /cards`에서 **조회 시 합성**하면 동일하게 보이면서(`scope=day` alert 노출) 생명주기/중복/스테일 문제를 통째로 제거할 수 있어 그 방향으로 구현. (관찰 동등 — FE는 `GET /cards.alert_cards`만 소비)
> - **비용**: `getCards`가 매 호출 시 `RouteValidator`(인접 거리 쿼리 1회 + 소요 합산)를 추가 수행. 가벼움.
> - **분리**: 체크 토글 영속은 FE(localStorage) 담당. 본 PR은 "무엇을 띄울지"의 서버 데이터만.
> - `RouteValidator`(domain/verify, `@Component`, readOnly)를 `CardService`에서 호출 — 순환 의존 없음.

## 📸 스크린샷

없음 (백엔드 로직 변경)

---

### 변경 파일

| 파일 | 변경 |
|---|---|
| `apps/backend/.../place/CardService.java` | day-scope alert 조회 시 합성 + 매퍼 |
| `apps/backend/.../place/CardServiceTest.java` | 신규 테스트 2(매핑/AI alert 공존) + RouteValidator mock |
