### PR TITLE
Fix/210 scr 02 dump flight datetime

### DIFF
--- a/apps/frontend/src/components/dump/DumpDateTimeField.tsx
+++ b/apps/frontend/src/components/dump/DumpDateTimeField.tsx
@@ -1,0 +1,118 @@
+import { format, isSameDay, isValid, parse } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { CalendarIcon } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Input } from '@/components/ui/input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+const DATE_FORMAT = 'yyyy-MM-dd';
+
+const parseValue = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) return { date: undefined as Date | undefined, time: '' };
+  const [datePart, timePart = ''] = trimmed.split(' ');
+  const date = parse(datePart, DATE_FORMAT, new Date());
+  return { date: isValid(date) ? date : undefined, time: timePart };
+};
+
+const buildValue = (date: Date | undefined, time: string) => {
+  if (!date) return '';
+  const datePart = format(date, DATE_FORMAT);
+  return time ? `${datePart} ${time}` : datePart;
+};
+
+const formatDisplay = (value: string) => {
+  const { date, time } = parseValue(value);
+  if (!date) return value; // 구버전 자유 텍스트는 그대로
+  const datePart = format(date, 'M월 d일', { locale: ko });
+  return time ? `${datePart} ${time}` : datePart;
+};
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  min?: string;
+};
+
+export const DumpDateTimeField = ({
+  value,
+  onChange,
+  placeholder,
+  min,
+}: Props) => {
+  const [open, setOpen] = useState(false);
+  const { date, time } = parseValue(value);
+  const { date: minDate, time: minTime } = parseValue(min ?? '');
+  const hasValue = value.trim().length > 0;
+
+  // 같은 날이면서 min 시각보다 이르면 min 시각으로 끌어올림
+  const clampTime = (d: Date | undefined, t: string) => {
+    if (d && minDate && minTime && isSameDay(d, minDate) && t && t < minTime) {
+      return minTime;
+    }
+    return t;
+  };
+
+  const handleDateSelect = (d: Date | undefined) => {
+    onChange(buildValue(d, clampTime(d, time)));
+  };
+
+  const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const baseDate = date ?? new Date();
+    onChange(buildValue(baseDate, clampTime(baseDate, e.target.value)));
+  };
+
+  const sameAsMin = !!(date && minDate && isSameDay(date, minDate));
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className={cn(
+            'h-9 w-full justify-start gap-1.5 px-2.5 text-sm font-normal',
+            !hasValue && 'text-muted-foreground'
+          )}
+        >
+          <CalendarIcon className="size-3.5 text-gray-400" />
+          <span className="truncate">
+            {hasValue ? formatDisplay(value) : placeholder}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto">
+        <Calendar
+          mode="single"
+          selected={date}
+          onSelect={handleDateSelect}
+          defaultMonth={date ?? minDate}
+          disabled={minDate ? { before: minDate } : undefined}
+          locale={ko}
+          autoFocus
+        />
+        <div className="flex items-center gap-2 border-t border-border pt-2.5">
+          <label className="text-xs text-muted-foreground">시간</label>
+          <Input
+            type="time"
+            value={time}
+            min={sameAsMin ? minTime || undefined : undefined}
+            onChange={handleTimeChange}
+            className="h-8 flex-1"
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default DumpDateTimeField;

--- a/apps/frontend/src/components/dump/DumpFlightInfo.tsx
+++ b/apps/frontend/src/components/dump/DumpFlightInfo.tsx
@@ -2,6 +2,8 @@ import { Input } from '@/components/ui/input';
 
 import { useDumpStore } from '../../utils/dump-store';
 
+import { DumpDateTimeField } from './DumpDateTimeField';
+
 type FlightSection = {
   key: 'departure' | 'return';
   label: string;
@@ -66,12 +68,14 @@ const DumpFlightInfo = () => {
               </div>
               <div>
                 <label className="block text-xs text-gray-500 mb-1">시간</label>
-                <Input
-                  className="h-9 text-sm bg-white"
-                  placeholder="예: 09:30"
+                <DumpDateTimeField
                   value={row.time}
-                  onChange={(e) =>
-                    updateFlight(section.key, 'time', e.target.value)
+                  onChange={(v) => updateFlight(section.key, 'time', v)}
+                  placeholder="날짜·시간 선택"
+                  min={
+                    section.key === 'return'
+                      ? flightForm.departure.time
+                      : undefined
                   }
                 />
               </div>

--- a/apps/frontend/src/components/dump/DumpFlightInfo.tsx
+++ b/apps/frontend/src/components/dump/DumpFlightInfo.tsx
@@ -4,6 +4,10 @@ import { useDumpStore } from '../../utils/dump-store';
 
 import { DumpDateTimeField } from './DumpDateTimeField';
 
+// 항공편 코드: 영문·숫자만 허용하고 대문자로 통일 (예: ke123 → KE123)
+const sanitizeFlightNumber = (value: string) =>
+  value.replace(/[^A-Za-z0-9]/g, '').toUpperCase();
+
 type FlightSection = {
   key: 'departure' | 'return';
   label: string;
@@ -62,7 +66,11 @@ const DumpFlightInfo = () => {
                   placeholder="예: KE123"
                   value={row.flightNumber}
                   onChange={(e) =>
-                    updateFlight(section.key, 'flightNumber', e.target.value)
+                    updateFlight(
+                      section.key,
+                      'flightNumber',
+                      sanitizeFlightNumber(e.target.value)
+                    )
                   }
                 />
               </div>

--- a/apps/frontend/src/components/dump/DumpGuideCard.css
+++ b/apps/frontend/src/components/dump/DumpGuideCard.css
@@ -5,11 +5,29 @@
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
 }
 
+.dump-guide-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
 .dump-guide-title {
-  margin: 0 0 16px;
+  margin: 0;
   font-size: 15px;
   font-weight: 600;
   color: #111827;
+}
+
+.dump-guide-description {
+  margin: 0;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background-color: #f3f4f6;
+  font-size: 12px;
+  color: #6b7280;
+  white-space: nowrap;
 }
 
 .dump-guide-list {

--- a/apps/frontend/src/components/dump/DumpGuideCard.tsx
+++ b/apps/frontend/src/components/dump/DumpGuideCard.tsx
@@ -11,7 +11,10 @@ const DumpGuideCard = () => {
 
   return (
     <div className="dump-guide-card">
-      <h2 className="dump-guide-title">보조 정보 (선택)</h2>
+      <div className="dump-guide-header">
+        <h2 className="dump-guide-title">보조 정보 (선택)</h2>
+        <p className="dump-guide-description">이메일 연동 기능 구현 예정</p>
+      </div>
 
       <div className="dump-guide-list">
         <button

--- a/apps/frontend/src/components/dump/DumpHotelInfo.tsx
+++ b/apps/frontend/src/components/dump/DumpHotelInfo.tsx
@@ -4,6 +4,8 @@ import { Input } from '@/components/ui/input';
 
 import { useDumpStore } from '../../utils/dump-store';
 
+import { DumpDateTimeField } from './DumpDateTimeField';
+
 const DumpHotelInfo = () => {
   const hotels = useDumpStore((s) => s.accommodations);
   const { addAccommodation, removeAccommodation, updateAccommodation } =
@@ -54,26 +56,21 @@ const DumpHotelInfo = () => {
             </div>
             <div>
               <label className="block text-xs text-gray-500 mb-1">체크인</label>
-              <Input
-                className="h-9 text-sm bg-white"
-                placeholder="예: 5월 10일 15:00"
+              <DumpDateTimeField
                 value={hotel.checkIn}
-                onChange={(e) =>
-                  updateAccommodation(hotel.id, 'checkIn', e.target.value)
-                }
+                onChange={(v) => updateAccommodation(hotel.id, 'checkIn', v)}
+                placeholder="날짜·시간 선택"
               />
             </div>
             <div>
               <label className="block text-xs text-gray-500 mb-1">
                 체크아웃
               </label>
-              <Input
-                className="h-9 text-sm bg-white"
-                placeholder="예: 5월 12일 11:00"
+              <DumpDateTimeField
                 value={hotel.checkOut}
-                onChange={(e) =>
-                  updateAccommodation(hotel.id, 'checkOut', e.target.value)
-                }
+                onChange={(v) => updateAccommodation(hotel.id, 'checkOut', v)}
+                placeholder="날짜·시간 선택"
+                min={hotel.checkIn}
               />
             </div>
           </div>

--- a/apps/frontend/src/components/ui/calendar.tsx
+++ b/apps/frontend/src/components/ui/calendar.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
+} from 'lucide-react';
+import * as React from 'react';
+import {
+  DayPicker,
+  getDefaultClassNames,
+  type DayButton,
+  type Locale,
+} from 'react-day-picker';
+
+import { Button, buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const Calendar = ({
+  className,
+  classNames,
+  showOutsideDays = true,
+  captionLayout = 'label',
+  buttonVariant = 'ghost',
+  locale,
+  formatters,
+  components,
+  ...props
+}: React.ComponentProps<typeof DayPicker> & {
+  buttonVariant?: React.ComponentProps<typeof Button>['variant'];
+}) => {
+  const defaultClassNames = getDefaultClassNames();
+
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn(
+        'group/calendar bg-background p-2 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(7)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent',
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className
+      )}
+      captionLayout={captionLayout}
+      locale={locale}
+      formatters={{
+        formatMonthDropdown: (date) =>
+          date.toLocaleString(locale?.code, { month: 'short' }),
+        ...formatters,
+      }}
+      classNames={{
+        root: cn('w-fit', defaultClassNames.root),
+        months: cn(
+          'relative flex flex-col gap-4 md:flex-row',
+          defaultClassNames.months
+        ),
+        month: cn('flex w-full flex-col gap-4', defaultClassNames.month),
+        nav: cn(
+          'absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1',
+          defaultClassNames.nav
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+          defaultClassNames.button_previous
+        ),
+        button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+          defaultClassNames.button_next
+        ),
+        month_caption: cn(
+          'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
+          defaultClassNames.month_caption
+        ),
+        dropdowns: cn(
+          'flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium',
+          defaultClassNames.dropdowns
+        ),
+        dropdown_root: cn(
+          'relative rounded-(--cell-radius)',
+          defaultClassNames.dropdown_root
+        ),
+        dropdown: cn(
+          'absolute inset-0 bg-popover opacity-0',
+          defaultClassNames.dropdown
+        ),
+        caption_label: cn(
+          'font-medium select-none',
+          captionLayout === 'label'
+            ? 'text-sm'
+            : 'flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
+          defaultClassNames.caption_label
+        ),
+        table: 'w-full border-collapse',
+        weekdays: cn('flex', defaultClassNames.weekdays),
+        weekday: cn(
+          'flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none',
+          defaultClassNames.weekday
+        ),
+        week: cn('mt-2 flex w-full', defaultClassNames.week),
+        week_number_header: cn(
+          'w-(--cell-size) select-none',
+          defaultClassNames.week_number_header
+        ),
+        week_number: cn(
+          'text-[0.8rem] text-muted-foreground select-none',
+          defaultClassNames.week_number
+        ),
+        day: cn(
+          'group/day relative aspect-square h-full w-full rounded-(--cell-radius) p-0 text-center select-none [&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius)',
+          props.showWeekNumber
+            ? '[&:nth-child(2)[data-selected=true]_button]:rounded-l-(--cell-radius)'
+            : '[&:first-child[data-selected=true]_button]:rounded-l-(--cell-radius)',
+          defaultClassNames.day
+        ),
+        range_start: cn(
+          'relative isolate z-0 rounded-l-(--cell-radius) bg-muted after:absolute after:inset-y-0 after:right-0 after:w-4 after:bg-muted',
+          defaultClassNames.range_start
+        ),
+        range_middle: cn('rounded-none', defaultClassNames.range_middle),
+        range_end: cn(
+          'relative isolate z-0 rounded-r-(--cell-radius) bg-muted after:absolute after:inset-y-0 after:left-0 after:w-4 after:bg-muted',
+          defaultClassNames.range_end
+        ),
+        today: cn(
+          'rounded-(--cell-radius) bg-muted text-foreground data-[selected=true]:rounded-none',
+          defaultClassNames.today
+        ),
+        outside: cn(
+          'text-muted-foreground aria-selected:text-muted-foreground',
+          defaultClassNames.outside
+        ),
+        disabled: cn(
+          'text-muted-foreground opacity-50',
+          defaultClassNames.disabled
+        ),
+        hidden: cn('invisible', defaultClassNames.hidden),
+        ...classNames,
+      }}
+      components={{
+        Root: ({ className, rootRef, ...props }) => {
+          return (
+            <div
+              data-slot="calendar"
+              ref={rootRef}
+              className={cn(className)}
+              {...props}
+            />
+          );
+        },
+        Chevron: ({ className, orientation, ...props }) => {
+          if (orientation === 'left') {
+            return (
+              <ChevronLeftIcon className={cn('size-4', className)} {...props} />
+            );
+          }
+
+          if (orientation === 'right') {
+            return (
+              <ChevronRightIcon
+                className={cn('size-4', className)}
+                {...props}
+              />
+            );
+          }
+
+          return (
+            <ChevronDownIcon className={cn('size-4', className)} {...props} />
+          );
+        },
+        DayButton: ({ ...props }) => (
+          <CalendarDayButton locale={locale} {...props} />
+        ),
+        WeekNumber: ({ children, ...props }) => {
+          return (
+            <td {...props}>
+              <div className="flex size-(--cell-size) items-center justify-center text-center">
+                {children}
+              </div>
+            </td>
+          );
+        },
+        ...components,
+      }}
+      {...props}
+    />
+  );
+};
+
+const CalendarDayButton = ({
+  className,
+  day,
+  modifiers,
+  locale,
+  ...props
+}: React.ComponentProps<typeof DayButton> & { locale?: Partial<Locale> }) => {
+  const defaultClassNames = getDefaultClassNames();
+
+  const ref = React.useRef<HTMLButtonElement>(null);
+  React.useEffect(() => {
+    if (modifiers.focused) ref.current?.focus();
+  }, [modifiers.focused]);
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-selected-single={
+        modifiers.selected &&
+        !modifiers.range_start &&
+        !modifiers.range_end &&
+        !modifiers.range_middle
+      }
+      data-range-start={modifiers.range_start}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      className={cn(
+        'relative isolate z-10 flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 border-0 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] group-data-[focused=true]/day:ring-ring/50 data-[range-end=true]:rounded-(--cell-radius) data-[range-end=true]:rounded-r-(--cell-radius) data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:rounded-none data-[range-middle=true]:bg-muted data-[range-middle=true]:text-foreground data-[range-start=true]:rounded-(--cell-radius) data-[range-start=true]:rounded-l-(--cell-radius) data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground dark:hover:text-foreground [&>span]:text-xs [&>span]:opacity-70',
+        defaultClassNames.day,
+        className
+      )}
+      {...props}
+    />
+  );
+};
+
+export { Calendar, CalendarDayButton };

--- a/apps/frontend/src/components/ui/popover.tsx
+++ b/apps/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,90 @@
+import { Popover as PopoverPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Popover = ({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) => {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+};
+
+const PopoverTrigger = ({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) => {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+};
+
+const PopoverContent = ({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) => {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+};
+
+const PopoverAnchor = ({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) => {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+};
+
+const PopoverHeader = ({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) => {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn('flex flex-col gap-0.5 text-sm', className)}
+      {...props}
+    />
+  );
+};
+
+const PopoverTitle = ({ className, ...props }: React.ComponentProps<'h2'>) => {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn('font-medium', className)}
+      {...props}
+    />
+  );
+};
+
+const PopoverDescription = ({
+  className,
+  ...props
+}: React.ComponentProps<'p'>) => {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn('text-muted-foreground', className)}
+      {...props}
+    />
+  );
+};
+
+export {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+};

--- a/apps/frontend/src/utils/dump-store.ts
+++ b/apps/frontend/src/utils/dump-store.ts
@@ -161,16 +161,20 @@ export const useDumpStore = create<DumpStore>()(
 
           const trim = (v: string) => v.trim();
 
-          const flight: FlightInput = {
-            departure_airport: trim(flightForm.departure.airport) || undefined,
-            arrival_airport: trim(flightForm.return.airport) || undefined, //귀국 공항
-            flight_number: trim(flightForm.departure.flightNumber) || undefined,
-            datetime: trim(flightForm.departure.time) || undefined,
+          // 섹션(출발/귀국) 1개를 항공편 1편으로 매핑.
+          // arrival_airport는 UI에 입력칸이 없어 비움(나머지 3칸만 전송).
+          const buildFlight = (row: FlightRow): FlightInput | undefined => {
+            const flight: FlightInput = {
+              departure_airport: trim(row.airport) || undefined,
+              flight_number: trim(row.flightNumber) || undefined,
+              datetime: trim(row.time) || undefined,
+            };
+            // 입력이 하나도 없으면 통째로 생략
+            return Object.values(flight).some(Boolean) ? flight : undefined;
           };
-          // 4칸 다 비었으면 통째로 생략
-          const departure_flight = Object.values(flight).some(Boolean)
-            ? flight
-            : undefined;
+
+          const departure_flight = buildFlight(flightForm.departure);
+          const return_flight = buildFlight(flightForm.return);
 
           const accommodation_inputs: AccommodationInput[] = accommodations
             .map((a) => ({
@@ -185,6 +189,7 @@ export const useDumpStore = create<DumpStore>()(
             const response = await submitDumpText(tripId, {
               dump_text: dumpText,
               ...(departure_flight && { departure_flight }),
+              ...(return_flight && { return_flight }),
               ...(accommodation_inputs.length && { accommodation_inputs }),
             });
             set({ requestStatus: 'success', jobId: response.job_id });

--- a/apps/frontend/src/utils/dump-store.ts
+++ b/apps/frontend/src/utils/dump-store.ts
@@ -27,6 +27,17 @@ const emptyAccommodation = (): Accommodation => ({
   checkOut: '',
 });
 
+// "yyyy-MM-dd HH:mm" 끼리 a가 b보다 명확히 이전인지 판단.
+// 같은 날인데 한쪽만 시간이 있으면 비교 불가 → false(정리하지 않음).
+const isDateTimeBefore = (a: string, b: string): boolean => {
+  const [aDate, aTime = ''] = a.trim().split(' ');
+  const [bDate, bTime = ''] = b.trim().split(' ');
+  if (!aDate || !bDate) return false;
+  if (aDate !== bDate) return aDate < bDate;
+  if (aTime && bTime) return aTime < bTime;
+  return false;
+};
+
 type DumpStore = {
   dumpText: string;
   flightForm: FlightForm;
@@ -71,12 +82,20 @@ export const useDumpStore = create<DumpStore>()(
         },
 
         updateFlight: (section, field, value) => {
-          set((s) => ({
-            flightForm: {
-              ...s.flightForm,
-              [section]: { ...s.flightForm[section], [field]: value },
-            },
-          }));
+          set((s) => {
+            const nextSection = { ...s.flightForm[section], [field]: value };
+            const next = { ...s.flightForm, [section]: nextSection };
+            // 출발 시각을 귀국보다 늦게 바꾸면 무효해진 귀국 시각 정리
+            if (
+              section === 'departure' &&
+              field === 'time' &&
+              next.return.time &&
+              isDateTimeBefore(next.return.time, value)
+            ) {
+              next.return = { ...next.return, time: '' };
+            }
+            return { flightForm: next };
+          });
         },
 
         addAccommodation: () => {
@@ -93,9 +112,19 @@ export const useDumpStore = create<DumpStore>()(
 
         updateAccommodation: (id, field, value) => {
           set((s) => ({
-            accommodations: s.accommodations.map((a) =>
-              a.id === id ? { ...a, [field]: value } : a
-            ),
+            accommodations: s.accommodations.map((a) => {
+              if (a.id !== id) return a;
+              const next = { ...a, [field]: value };
+              // 체크인을 체크아웃보다 늦게 바꾸면 무효해진 체크아웃 정리
+              if (
+                field === 'checkIn' &&
+                next.checkOut &&
+                isDateTimeBefore(next.checkOut, value)
+              ) {
+                next.checkOut = '';
+              }
+              return next;
+            }),
           }));
         },
 


### PR DESCRIPTION
## 📝 작업 내용

> 덤프 보조정보(항공/숙소)의 날짜를 수동 텍스트 입력에서 캘린더+시간 피커로 바꾸고, 항공편을 출발/귀국 두 편으로 나눠 정확히 전송하도록 수정

- **날짜 입력 피커화**: 항공 시간·숙소 체크인/체크아웃을 `DumpDateTimeField`(Popover + Calendar + 시간)로 통일. 저장 형식 `"yyyy-MM-dd HH:mm"`

- **날짜 정합성(양방향)**: 체크아웃<체크인 / 귀국<출발 방지
  - 앞 방향: 캘린더에서 이전 날짜 비활성 + 같은 날 이른 시간 보정(`min`)
  - 뒤 방향: 체크인/출발을 더 늦게 바꾸면 무효해진 값 store에서 정리(`isDateTimeBefore`)

- **항공편 입력 제한**: 영문·숫자만 허용 + 대문자 변환(`KE123`)

- **API 전송 분리**: 기존엔 한 편(`departure_flight`)으로 합쳐 귀국 편명·시간이 유실되고 `return_flight` 미전송이던 것을, 섹션별로 `departure_flight`/`return_flight` 각각 빌드해 전송

- shadcn `popover`/`calendar` 추가

## 🔗 관련 이슈

closes #210

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.


## 📸 스크린샷
<img width="326" height="516" alt="image" src="https://github.com/user-attachments/assets/05af9239-33ef-4bad-8b4f-230f7eaf9f29" />
