### PR TITLE
Fix: 덤프 프로그래스 단계 진행 프론트 타이머 기반으로 변경

### DIFF
--- a/apps/frontend/src/hooks/useParseJobStatus.ts
+++ b/apps/frontend/src/hooks/useParseJobStatus.ts
@@ -11,12 +11,28 @@ const POLLING_INTERVAL_MS = 1500;
 const POLLING_TIMEOUT_MS = 120_000;
 const MAX_CONSECUTIVE_ERRORS = 3;
 
+const STEP_2_DELAY_MS = 4000;
+const STEP_3_DELAY_MS = 8000;
+
 // jobId === null 이면 폴링을 멈추고 idle 로 돌아간다. (clearJob() 호출 시 동작)
 export const useParseJobStatus = (
   tripId: string | null,
   jobId: string | null
 ): ParseJobView => {
   const [view, setView] = useState<ParseJobView>({ kind: 'idle' });
+  const [timerStep, setTimerStep] = useState<1 | 2 | 3>(1);
+
+  const isLoading = view.kind === 'loading';
+  useEffect(() => {
+    if (!isLoading) return;
+    setTimerStep(1);
+    const t2 = setTimeout(() => setTimerStep(2), STEP_2_DELAY_MS);
+    const t3 = setTimeout(() => setTimerStep(3), STEP_3_DELAY_MS);
+    return () => {
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [isLoading]);
 
   useEffect(() => {
     if (!tripId || !jobId) {
@@ -71,5 +87,8 @@ export const useParseJobStatus = (
     };
   }, [tripId, jobId]);
 
+  if (view.kind === 'loading') {
+    return { kind: 'loading', step: timerStep };
+  }
   return view;
 };


### PR DESCRIPTION
## 📝 작업 내용

- 덤프 프로그래스 단계 표시(1→2→3)를 백엔드 `step` 응답 의존에서 프론트 타이머 기반 진행으로 변경

## 🔗 관련 이슈

closes #209 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.
> 없으면 "없음"으로 남겨주세요.

- 백엔드가 단계 전환(`step`)을 하는 경우 속도 저하로 폴링은 완료/에러 판정에만 쓰고 단계 표시는 프론트 타이머로 진행하도록 변경했습니다.

- 변경은 `useParseJobStatus` 훅 내부에 집중돼 있습니다. 로딩 중일 때 `timerStep`을 4초 후 2단계 / 8초 후 3단계로 올리고, 3단계에서는 완료 응답을 기다립니다. 반환 시 `view.step`(백엔드 값) 대신 `timerStep`으로 단계를 덮어씁니다.

- 완료/에러 판정 및 화면 전환 로직(`DumpPage`의 `isInProgress`, done 시 `/grouping` 이동)은 변경하지 않았습니다.

## 📸 스크린샷