### PR TITLE
Fix: trip summary schedule companion

### DIFF
--- a/apps/frontend/src/pages/DumpPage.css
+++ b/apps/frontend/src/pages/DumpPage.css
@@ -49,6 +49,8 @@
 }
 
 .dump-page--progress {
+  display: flex;
   align-items: center;
+  justify-content: center;
   background-color: #fafafa;
 }

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -64,29 +64,29 @@ type GroupingState =
   | { phase: 'idle' }
   | { phase: 'loading' }
   | {
-      phase: 'ready';
-      groups: Groups03Response;
-      contextSummary: string | null;
-      busy: boolean;
-      errorMessage: string | null;
-    }
+    phase: 'ready';
+    groups: Groups03Response;
+    contextSummary: string | null;
+    busy: boolean;
+    errorMessage: string | null;
+  }
   | { phase: 'error'; message: string };
 
 type GroupingAction =
   | { type: 'RESET' }
   | { type: 'LOAD_START' }
   | {
-      type: 'LOAD_SUCCESS';
-      groups: Groups03Response;
-      contextSummary: string | null;
-    }
+    type: 'LOAD_SUCCESS';
+    groups: Groups03Response;
+    contextSummary: string | null;
+  }
   | { type: 'LOAD_FAIL'; message: string }
   | { type: 'BUSY_START' }
   | {
-      type: 'REFRESH_SUCCESS';
-      groups: Groups03Response;
-      contextSummary: string | null;
-    }
+    type: 'REFRESH_SUCCESS';
+    groups: Groups03Response;
+    contextSummary: string | null;
+  }
   | { type: 'UPDATE_CARD'; card: Card }
   | { type: 'BUSY_FAIL'; message: string };
 

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -28,6 +28,10 @@ import type {
 import type { Card, Groups03Response } from '@/types/grouping-api';
 
 import {
+  useCalendarStore,
+  formatDateRangeLabel,
+} from '../utils/calendar-store';
+import {
   addCard,
   fetchCards,
   fetchGroups03,
@@ -154,6 +158,11 @@ const GroupingPage = () => {
   const storeTripId = useOnboardingStore((s) => s.tripId);
   const setStoreTripId = useOnboardingStore((s) => s.actions.setTripId);
   const tripId: string | null = urlTripId ?? storeTripId;
+
+  // 여행지/일정/동행자 등 트립 메타데이터는 groups API 응답에 없으므로 온보딩/캘린더 스토어에서 채운다.
+  const destinations = useOnboardingStore((s) => s.form.destinations);
+  const companionCount = useOnboardingStore((s) => s.form.companion_count);
+  const { type: calendarType, exactDate, flexDate } = useCalendarStore();
 
   // URL의 tripId가 store와 다르면 store에 반영 (다른 페이지로 갔다 와도 일관)
   useEffect(() => {
@@ -387,7 +396,15 @@ const GroupingPage = () => {
     doneCount: 0,
   };
   const groups = viewModel?.groups ?? [];
-  const summary = viewModel?.summary ?? FALLBACK_SUMMARY;
+  const nights = exactDate?.nights ?? flexDate?.nights ?? 0;
+  const summary: TripSummaryViewModel = {
+    ...(viewModel?.summary ?? FALLBACK_SUMMARY),
+    destinations: destinations.length ? destinations : ['-'],
+    dateRange: formatDateRangeLabel(calendarType, exactDate, flexDate),
+    nights,
+    days: nights + 1,
+    travelers: companionCount,
+  };
 
   return (
     <div className="min-h-screen bg-muted">

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -64,29 +64,29 @@ type GroupingState =
   | { phase: 'idle' }
   | { phase: 'loading' }
   | {
-    phase: 'ready';
-    groups: Groups03Response;
-    contextSummary: string | null;
-    busy: boolean;
-    errorMessage: string | null;
-  }
+      phase: 'ready';
+      groups: Groups03Response;
+      contextSummary: string | null;
+      busy: boolean;
+      errorMessage: string | null;
+    }
   | { phase: 'error'; message: string };
 
 type GroupingAction =
   | { type: 'RESET' }
   | { type: 'LOAD_START' }
   | {
-    type: 'LOAD_SUCCESS';
-    groups: Groups03Response;
-    contextSummary: string | null;
-  }
+      type: 'LOAD_SUCCESS';
+      groups: Groups03Response;
+      contextSummary: string | null;
+    }
   | { type: 'LOAD_FAIL'; message: string }
   | { type: 'BUSY_START' }
   | {
-    type: 'REFRESH_SUCCESS';
-    groups: Groups03Response;
-    contextSummary: string | null;
-  }
+      type: 'REFRESH_SUCCESS';
+      groups: Groups03Response;
+      contextSummary: string | null;
+    }
   | { type: 'UPDATE_CARD'; card: Card }
   | { type: 'BUSY_FAIL'; message: string };
 


### PR DESCRIPTION
## 📝 작업 내용

- 정리(grouping) 페이지 여행 요약에 온보딩에서 입력한 여행지·일정·동행자 값이 표시되지 않던 문제를 수정
- 덤프 진행(progress) 화면이 중앙 정렬되지 않던 레이아웃을 함께 고쳤습니다.

## 🔗 관련 이슈

closes #196

## 🗂️ 변경 범위

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- 여행 요약의 일정·동행자·여행지 값은 groups API 응답에 없어서, 덤프 페이지와 동일하게 온보딩 스토어(`destinations`, `companion_count`)와 캘린더 스토어(`exactDate`/`flexDate`)에서 가져와 채우는 방식으로 맞췄습니다. 

## 📸 스크린샷