### PR TITLE
Fix: scr04 card day move

### DIFF
--- a/apps/frontend/src/components/arrange/ArrangeCard.tsx
+++ b/apps/frontend/src/components/arrange/ArrangeCard.tsx
@@ -10,6 +10,7 @@ import PlaceCardBadge from '@/components/grouping/PlaceCardBadge';
 import { cn } from '@/lib/utils';
 import type { ArrangeCardViewModel } from '@/types/arrange';
 import type { PlaceCardAccent } from '@/types/grouping';
+import { setArrangeDragData } from '@/utils/arrange-dnd';
 
 const ACCENT_BAR: Record<PlaceCardAccent, string> = {
   blue: 'bg-blue-500',
@@ -42,9 +43,9 @@ const ArrangeCard = ({
   isDragging = false,
 }: ArrangeCardProps) => {
   const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
-    // Day 컬럼 드롭 핸들러가 읽을 카드 식별자. (Firefox 는 setData 가 있어야 드래그가 시작됨)
-    event.dataTransfer.setData('text/plain', id);
-    event.dataTransfer.effectAllowed = 'move';
+    // Day 컬럼 드롭 핸들러가 읽을 카드 식별자 + 출처(좌측 목록 = fromDayId:null).
+    // (Firefox 는 setData 가 있어야 드래그가 시작됨)
+    setArrangeDragData(event.dataTransfer, { cardId: id, fromDayId: null });
     onDragStart?.();
   };
 

--- a/apps/frontend/src/components/arrange/CardListPanel.tsx
+++ b/apps/frontend/src/components/arrange/CardListPanel.tsx
@@ -1,13 +1,17 @@
 // CardListPanel — 배치 화면 좌측 패널 전체.
 // 헤더("카드 목록" + 재정렬 버튼 + 전체 카드 수) + 세로 스크롤되는 그룹 목록.
 // 카드는 클릭 시 상세 패널이 열리고, 드래그하여 우측 Day 컬럼에 배치할 수 있다.
+// Day 보드에서 드래그해 온 카드를 이 패널에 드롭하면 미배치 상태로 되돌린다.
 
 import { RefreshCw } from 'lucide-react';
+import { useState, type DragEvent } from 'react';
 
 import ArrangeCard from '@/components/arrange/ArrangeCard';
 import CardGroupSection from '@/components/arrange/CardGroupSection';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 import type { ArrangeCardGroup, ArrangeCardViewModel } from '@/types/arrange';
+import { readArrangeDragData } from '@/utils/arrange-dnd';
 
 type CardListPanelProps = {
   title: string;
@@ -21,8 +25,12 @@ type CardListPanelProps = {
   onDragCardStart?: (cardId: string) => void;
   /** 카드 드래그 종료 */
   onDragCardEnd?: () => void;
+  /** Day 보드에서 끌어온 카드를 좌측으로 되돌릴 때(미배치 복원) */
+  onReturnCard?: (cardId: string) => void;
   /** 현재 드래그 중인 카드 id(흐림 처리용) */
   draggingCardId?: string | null;
+  /** 드래그가 진행 중이면 패널을 드롭 가능 상태로 강조 */
+  dragActive?: boolean;
 };
 
 const CardListPanel = ({
@@ -33,13 +41,45 @@ const CardListPanel = ({
   onSelectCard,
   onDragCardStart,
   onDragCardEnd,
+  onReturnCard,
   draggingCardId,
+  dragActive = false,
 }: CardListPanelProps) => {
   // 카드가 모두 배치되어 비워진 그룹은 목록에서 숨긴다.
   const visibleGroups = groups.filter((group) => group.cards.length > 0);
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault(); // drop 허용
+    event.dataTransfer.dropEffect = 'move';
+    if (!isOver) setIsOver(true);
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      setIsOver(false);
+    }
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsOver(false);
+    const payload = readArrangeDragData(event.dataTransfer);
+    // Day 보드에서 온 카드만 되돌린다(좌측 카드를 좌측에 드롭하면 무시).
+    if (payload && payload.fromDayId !== null) onReturnCard?.(payload.cardId);
+  };
 
   return (
-    <div className="flex w-[380px] shrink-0 flex-col overflow-hidden rounded-2xl bg-muted/40 ring-1 ring-foreground/10">
+    <div
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className={cn(
+        'flex w-[380px] shrink-0 flex-col overflow-hidden rounded-2xl bg-muted/40 ring-1 ring-foreground/10 transition-colors',
+        dragActive && 'ring-primary/30',
+        isOver && 'bg-primary/5 ring-2 ring-primary/40'
+      )}
+    >
       <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
         <h2 className="text-sm font-bold text-foreground">{title}</h2>
         <div className="flex items-center gap-2">

--- a/apps/frontend/src/components/arrange/DayColumn.tsx
+++ b/apps/frontend/src/components/arrange/DayColumn.tsx
@@ -1,49 +1,99 @@
 // DayColumn — 우측 칸반 보드의 Day 컬럼 한 개.
 // 헤더(Day 라벨 + 날짜 + 카드 수) + 본문(배치된 카드들 또는 빈 드롭 플레이스홀더).
-// 좌측 카드 목록에서 드래그한 카드를 여기에 드롭하면 onDropCard 로 전달된다(네이티브 HTML5 DnD).
+// 카드 드롭(좌측 목록/다른 Day → 이 Day) + 같은 Day 내 순서 재정렬을 모두 지원한다(네이티브 HTML5 DnD).
+//  - 배치된 카드도 draggable: 다른 Day 로 옮기거나 좌측으로 되돌릴 수 있다(고정 시간 카드는 제외).
+//  - 드롭 위치(마우스 Y)로 삽입 인덱스를 계산해 onDropCard 에 전달한다.
 
 import { Plus } from 'lucide-react';
-import { useState, type DragEvent } from 'react';
+import { Fragment, useRef, useState, type DragEvent } from 'react';
 
 import ScheduleCard from '@/components/arrange/ScheduleCard';
 import { cn } from '@/lib/utils';
 import type { DayColumnViewModel } from '@/types/arrange';
+import {
+  readArrangeDragData,
+  setArrangeDragData,
+  type ArrangeDragPayload,
+} from '@/utils/arrange-dnd';
 
 type DayColumnProps = DayColumnViewModel & {
-  /** 카드를 이 Day에 드롭했을 때(드래그된 카드 id) */
-  onDropCard?: (cardId: string) => void;
+  /** 카드를 이 Day에 드롭했을 때(드래그 payload + 삽입 인덱스) */
+  onDropCard?: (payload: ArrangeDragPayload, targetIndex: number) => void;
+  /** 배치된 카드 드래그 시작(하이라이트용) */
+  onCardDragStart?: (cardId: string) => void;
+  /** 배치된 카드 드래그 종료 */
+  onCardDragEnd?: () => void;
+  /** 현재 드래그 중인 카드 id(흐림 처리용) */
+  draggingCardId?: string | null;
   /** 드래그가 진행 중이면 모든 컬럼을 드롭 가능 상태로 강조 */
   dragActive?: boolean;
 };
 
+// 카드 사이/끝의 삽입 위치 표시 선.
+const DropIndicator = () => (
+  <div className="mx-1 h-0.5 rounded-full bg-primary" aria-hidden="true" />
+);
+
 const DayColumn = ({
+  id,
   dayLabel,
   dateLabel,
   cards,
   onDropCard,
+  onCardDragStart,
+  onCardDragEnd,
+  draggingCardId,
   dragActive = false,
 }: DayColumnProps) => {
   const isEmpty = cards.length === 0;
   const [isOver, setIsOver] = useState(false);
+  const [dropIndex, setDropIndex] = useState<number | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // 마우스 Y 위치 → 카드 사이 삽입 인덱스(각 카드의 세로 중앙 기준).
+  const computeDropIndex = (clientY: number): number => {
+    const container = listRef.current;
+    if (!container) return cards.length;
+    const items = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-card-item]')
+    );
+    for (let i = 0; i < items.length; i += 1) {
+      const rect = items[i].getBoundingClientRect();
+      if (clientY < rect.top + rect.height / 2) return i;
+    }
+    return items.length;
+  };
+
+  const handleCardDragStart = (
+    event: DragEvent<HTMLDivElement>,
+    cardId: string
+  ) => {
+    setArrangeDragData(event.dataTransfer, { cardId, fromDayId: id });
+    onCardDragStart?.(cardId);
+  };
 
   const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault(); // drop 을 허용하려면 필수
     event.dataTransfer.dropEffect = 'move';
     if (!isOver) setIsOver(true);
+    setDropIndex(computeDropIndex(event.clientY));
   };
 
   const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
     // 자식 요소로 이동할 때 발생하는 leave 는 무시(컬럼 밖으로 나갈 때만 해제)
     if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
       setIsOver(false);
+      setDropIndex(null);
     }
   };
 
   const handleDrop = (event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
+    const targetIndex = computeDropIndex(event.clientY);
     setIsOver(false);
-    const cardId = event.dataTransfer.getData('text/plain');
-    if (cardId) onDropCard?.(cardId);
+    setDropIndex(null);
+    const payload = readArrangeDragData(event.dataTransfer);
+    if (payload) onDropCard?.(payload, targetIndex);
   };
 
   return (
@@ -93,10 +143,32 @@ const DayColumn = ({
           </p>
         </div>
       ) : (
-        <div className="mt-3 flex flex-1 flex-col gap-2.5 overflow-y-auto">
-          {cards.map((card) => (
-            <ScheduleCard key={card.id} {...card} />
-          ))}
+        <div
+          ref={listRef}
+          className="mt-3 flex flex-1 flex-col gap-2.5 overflow-y-auto"
+        >
+          {cards.map((card, index) => {
+            // 고정 시작 시간 카드(항공권 등)는 이동 불가.
+            const cardDraggable = !card.fixedTime;
+            return (
+              <Fragment key={card.id}>
+                {isOver && dropIndex === index && <DropIndicator />}
+                <div
+                  data-card-item=""
+                  draggable={cardDraggable}
+                  onDragStart={(event) => handleCardDragStart(event, card.id)}
+                  onDragEnd={onCardDragEnd}
+                  className={cn(
+                    cardDraggable && 'cursor-grab active:cursor-grabbing',
+                    draggingCardId === card.id && 'opacity-40'
+                  )}
+                >
+                  <ScheduleCard {...card} />
+                </div>
+              </Fragment>
+            );
+          })}
+          {isOver && dropIndex === cards.length && <DropIndicator />}
         </div>
       )}
     </div>

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -9,7 +9,7 @@
 //    (백엔드에 카드별 day 저장 API 가 없어 스냅샷 일괄 전송만 가능)
 
 import { ArrowLeft, ArrowRight, Plus } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import ArrangeCardDetailPanel from '@/components/arrange/ArrangeCardDetailPanel';
@@ -36,6 +36,7 @@ import type {
   ScheduledCardViewModel,
 } from '@/types/arrange';
 import type { RouteWarning } from '@/types/arrange-api';
+import type { ArrangeDragPayload } from '@/utils/arrange-dnd';
 
 import {
   buildPlacementRequest,
@@ -60,6 +61,22 @@ const toScheduledCard = (
   accent: card.accent,
   badges: card.badges,
 });
+
+// 배치 보드 카드 → 좌측 목록 카드로 되돌릴 때의 폴백 변환(원본 보존 실패 시).
+const toArrangeCard = (card: ScheduledCardViewModel): ArrangeCardViewModel => ({
+  id: card.id,
+  name: card.name,
+  accent: card.accent,
+  badges: card.badges,
+  draggable: true,
+});
+
+// index 위치에 item 삽입(미지정·범위 초과 시 맨 뒤).
+const insertAt = <T,>(arr: T[], item: T, index?: number): T[] => {
+  if (index == null || index >= arr.length) return [...arr, item];
+  const i = Math.max(0, index);
+  return [...arr.slice(0, i), item, ...arr.slice(i)];
+};
 
 const errorMessageOf = (error: unknown, fallback: string): string => {
   const apiBody = parseGroupingApiError(error);
@@ -142,6 +159,11 @@ const ArrangePage = () => {
   }, [dayColumns]);
 
   const [draggingCardId, setDraggingCardId] = useState<string | null>(null);
+  // 좌측 → Day 배치 시 원본 카드를 보존한다. 좌측으로 되돌릴 때 detail/메모 등
+  // ScheduledCardViewModel 이 들고 있지 않은 필드까지 복원하기 위함.
+  const originalCardsRef = useRef<
+    Map<string, { card: ArrangeCardViewModel; groupId: string }>
+  >(new Map());
   const [detailCard, setDetailCard] = useState<ArrangeCardViewModel | null>(
     null
   );
@@ -172,30 +194,137 @@ const ArrangePage = () => {
     setDetailOpen(true);
   };
 
-  // 카드를 좌측 목록에서 빼고 해당 Day 컬럼에 추가한다(로컬).
-  const placeCardOnDay = (cardId: string, dayId: string) => {
-    const card = groups
-      .flatMap((group) => group.cards)
-      .find((item) => item.id === cardId);
+  // 좌측 목록 카드 → Day 에 배치(targetIndex 위치 삽입).
+  const placeFromList = (
+    cardId: string,
+    targetDayId: string,
+    targetIndex?: number
+  ) => {
+    const group = groups.find((g) => g.cards.some((c) => c.id === cardId));
+    const card = group?.cards.find((c) => c.id === cardId);
     // 드래그 불가(처리 필요/제외) 카드는 배치하지 않는다.
-    if (!card || card.draggable === false) {
-      setDraggingCardId(null);
-      return;
-    }
+    if (!card || group == null || card.draggable === false) return;
 
+    // 되돌리기 복원용으로 원본 카드 + 원래 그룹 id 보존.
+    originalCardsRef.current.set(cardId, { card, groupId: group.id });
     setGroups((prev) =>
-      prev.map((group) => ({
-        ...group,
-        cards: group.cards.filter((item) => item.id !== cardId),
+      prev.map((g) => ({
+        ...g,
+        cards: g.cards.filter((c) => c.id !== cardId),
       }))
     );
     setDays((prev) =>
       prev.map((day) =>
-        day.id === dayId
-          ? { ...day, cards: [...day.cards, toScheduledCard(card)] }
+        day.id === targetDayId
+          ? {
+              ...day,
+              cards: insertAt(day.cards, toScheduledCard(card), targetIndex),
+            }
           : day
       )
     );
+  };
+
+  // Day → Day 이동(또는 같은 Day 내 순서 재정렬). fromDayId 는 payload(non-null) 에서 온다.
+  const moveBetweenDays = (
+    { cardId, fromDayId }: { cardId: string; fromDayId: string },
+    targetDayId: string,
+    targetIndex?: number
+  ) => {
+    const fromDay = days.find((d) => d.id === fromDayId);
+    const scheduled = fromDay?.cards.find((c) => c.id === cardId);
+    // 고정 시작 시간 카드(항공권 등)는 이동 불가.
+    if (!scheduled || scheduled.fixedTime) return;
+
+    if (fromDayId === targetDayId) {
+      // 같은 Day 내 재정렬: 제거로 앞쪽 인덱스가 한 칸 당겨지므로 보정.
+      const oldIndex = fromDay!.cards.findIndex((c) => c.id === cardId);
+      let idx = targetIndex;
+      if (idx != null && oldIndex > -1 && oldIndex < idx) idx -= 1;
+      setDays((prev) =>
+        prev.map((d) => {
+          if (d.id !== targetDayId) return d;
+          const without = d.cards.filter((c) => c.id !== cardId);
+          return { ...d, cards: insertAt(without, scheduled, idx) };
+        })
+      );
+    } else {
+      setDays((prev) =>
+        prev.map((d) => {
+          if (d.id === fromDayId)
+            return { ...d, cards: d.cards.filter((c) => c.id !== cardId) };
+          if (d.id === targetDayId)
+            return { ...d, cards: insertAt(d.cards, scheduled, targetIndex) };
+          return d;
+        })
+      );
+    }
+  };
+
+  // Day 컬럼 드롭 핸들러 — 출처(좌측/다른 Day)에 따라 분기한다.
+  const handleDropOnDay = (
+    payload: ArrangeDragPayload,
+    targetDayId: string,
+    targetIndex?: number
+  ) => {
+    if (payload.fromDayId === null) {
+      placeFromList(payload.cardId, targetDayId, targetIndex);
+    } else {
+      moveBetweenDays(
+        { cardId: payload.cardId, fromDayId: payload.fromDayId },
+        targetDayId,
+        targetIndex
+      );
+    }
+    setDraggingCardId(null);
+    setConfirmed(false);
+  };
+
+  // 배치된 카드를 좌측 목록으로 되돌린다(미배치 복원).
+  const returnCardToList = (cardId: string) => {
+    const fromDay = days.find((d) => d.cards.some((c) => c.id === cardId));
+    const scheduled = fromDay?.cards.find((c) => c.id === cardId);
+    // 고정 시작 시간 카드는 좌측으로 되돌리지 않는다.
+    if (!scheduled || scheduled.fixedTime) {
+      setDraggingCardId(null);
+      return;
+    }
+
+    const saved = originalCardsRef.current.get(cardId);
+    const restored = saved?.card ?? toArrangeCard(scheduled);
+
+    setDays((prev) =>
+      prev.map((d) =>
+        d.id === fromDay!.id
+          ? { ...d, cards: d.cards.filter((c) => c.id !== cardId) }
+          : d
+      )
+    );
+    setGroups((prev) => {
+      // 원래 그룹이 남아 있으면 그곳으로, 아니면 "추가한 카드" 또는 첫 그룹으로 폴백.
+      const originGroupId = saved?.groupId;
+      const targetGroupId =
+        originGroupId && prev.some((g) => g.id === originGroupId)
+          ? originGroupId
+          : prev.some((g) => g.id === ADDED_GROUP_ID)
+            ? ADDED_GROUP_ID
+            : prev[0]?.id;
+      if (targetGroupId) {
+        return prev.map((g) =>
+          g.id === targetGroupId ? { ...g, cards: [...g.cards, restored] } : g
+        );
+      }
+      // 좌측이 완전히 비어 있던 경우 새 그룹 생성.
+      return [
+        {
+          id: 'restored',
+          title: '카드 목록',
+          description: '다시 Day에 배치할 수 있어요.',
+          cards: [restored],
+        },
+      ];
+    });
+    originalCardsRef.current.delete(cardId);
     setDraggingCardId(null);
     setConfirmed(false);
   };
@@ -458,8 +587,10 @@ const ArrangePage = () => {
               groups={groups}
               onSelectCard={openCardDetail}
               draggingCardId={draggingCardId}
+              dragActive={draggingCardId !== null}
               onDragCardStart={setDraggingCardId}
               onDragCardEnd={() => setDraggingCardId(null)}
+              onReturnCard={returnCardToList}
             />
 
             {/* 칸반 보드 — 가로 스크롤 */}
@@ -470,7 +601,12 @@ const ArrangePage = () => {
                     key={day.id}
                     {...day}
                     dragActive={draggingCardId !== null}
-                    onDropCard={(cardId) => placeCardOnDay(cardId, day.id)}
+                    draggingCardId={draggingCardId}
+                    onCardDragStart={setDraggingCardId}
+                    onCardDragEnd={() => setDraggingCardId(null)}
+                    onDropCard={(payload, index) =>
+                      handleDropOnDay(payload, day.id, index)
+                    }
                   />
                 ))}
               </div>

--- a/apps/frontend/src/utils/arrange-dnd.ts
+++ b/apps/frontend/src/utils/arrange-dnd.ts
@@ -1,0 +1,43 @@
+// 배치 화면(SCR-04) 드래그앤드롭 공용 헬퍼.
+// 좌측 카드 목록 ↔ Day 보드 ↔ Day 간 이동을 한 드롭 핸들러로 처리하려면
+// "이 카드가 어디서 왔는지(출처)"를 drop 시점에 알아야 한다.
+// dataTransfer 에 출처를 담아 직렬화/파싱한다.
+
+/** 커스텀 MIME — payload(JSON)를 싣는다. */
+export const ARRANGE_DND_MIME = 'application/x-arrange-card';
+
+export type ArrangeDragPayload = {
+  cardId: string;
+  /** null = 좌측 "카드 목록", 그 외 = 출처 Day 컬럼 id */
+  fromDayId: string | null;
+};
+
+/** dragstart 에서 호출 — payload + 하위호환용 text/plain(id) 를 함께 싣는다. */
+export const setArrangeDragData = (
+  dataTransfer: DataTransfer,
+  payload: ArrangeDragPayload
+): void => {
+  dataTransfer.setData(ARRANGE_DND_MIME, JSON.stringify(payload));
+  // Firefox 는 드래그 시작에 text/plain 이 필요. 구버전/외부 폴백용으로도 id 를 남긴다.
+  dataTransfer.setData('text/plain', payload.cardId);
+  dataTransfer.effectAllowed = 'move';
+};
+
+/** drop 에서 호출 — payload 를 복원한다. text/plain 만 있으면 좌측 목록 출처로 간주. */
+export const readArrangeDragData = (
+  dataTransfer: DataTransfer
+): ArrangeDragPayload | null => {
+  const raw = dataTransfer.getData(ARRANGE_DND_MIME);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as Partial<ArrangeDragPayload>;
+      if (typeof parsed?.cardId === 'string') {
+        return { cardId: parsed.cardId, fromDayId: parsed.fromDayId ?? null };
+      }
+    } catch {
+      // 손상된 payload 는 text/plain 폴백으로 처리
+    }
+  }
+  const id = dataTransfer.getData('text/plain');
+  return id ? { cardId: id, fromDayId: null } : null;
+};


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- SCR-04 배치 화면에서 **이미 배치한 카드를 다른 Day로 이동·같은 Day 내 재정렬·좌측 목록으로 되돌리기**를 지원하도록 드래그앤드롭을 좌측→Day 단방향에서 양방향으로 확장했습니다. (한 번 놓으면 수정 불가 → 자유 편집 가능)

## 🔗 관련 이슈

- `docs/issue-fe-scr04-arrange-card-move-between-days.md` (FE 작성 이슈)

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

변경 파일 (`develop` 기준 6 files, +326 / -32):

- `utils/arrange-dnd.ts` *(신규)* — DnD 출처 식별용 payload 직렬화/파싱 헬퍼
- `components/arrange/ArrangeCard.tsx` — 좌측 카드에 payload 적용
- `components/arrange/DayColumn.tsx` — 배치 카드 드래그 가능화 + 드롭 위치(targetIndex) 계산
- `components/arrange/CardListPanel.tsx` — 좌측 패널을 드롭 존으로(되돌리기)
- `pages/ArrangePage.tsx` — 이동/재정렬/되돌리기 상태 로직
- `utils/calendar-store.ts` — #208 날짜 타입 전환 박/일 오표기 수정 (별도 커밋, develop 미반영 시 함께 포함)

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

SCR-04 배치 화면의 카드 이동/재정렬/되돌리기 작업입니다. 백엔드에 카드별 day 저장 API가 없어 **로컬 `days`/`groups` 상태만 갱신**하며, 저장은 기존 `POST /verify`·`POST /confirm`의 `buildPlacementRequest(days, …)` 스냅샷 일괄 전송 경로가 그대로 반영합니다(추가 API 호출 없음).

- **드래그 출처 식별 (`arrange-dnd.ts`)**: 기존엔 `dataTransfer`에 `text/plain` id만 실어 출처를 알 수 없었습니다. 커스텀 MIME(`application/x-arrange-card`)에 `{ cardId, fromDayId }` payload를 싣고, `fromDayId === null`이면 좌측 목록 출처로 간주합니다. Firefox 드래그 시작/외부 폴백용으로 `text/plain` id를 병행해 하위호환을 유지합니다.
- **단일 드롭 핸들러 분기 (`ArrangePage.tsx` `handleDropOnDay`)**: payload의 `fromDayId`로 `placeFromList`(좌측→Day) / `moveBetweenDays`(Day→Day, 같은 Day 재정렬 포함)를 분기합니다.
- **같은 Day 내 재정렬 인덱스 보정**: 카드 제거로 앞쪽 인덱스가 한 칸 당겨지므로 `oldIndex < targetIndex`일 때 `idx -= 1` 보정(`moveBetweenDays`).
- **좌측 되돌리기 시 원본 복원**: `toScheduledCard`가 `detail`/`actionGuide` 등을 버리므로, 배치 시점에 원본 `ArrangeCardViewModel`+그룹 id를 `originalCardsRef`(Map)로 보존해 복원합니다. 원본/원그룹이 없으면 "추가한 카드" → 첫 그룹 → 새 그룹 순으로 폴백합니다.
- **`fixedTime` 카드(항공권 등) 고정**: Day 간 이동·좌측 되돌리기 모두 차단해 좌측 `draggable === false` 정책과 일관성 유지.
- **미확정 전환**: 이동/재정렬/되돌리기 후 `setConfirmed(false)`로 "확정됨"을 풀어 재확정 가능. 좌측 카운트(`remainingCards`/`unplacedCount`)는 `groups` 파생이라 자동 반영.

> 집중 리뷰 포인트: ① `moveBetweenDays`의 같은-Day 재정렬 인덱스 보정(off-by-one), ② `returnCardToList`의 원본 복원 폴백 경로, ③ `arrange-dnd.ts`의 `text/plain` 하위호환 파싱.

### 라이브러리

외부 DnD 라이브러리 없이 **HTML5 네이티브 DnD**를 그대로 확장했습니다(신규 의존성 없음). 

## 🧪 빌드 / 검증

- [x] `npm run build` (tsc + vite) 통과
- [x] `npm run lint` (eslint) 통과
- 백엔드 변경 없음 → 백엔드 CI 영향 없음

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요.

