### PR TITLE
Fix: 배치 화면 Day 카드 수·헤더 메타(위치·인원·날짜) 표시 오류 수정

### DIFF
--- a/apps/frontend/src/components/onboarding/calendar/ExactCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/ExactCalendar.tsx
@@ -35,7 +35,7 @@ export const ExactCalendar = () => {
     if (from && to) {
       const nights = differenceInDays(to, from);
       setExactDate({ from, to, nights });
-      setForm({ travel_days: nights });
+      setForm({ travel_days: nights + 1 });
     } else {
       clearExactDate();
       setForm({ travel_days: 0 });

--- a/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
@@ -37,7 +37,7 @@ const FlexCalendar = () => {
     setSelectedMonth(month);
     if (durationNights !== null) {
       setFlexDate({ year: selectedYear, month, nights: durationNights });
-      setForm({ travel_days: durationNights });
+      setForm({ travel_days: durationNights + 1 });
     }
   };
 
@@ -46,7 +46,7 @@ const FlexCalendar = () => {
 
     if (selectedMonth) {
       setFlexDate({ year: selectedYear, month: selectedMonth, nights });
-      setForm({ travel_days: nights });
+      setForm({ travel_days: nights + 1 });
     }
   };
 

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -8,6 +8,7 @@
 //  - "동선 검증하기" = POST /verify, "일정 확정하기" = POST /confirm 로 전체 배치 스냅샷을 전송한다.
 //    (백엔드에 카드별 day 저장 API 가 없어 스냅샷 일괄 전송만 가능)
 
+import { format } from 'date-fns';
 import { ArrowLeft, ArrowRight, Plus } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -44,6 +45,10 @@ import {
   mapToArrangeViewModel,
 } from '../utils/arrange-mapper';
 import type { TripMeta } from '../utils/arrange-mapper';
+import {
+  useCalendarStore,
+  formatDateRangeLabel,
+} from '../utils/calendar-store';
 import { parseGroupingApiError } from '../utils/grouping-api';
 import { toCardAddRequest } from '../utils/grouping-mapper';
 import { useOnboardingStore } from '../utils/onboarding-store';
@@ -74,6 +79,7 @@ const ArrangePage = () => {
   const storeTripId = useOnboardingStore((s) => s.tripId);
   const setStoreTripId = useOnboardingStore((s) => s.actions.setTripId);
   const form = useOnboardingStore((s) => s.form);
+  const { type: calendarType, exactDate, flexDate } = useCalendarStore();
   const tripId: string | null = urlTripId ?? storeTripId;
 
   useEffect(() => {
@@ -97,9 +103,19 @@ const ArrangePage = () => {
       travelDays: detail?.travel_days ?? form.travel_days,
       destinations: detail?.destinations ?? form.destinations,
       travelers: detail?.companion_count ?? form.companion_count,
-      startDate: detail?.start_date ?? null,
+      // start_date 는 온보딩에서 백엔드로 전송하지 않아 보통 null 이다.
+      // 다른 화면(정리)과 동일하게 캘린더 스토어(사용자가 고른 날짜)로 폴백한다.
+      startDate:
+        detail?.start_date ??
+        (exactDate ? format(exactDate.from, 'yyyy-MM-dd') : null),
     }),
-    [detail, form.travel_days, form.destinations, form.companion_count]
+    [
+      detail,
+      form.travel_days,
+      form.destinations,
+      form.companion_count,
+      exactDate,
+    ]
   );
 
   // 좌측 stock + 헤더 메타. (Day 보드 로딩과 무관하게 먼저 그릴 수 있다.)
@@ -343,11 +359,22 @@ const ArrangePage = () => {
     ? 'tripId가 없습니다. /onboarding 으로 여행을 먼저 만들거나 URL에 ?tripId=… 를 추가하세요.'
     : null;
 
-  const summary = viewModel?.summary ?? {
+  const baseSummary = viewModel?.summary ?? {
     destination: form.destinations[0] ?? '여행',
     extraDestinations: Math.max(form.destinations.length - 1, 0),
     travelers: form.companion_count,
     dateRange: '-',
+  };
+  // 날짜 표기는 정리 화면과 동일하게 캘린더 스토어를 우선으로 쓰고,
+  // 스토어가 비어 있으면(새로고침 등) 백엔드 start_date 로 만든 범위로 폴백한다.
+  const storeDateRange = formatDateRangeLabel(
+    calendarType,
+    exactDate,
+    flexDate
+  );
+  const summary = {
+    ...baseSummary,
+    dateRange: storeDateRange !== '-' ? storeDateRange : baseSummary.dateRange,
   };
   const heading = viewModel?.heading ?? {
     title: '일정 배치',


### PR DESCRIPTION
## 📝 작업 내용

- 배치 화면

-  ① 2박3일인데 Day 카드가 2개만 뜨던 문제 수정

- ② 헤더의 위치·인원·날짜가 다른 화면과 다르게 표시(특히 날짜 `-`)되던 문제 수정

## 🔗 관련 이슈

closes #217

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- **원인 1 (Day 카드 수):** 온보딩 캘린더가 `travel_days`에 일수가 아닌 **박수**를 저장하고 있었습니다(`differenceInDays`). `travel_days`는 다른 화면(`grouping-mapper`, `trip-meta`)에서 이미 "일수"로 해석하므로, 저장 시 `+1`로 통일했습니다.

- **원인 2 (헤더 날짜):** `start_date`는 온보딩에서 백엔드로 전송하지 않아 `GET /trips`에서 보통 `null`로 내려옵니다. 그래서 배치 헤더 날짜가 `-`로 떴습니다. 정리 화면과 동일하게 **캘린더 스토어(exact/flex)** 로 폴백하도록 맞췄고, `meta.startDate` 폴백으로 Day 컬럼 날짜 라벨도 함께 채워집니다. 스토어가 비면(새로고침 등) 백엔드 `start_date` 기반 범위로 폴백합니다.

## 📸 스크린샷
