### PR TITLE
Fix: 날짜 타입 전환 시 요약 일정 박/일 오표기 수정

### DIFF
--- a/apps/frontend/src/utils/calendar-store.ts
+++ b/apps/frontend/src/utils/calendar-store.ts
@@ -21,8 +21,10 @@ export const useCalendarStore = create<CalendarStore>()(
       type: null,
       exactDate: null,
       flexDate: null,
-      setExactDate: (value) => set({ type: 'exact', exactDate: value }),
-      setFlexDate: (value) => set({ type: 'flexible', flexDate: value }),
+      setExactDate: (value) =>
+        set({ type: 'exact', exactDate: value, flexDate: null }),
+      setFlexDate: (value) =>
+        set({ type: 'flexible', flexDate: value, exactDate: null }),
       clearExactDate: () => set({ type: null, exactDate: null }),
       resetCalendar: () => set({ type: null, exactDate: null, flexDate: null }),
     }),


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 날짜 타입(정확↔유연) 전환 시 반대편 날짜 상태가 남아 요약 '일정'의 박/일이 어긋나던 문제 수정

## 🔗 관련 이슈

closes #207

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- 원인: 요약의 박/일 계산이 `exactDate?.nights ?? flexDate?.nights ?? 0` 라 `type` 과 무관하게 `exactDate` 를 우선했고, `setExactDate`/`setFlexDate` 가 반대편 날짜를 비우지 않아 stale 값이 남음.'

- 수정: 호출부(온보딩/덤프/그룹핑 3곳)는 그대로 두고, `calendar-store` 의 setter에서 반대편 날짜(`exactDate`/`flexDate`)를 `null` 로 비우도록 변경


## 📸 스크린샷

