### PR TITLE
feat(be): #191 카드 scheduled_time 타임라인(고정 시작 + 이동시간 누적)

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/group/DayTimeline.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/DayTimeline.java
@@ -1,0 +1,38 @@
+package com.tripkey.domain.group;
+
+import com.tripkey.domain.place.PlaceCard;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Day 활동 카드(dayOrder 순)에 절대 시각을 배정한다.
+ * 고정 시작시각부터 카드별 소요시간 + 카드 간 이동시간(route_legs)을 누적한다.
+ * 소요시간 없음/이동시간 캐시 miss 는 0 으로 간주(best-effort).
+ */
+final class DayTimeline {
+
+    private static final DateTimeFormatter HH_MM = DateTimeFormatter.ofPattern("HH:mm");
+
+    private DayTimeline() {
+    }
+
+    static Map<UUID, String> compute(
+            List<PlaceCard> orderedCards,
+            Map<UUID, Integer> travelSecondsByFromInstance,
+            LocalTime start) {
+        Map<UUID, String> result = new LinkedHashMap<>();
+        LocalTime clock = start;
+        for (PlaceCard card : orderedCards) {
+            result.put(card.getInstanceId(), clock.format(HH_MM));
+            int durationMin = card.getEstimatedDurationMin() == null ? 0 : card.getEstimatedDurationMin();
+            int travelSec = travelSecondsByFromInstance.getOrDefault(card.getInstanceId(), 0);
+            clock = clock.plusMinutes(durationMin).plusSeconds(travelSec);
+        }
+        return result;
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/group/DayViewService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/DayViewService.java
@@ -4,17 +4,22 @@ import com.tripkey.common.exception.InvalidDayParamException;
 import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.route.RouteService;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.group.DayViewModel;
+import com.tripkey.dto.placement.RouteLeg;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +27,9 @@ public class DayViewService {
 
     private final TripRepository tripRepository;
     private final PlaceCardRepository placeCardRepository;
+    private final RouteService routeService;
+
+    private static final LocalTime DAY_START = LocalTime.of(9, 0);
 
     @Transactional(readOnly = true)
     public DayViewModel getDayViewModel(UUID tripId, int dayNumber) {
@@ -53,11 +61,22 @@ public class DayViewService {
             otherCards.add(card);
         }
 
+        // 활동 카드(항공 제외)에 고정 시작시각 기준 타임라인을 합성한다(미저장, dayOrder 기준 계산).
+        Map<UUID, Integer> travelSecondsByFrom = routeService.readCachedLegs(tripId).stream()
+                .filter(leg -> leg.day() != null && leg.day() == dayNumber)
+                .collect(Collectors.toMap(RouteLeg::fromInstanceId, RouteLeg::durationSeconds, (a, b) -> a));
+        List<PlaceCard> orderedByPlacement = otherCards.stream()
+                .sorted(Comparator.comparing(c -> c.getDayOrder() == null ? Short.MAX_VALUE : c.getDayOrder()))
+                .toList();
+        Map<UUID, String> scheduledTimes = DayTimeline.compute(orderedByPlacement, travelSecondsByFrom, DAY_START);
+
         return DayViewModel.of(
                 dayNumber,
                 startTimeCard != null ? CardDto.from(startTimeCard) : null,
                 endTimeCard != null ? CardDto.from(endTimeCard) : null,
-                otherCards.stream().map(CardDto::from).toList()
+                otherCards.stream()
+                        .map(card -> CardDto.from(card).withScheduledTime(scheduledTimes.get(card.getInstanceId())))
+                        .toList()
         );
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/dto/card/CardDto.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/card/CardDto.java
@@ -40,10 +40,19 @@ public record CardDto(
         String checkOut,
         String flightNumber,
         String flightDatetime,
-        String flightRole
+        String flightRole,
+        String scheduledTime
 ) {
 
     public record Coordinates(Double lat, Double lng) {
+    }
+
+    public CardDto withScheduledTime(String scheduledTime) {
+        return new CardDto(
+                instanceId, placeId, name, category, classification, placementStatus, processingStatus, actionType,
+                canExclude, allowDuplicate, isExcluded, isAiGenerated, estimatedDurationMin, coordinates, location,
+                address, timeConstraint, questionText, options, blockedReason, userContext, tips, tags, source, day,
+                dayOrder, notes, memo, checkIn, checkOut, flightNumber, flightDatetime, flightRole, scheduledTime);
     }
 
     public static CardDto from(PlaceCard card) {
@@ -84,7 +93,8 @@ public record CardDto(
                 card.getCheckOut(),
                 card.getFlightNumber(),
                 card.getFlightDatetime(),
-                card.getFlightRole()
+                card.getFlightRole(),
+                null
         );
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/group/DayTimelineTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/DayTimelineTest.java
@@ -1,0 +1,67 @@
+package com.tripkey.domain.group;
+
+import com.tripkey.domain.place.PlaceCard;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DayTimelineTest {
+
+    private static PlaceCard card(UUID id, Short estimatedDurationMin) {
+        try {
+            Constructor<PlaceCard> ctor = PlaceCard.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            PlaceCard c = ctor.newInstance();
+            setField(c, "instanceId", id);
+            setField(c, "estimatedDurationMin", estimatedDurationMin);
+            return c;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field f = PlaceCard.class.getDeclaredField(name);
+            f.setAccessible(true);
+            f.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void assignsStartTimeThenAccumulatesDurationAndTravel() {
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        UUID c = UUID.randomUUID();
+        List<PlaceCard> ordered = List.of(card(a, (short) 60), card(b, (short) 90), card(c, null));
+        Map<UUID, Integer> travelSeconds = Map.of(a, 1800, b, 600); // a->b 30분, b->c 10분
+
+        Map<UUID, String> times = DayTimeline.compute(ordered, travelSeconds, LocalTime.of(9, 0));
+
+        assertThat(times.get(a)).isEqualTo("09:00");
+        assertThat(times.get(b)).isEqualTo("10:30"); // 09:00 + 60분 + 30분
+        assertThat(times.get(c)).isEqualTo("12:10"); // 10:30 + 90분 + 10분
+    }
+
+    @Test
+    void treatsNullDurationAndMissingTravelAsZero() {
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        List<PlaceCard> ordered = List.of(card(a, null), card(b, (short) 30));
+        Map<UUID, Integer> travelSeconds = Map.of(); // cache miss → 이동시간 없음
+
+        Map<UUID, String> times = DayTimeline.compute(ordered, travelSeconds, LocalTime.of(9, 0));
+
+        assertThat(times.get(a)).isEqualTo("09:00");
+        assertThat(times.get(b)).isEqualTo("09:00"); // a 소요 0 + 이동 0
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/group/DayViewServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/DayViewServiceTest.java
@@ -4,9 +4,11 @@ import com.tripkey.common.exception.InvalidDayParamException;
 import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.route.RouteService;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.group.DayViewModel;
+import com.tripkey.dto.placement.RouteLeg;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,10 +19,13 @@ import java.lang.reflect.Field;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +36,9 @@ class DayViewServiceTest {
 
     @Mock
     private PlaceCardRepository placeCardRepository;
+
+    @Mock
+    private RouteService routeService;
 
     @InjectMocks
     private DayViewService dayViewService;
@@ -235,6 +243,36 @@ class DayViewServiceTest {
         assertThat(response.cards())
                 .extracting(CardDto::instanceId)
                 .containsExactly(earlier.getInstanceId(), later.getInstanceId());
+    }
+
+    @Test
+    void getDayViewModelAssignsScheduledTimesFromFixedStartWithTravel() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard first = activityCard(tripId, 1, (short) 60, at(10, 0));
+        PlaceCard second = activityCard(tripId, 2, (short) 30, at(11, 0));
+        when(placeCardRepository.findAllByTripIdAndDay(tripId, 1)).thenReturn(List.of(first, second));
+        lenient().when(routeService.readCachedLegs(tripId)).thenReturn(List.of(
+                new RouteLeg(1, first.getInstanceId(), second.getInstanceId(), 1800, 5000, "walking", "google")));
+
+        DayViewModel response = dayViewService.getDayViewModel(tripId, 1);
+
+        Map<UUID, String> times = response.cards().stream()
+                .collect(Collectors.toMap(CardDto::instanceId, CardDto::scheduledTime));
+        assertThat(times.get(first.getInstanceId())).isEqualTo("09:00");
+        assertThat(times.get(second.getInstanceId())).isEqualTo("10:30"); // 09:00 + 60분 + 30분 이동
+    }
+
+    private PlaceCard activityCard(UUID tripId, int dayOrder, Short durationMin, OffsetDateTime createdAt) {
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, "활동 카드", "place", null, durationMin, null, null, null, null, null
+        );
+        setField(card, "instanceId", UUID.randomUUID());
+        setField(card, "day", 1);
+        setField(card, "dayOrder", (short) dayOrder);
+        setField(card, "createdAt", createdAt);
+        return card;
     }
 
     private PlaceCard flightCard(UUID tripId, String flightNumber, String flightRole, int day, OffsetDateTime createdAt) {

--- a/apps/backend/src/test/java/com/tripkey/dto/card/CardDtoTest.java
+++ b/apps/backend/src/test/java/com/tripkey/dto/card/CardDtoTest.java
@@ -1,0 +1,30 @@
+package com.tripkey.dto.card;
+
+import com.tripkey.domain.place.PlaceCard;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CardDtoTest {
+
+    private static PlaceCard sampleCard() {
+        return PlaceCard.createUserCard(
+                UUID.randomUUID(), "도톤보리", "place", null, null, null, null, null, null, null);
+    }
+
+    @Test
+    void fromLeavesScheduledTimeNull() {
+        assertThat(CardDto.from(sampleCard()).scheduledTime()).isNull();
+    }
+
+    @Test
+    void withScheduledTimeReturnsCopyWithTimePreservingOtherFields() {
+        CardDto dto = CardDto.from(sampleCard()).withScheduledTime("09:00");
+
+        assertThat(dto.scheduledTime()).isEqualTo("09:00");
+        assertThat(dto.name()).isEqualTo("도톤보리");
+        assertThat(dto.category()).isEqualTo("place");
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

> SCR-05 확정 화면 카드의 절대 시각 라벨(`contextCards[].timeLabel`)을 위해, Day 활동 카드에
> `scheduled_time`을 배정해 `GET /trips/{id}/days/{n}` 응답에 노출 (FE 요청 §5).

- **`DayTimeline`**(신규 순수 유틸): dayOrder 순 카드에 **고정 시작시각(09:00)** 부터 `카드 소요시간 + 카드 간 이동시간(route_legs)`을 누적해 각 카드에 `"HH:mm"` 배정. null 소요/캐시 miss 구간은 0(best-effort).
- **`CardDto`**: `scheduledTime`(nullable) 추가 + `withScheduledTime()` 복사 메서드. `from()`은 null(시각은 Day 문맥 의존이라 Day 뷰에서만 채움).
- **`DayViewService`**: `RouteService.readCachedLegs`(#187)로 해당 Day 이동시간 맵을 만들어 `DayTimeline.compute` → 활동 카드 `CardDto`에 `withScheduledTime` 부여. 항공편(start/endTimeCard)은 기존대로 `flight_datetime` 사용.
- **조회 시 계산(compute-on-read)** — 미저장이라 항상 현재 배치 반영. `route_legs`/verify/다른 엔드포인트 미변경.

## 🔗 관련 이슈

closes #191

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? — TDD(RED→GREEN) + 백엔드 전체 `./gradlew test` **175개 통과**. (실서버 수동 E2E는 미실시 — 로직은 단위 테스트로 커버)
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — 전체 175개 통과. 기존 DayView 동작(항공 슬롯/표시 순서) 유지, `CardDto` 직렬화 회귀 없음.
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요? — 시작시각 09:00은 의도적 상수(`DAY_START`).
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? — §5만. #187(route_legs) 머지에 의존.

## 👀 리뷰어에게

> - **Day 시작시각 = 09:00 고정**(합의된 결정). 사용자 입력/항공 앵커는 범위 밖(추후). 절대 시각은 이 가정 기반의 파생값.
> - **표시 순서 vs 계산 순서**: 응답 카드 표시 순서는 기존대로 `createdAt`, `scheduled_time`은 `dayOrder` 기준 계산. (표시 순서를 dayOrder로 바꾸는 건 별개 이슈.)
> - 이동시간은 #187 `readCachedLegs`(캐시 전용) 재사용 — AI 호출 없음. 캐시 miss/좌표 없음 구간은 이동시간 0.
> - `DayViewService`에 `RouteService` 의존 추가 — 순환 없음.

## 📸 스크린샷

없음 (백엔드 로직 변경)

---

### 변경 파일

| 파일 | 변경 |
|---|---|
| `apps/backend/.../group/DayTimeline.java` | 타임라인 계산 유틸 |
| `apps/backend/.../dto/card/CardDto.java` | `scheduledTime` + `withScheduledTime` |
| `apps/backend/.../group/DayViewService.java` | 시각 합성 (RouteService 의존) |
| `DayTimelineTest`/ `CardDtoTest`/ `DayViewServiceTest` | 테스트 |