### PR TITLE
Chore: '동행자 수' 라벨 '여행 인원'으로 문구 수정

### DIFF
--- a/apps/frontend/src/components/grouping/TripSummaryCard.tsx
+++ b/apps/frontend/src/components/grouping/TripSummaryCard.tsx
@@ -63,7 +63,7 @@ const TripSummaryCard = ({
           </span>
         </SummaryRow>
 
-        <SummaryRow icon={User} label="동행자">
+        <SummaryRow icon={User} label="여행 인원">
           <span className="font-semibold text-foreground">{travelers}명</span>
         </SummaryRow>
 

--- a/apps/frontend/src/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/pages/OnboardingPage.tsx
@@ -118,7 +118,7 @@ const OnboardingPage = () => {
             </section>
 
             <section className="onboarding-page__card onboarding-page__traveler">
-              <TravelerCount title="동행자 수" />
+              <TravelerCount title="여행 인원" />
               <TravelerReservation title="여행 예약 상태" />
             </section>
           </div>


### PR DESCRIPTION
## 📝 작업 내용

> 인원 입력/표시 라벨을 "동행자(수)"에서 "여행 인원"으로 통일

## 🔗 관련 이슈

closes #219 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- 온보딩: `OnboardingPage.tsx:121` `동행자 수` → `여행 인원`
- 정리 요약: `TripSummaryCard.tsx:66` `동행자` → `여행 인원`

## 📸 스크린샷
