### PR TITLE
fix(be): #226 SCR-04 그룹 라벨에 주소 원문 노출되는 문제 수정

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupRegionLabelResolver.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupRegionLabelResolver.java
@@ -1,0 +1,316 @@
+package com.tripkey.domain.group;
+
+import com.tripkey.domain.place.PlaceCard;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class GroupRegionLabelResolver {
+
+    static final String FALLBACK_LABEL = "기타";
+
+    private static final int MAX_LABEL_LENGTH = 40;
+    private static final Pattern KOREAN_DISTRICT = Pattern.compile("([가-힣]{1,12}(?:구|군))");
+    private static final Pattern KOREAN_CITY = Pattern.compile("([가-힣]{1,12}시)");
+    private static final Pattern JAPANESE_ADMIN_BOUNDARY = Pattern.compile("[都道府県市郡町村\\s\\d〒-]");
+
+    public String resolve(List<PlaceCard> cards, List<String> destinations) {
+        List<String> locations = cards.stream()
+                .map(PlaceCard::getLocation)
+                .toList();
+        List<String> cardNames = cards.stream()
+                .map(PlaceCard::getName)
+                .toList();
+        return resolveValues(locations, cardNames, destinations);
+    }
+
+    String resolveValues(List<String> locations, List<String> cardNames, List<String> destinations) {
+        String dominant = dominantCandidate(locations.stream()
+                .map(this::toCandidate)
+                .filter(Objects::nonNull)
+                .toList());
+        if (dominant != null) {
+            return dominant;
+        }
+
+        if (cardNames.size() == 1) {
+            String cardLabel = toSafeShortLabel(cardNames.get(0));
+            if (cardLabel != null) {
+                return cardLabel;
+            }
+        }
+
+        String destination = firstSafeDestination(destinations);
+        return destination != null ? destination : FALLBACK_LABEL;
+    }
+
+    String toCandidate(String raw) {
+        String normalized = normalize(raw);
+        if (normalized == null || isPlaceholder(normalized)) {
+            return null;
+        }
+
+        String korean = extractKoreanDistrict(normalized);
+        if (korean != null) {
+            return korean;
+        }
+
+        String japanese = extractJapaneseDistrict(normalized);
+        if (japanese != null) {
+            return japanese;
+        }
+
+        if (normalized.contains(",")) {
+            return fromCommaSeparatedAddress(normalized);
+        }
+
+        String stripped = stripAddressPrefix(normalized);
+        return toSafeShortLabel(stripped);
+    }
+
+    private String fromCommaSeparatedAddress(String value) {
+        List<String> tokens = splitCommaTokens(value);
+        if (tokens.isEmpty()) {
+            return null;
+        }
+
+        int adminIndex = firstAdministrativeTokenIndex(tokens);
+        if (adminIndex >= 0) {
+            for (int i = adminIndex + 1; i < tokens.size(); i++) {
+                String token = tokens.get(i);
+                if (looksLikeStreetAddress(token) || isAdministrativeToken(token)) {
+                    continue;
+                }
+                String candidate = toSafeShortLabel(stripAddressPrefix(token));
+                if (candidate != null && hasStreetTokenAfter(tokens, i)) {
+                    return candidate;
+                }
+            }
+
+            String adminCandidate = stripAdministrativeSuffix(tokens.get(adminIndex));
+            if (adminCandidate != null) {
+                return adminCandidate;
+            }
+        }
+
+        for (String token : tokens) {
+            if (looksLikeStreetAddress(token) || isAdministrativeToken(token)) {
+                continue;
+            }
+            String candidate = toSafeShortLabel(stripAddressPrefix(token));
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+
+        for (String token : tokens) {
+            String candidate = stripAdministrativeSuffix(token);
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+
+        for (String token : tokens) {
+            String candidate = toSafeShortLabel(stripAddressPrefix(token));
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static int firstAdministrativeTokenIndex(List<String> tokens) {
+        for (int i = 0; i < tokens.size(); i++) {
+            if (isAdministrativeToken(tokens.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean hasStreetTokenAfter(List<String> tokens, int index) {
+        for (int i = index + 1; i < tokens.size(); i++) {
+            if (looksLikeStreetAddress(tokens.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String dominantCandidate(List<String> candidates) {
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (String candidate : candidates) {
+            counts.merge(candidate, 1, Integer::sum);
+        }
+        return counts.entrySet().stream()
+                .max(Map.Entry.<String, Integer>comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+    }
+
+    private static List<String> splitCommaTokens(String value) {
+        List<String> tokens = new ArrayList<>();
+        for (String part : value.split(",")) {
+            String token = normalize(part);
+            if (token != null) {
+                tokens.add(token);
+            }
+        }
+        return tokens;
+    }
+
+    private static String extractKoreanDistrict(String value) {
+        Matcher district = KOREAN_DISTRICT.matcher(value);
+        String found = null;
+        while (district.find()) {
+            found = district.group(1);
+        }
+        if (found != null) {
+            return found;
+        }
+
+        Matcher city = KOREAN_CITY.matcher(value);
+        while (city.find()) {
+            found = city.group(1);
+        }
+        return found;
+    }
+
+    private static String extractJapaneseDistrict(String value) {
+        int index = value.indexOf('区');
+        if (index < 0) {
+            return null;
+        }
+
+        int start = index;
+        while (start > 0) {
+            String previous = value.substring(start - 1, start);
+            if (JAPANESE_ADMIN_BOUNDARY.matcher(previous).matches()) {
+                break;
+            }
+            start--;
+        }
+
+        String candidate = value.substring(start, index + 1).trim();
+        return toSafeShortLabel(candidate);
+    }
+
+    private static String stripAdministrativeSuffix(String token) {
+        String value = normalize(token);
+        if (value == null) {
+            return null;
+        }
+
+        for (String suffix : List.of(" Ward", " District", " City", " Prefecture")) {
+            if (value.endsWith(suffix)) {
+                return toSafeShortLabel(value.substring(0, value.length() - suffix.length()));
+            }
+        }
+        return null;
+    }
+
+    private static boolean isAdministrativeToken(String token) {
+        String lower = token.toLowerCase(Locale.ROOT);
+        return lower.endsWith(" ward")
+                || lower.endsWith(" district")
+                || lower.endsWith(" city")
+                || lower.endsWith(" prefecture");
+    }
+
+    private static String stripAddressPrefix(String value) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            return null;
+        }
+
+        String stripped = normalized
+                .replaceFirst("^〒\\s*\\d{3}-?\\d{4}\\s*", "")
+                .replaceFirst("(?i)^postal\\s+code\\s+\\d+[\\w-]*\\s*", "");
+
+        String[] parts = stripped.split("\\s+");
+        int start = 0;
+        while (start < parts.length - 1 && looksLikeAddressPrefixToken(parts[start])) {
+            start++;
+        }
+        return normalize(String.join(" ", java.util.Arrays.copyOfRange(parts, start, parts.length)));
+    }
+
+    private static boolean looksLikeAddressPrefixToken(String token) {
+        String lower = token.toLowerCase(Locale.ROOT);
+        return lower.matches(".*\\d.*")
+                || lower.equals("chome")
+                || lower.equals("chōme")
+                || lower.equals("丁目");
+    }
+
+    private static boolean looksLikeStreetAddress(String token) {
+        String value = normalize(token);
+        if (value == null) {
+            return false;
+        }
+        String lower = value.toLowerCase(Locale.ROOT);
+        if (lower.matches("^\\d+[\\w-]*(?:\\s+|$).*")) {
+            return true;
+        }
+        long digits = lower.chars().filter(Character::isDigit).count();
+        return digits >= 3 && digits * 2 >= lower.length();
+    }
+
+    private static String firstSafeDestination(List<String> destinations) {
+        if (destinations == null) {
+            return null;
+        }
+        return destinations.stream()
+                .map(GroupRegionLabelResolver::toSafeShortLabel)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static String toSafeShortLabel(String value) {
+        String normalized = normalize(value);
+        if (normalized == null || isPlaceholder(normalized)) {
+            return null;
+        }
+        if (normalized.length() > MAX_LABEL_LENGTH) {
+            return null;
+        }
+        if (normalized.contains(",")) {
+            return null;
+        }
+        if (looksLikeStreetAddress(normalized)) {
+            return null;
+        }
+        return normalized;
+    }
+
+    private static boolean isPlaceholder(String value) {
+        String lower = value.toLowerCase(Locale.ROOT);
+        return lower.equals("unknown")
+                || lower.equals("n/a")
+                || lower.equals("none")
+                || lower.equals("null")
+                || lower.equals("주소 미정")
+                || lower.equals("미정");
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim().replaceAll("\\s+", " ");
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
@@ -180,14 +180,44 @@ public class GroupService {
     private static String dominantLocation(List<PlaceCard> cards) {
         return cards.stream()
                 .map(PlaceCard::getLocation)
+                .map(GroupService::toRegionLabel)
                 .filter(Objects::nonNull)
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
                 .collect(Collectors.groupingBy(s -> s, Collectors.counting()))
                 .entrySet().stream()
                 .max(Map.Entry.<String, Long>comparingByValue())
                 .map(Map.Entry::getKey)
                 .orElse(FALLBACK_LABEL);
+    }
+
+    /**
+     * 주소 원문을 그룹 라벨용 짧은 지역명으로 축약한다.
+     * 예: "5-55 Chausuyamacho, Tennoji Ward, Osaka" -> "Tennoji",
+     *     "Dotonbori, Osaka" -> "Osaka", "시부야" -> "시부야".
+     * 클러스터가 1장짜리여도 주소 원문이 그대로 그룹 제목이 되지 않도록 한다.
+     * 축약할 토큰이 없으면 null 을 반환해 상위 dominantLocation 의 폴백(기타)에 맡긴다.
+     */
+    private static String toRegionLabel(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        List<String> tokens = new ArrayList<>();
+        for (String part : raw.split(",")) {
+            String token = part.trim();
+            if (!token.isEmpty()) {
+                tokens.add(token);
+            }
+        }
+        if (tokens.isEmpty()) {
+            return null;
+        }
+        // 1순위: "~ Ward" 행정구 토큰 -> "Ward" 를 떼어낸 지역명 (예: "Tennoji Ward" -> "Tennoji")
+        for (String token : tokens) {
+            if (token.endsWith(" Ward")) {
+                return token.substring(0, token.length() - " Ward".length()).trim();
+            }
+        }
+        // 2순위: 마지막 토큰(보통 도시명). 콤마가 없으면 원문 그대로 — 이미 짧은 지역명.
+        return tokens.get(tokens.size() - 1);
     }
 
     private static List<CardDto> toSortedDtos(List<PlaceCard> cards) {

--- a/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/group/GroupService.java
@@ -3,6 +3,8 @@ package com.tripkey.domain.group;
 import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripDestination;
+import com.tripkey.domain.trip.TripDestinationRepository;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.group.Groups03Response;
@@ -17,7 +19,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -27,10 +28,11 @@ public class GroupService {
 
     private static final double SCR04_CLUSTER_EPS_METERS = 1500.0;
     private static final int SCR04_CLUSTER_MIN_POINTS = 1;
-    private static final String FALLBACK_LABEL = "기타";
 
     private final TripRepository tripRepository;
+    private final TripDestinationRepository tripDestinationRepository;
     private final PlaceCardRepository placeCardRepository;
+    private final GroupRegionLabelResolver groupRegionLabelResolver;
 
     @Transactional(readOnly = true)
     public Groups03Response getGroups03(UUID tripId) {
@@ -108,7 +110,8 @@ public class GroupService {
             availableCandidates.add(card);
         }
 
-        List<StockGroup> available = clusterIntoStockGroups(tripId, availableCandidates);
+        List<String> destinations = tripDestinations(tripId);
+        List<StockGroup> available = clusterIntoStockGroups(tripId, availableCandidates, destinations);
 
         return Groups04Response.of(
                 available,
@@ -118,7 +121,7 @@ public class GroupService {
         );
     }
 
-    private List<StockGroup> clusterIntoStockGroups(UUID tripId, List<PlaceCard> candidates) {
+    private List<StockGroup> clusterIntoStockGroups(UUID tripId, List<PlaceCard> candidates, List<String> destinations) {
         if (candidates.isEmpty()) {
             return List.of();
         }
@@ -144,7 +147,10 @@ public class GroupService {
         record LabeledCluster(int clusterId, String dominantLabel, List<PlaceCard> cards) {}
 
         List<LabeledCluster> clusters = cardsByCluster.entrySet().stream()
-                .map(e -> new LabeledCluster(e.getKey(), dominantLocation(e.getValue()), e.getValue()))
+                .map(e -> new LabeledCluster(
+                        e.getKey(),
+                        groupRegionLabelResolver.resolve(e.getValue(), destinations),
+                        e.getValue()))
                 .toList();
 
         Map<String, List<LabeledCluster>> byLabel = clusters.stream()
@@ -177,47 +183,16 @@ public class GroupService {
         return result;
     }
 
-    private static String dominantLocation(List<PlaceCard> cards) {
-        return cards.stream()
-                .map(PlaceCard::getLocation)
-                .map(GroupService::toRegionLabel)
-                .filter(Objects::nonNull)
-                .collect(Collectors.groupingBy(s -> s, Collectors.counting()))
-                .entrySet().stream()
-                .max(Map.Entry.<String, Long>comparingByValue())
-                .map(Map.Entry::getKey)
-                .orElse(FALLBACK_LABEL);
-    }
-
-    /**
-     * 주소 원문을 그룹 라벨용 짧은 지역명으로 축약한다.
-     * 예: "5-55 Chausuyamacho, Tennoji Ward, Osaka" -> "Tennoji",
-     *     "Dotonbori, Osaka" -> "Osaka", "시부야" -> "시부야".
-     * 클러스터가 1장짜리여도 주소 원문이 그대로 그룹 제목이 되지 않도록 한다.
-     * 축약할 토큰이 없으면 null 을 반환해 상위 dominantLocation 의 폴백(기타)에 맡긴다.
-     */
-    private static String toRegionLabel(String raw) {
-        if (raw == null) {
-            return null;
+    private List<String> tripDestinations(UUID tripId) {
+        List<TripDestination> destinations = tripDestinationRepository.findByTripTripIdOrderBySortOrder(tripId);
+        if (destinations == null) {
+            return List.of();
         }
-        List<String> tokens = new ArrayList<>();
-        for (String part : raw.split(",")) {
-            String token = part.trim();
-            if (!token.isEmpty()) {
-                tokens.add(token);
-            }
-        }
-        if (tokens.isEmpty()) {
-            return null;
-        }
-        // 1순위: "~ Ward" 행정구 토큰 -> "Ward" 를 떼어낸 지역명 (예: "Tennoji Ward" -> "Tennoji")
-        for (String token : tokens) {
-            if (token.endsWith(" Ward")) {
-                return token.substring(0, token.length() - " Ward".length()).trim();
-            }
-        }
-        // 2순위: 마지막 토큰(보통 도시명). 콤마가 없으면 원문 그대로 — 이미 짧은 지역명.
-        return tokens.get(tokens.size() - 1);
+        return destinations.stream()
+                .map(TripDestination::getName)
+                .filter(name -> name != null && !name.isBlank())
+                .distinct()
+                .toList();
     }
 
     private static List<CardDto> toSortedDtos(List<PlaceCard> cards) {

--- a/apps/backend/src/test/java/com/tripkey/domain/group/GroupRegionLabelResolverTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/GroupRegionLabelResolverTest.java
@@ -1,0 +1,87 @@
+package com.tripkey.domain.group;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GroupRegionLabelResolverTest {
+
+    private final GroupRegionLabelResolver resolver = new GroupRegionLabelResolver();
+
+    @Test
+    void keepsAlreadyShortRegionName() {
+        assertThat(resolver.toCandidate("시부야")).isEqualTo("시부야");
+        assertThat(resolver.toCandidate("Tennoji")).isEqualTo("Tennoji");
+    }
+
+    @Test
+    void shortensWardAddressToWardNameWhenOnlyCityFollows() {
+        assertThat(resolver.toCandidate("5-55 Chausuyamacho, Tennoji Ward, Osaka"))
+                .isEqualTo("Tennoji");
+    }
+
+    @Test
+    void prefersSpecificNeighborhoodAfterWardWhenStreetTokenFollows() {
+        assertThat(resolver.toCandidate("Osaka, Chuo Ward, Nishishinsaibashi, 1-chome-10-28"))
+                .isEqualTo("Nishishinsaibashi");
+    }
+
+    @Test
+    void stripsNumericAddressPrefixFromSingleTokenAddress() {
+        assertThat(resolver.toCandidate("1-chome-10-28 Nishishinsaibashi"))
+                .isEqualTo("Nishishinsaibashi");
+    }
+
+    @Test
+    void prefersSpecificTokenBeforeCityWhenNoAdministrativeTokenExists() {
+        assertThat(resolver.toCandidate("Dotonbori, Osaka"))
+                .isEqualTo("Dotonbori");
+    }
+
+    @Test
+    void extractsKoreanDistrictFromKoreanAddress() {
+        assertThat(resolver.toCandidate("서울특별시 마포구 월드컵북로 123"))
+                .isEqualTo("마포구");
+    }
+
+    @Test
+    void extractsJapaneseDistrictFromJapaneseAddress() {
+        assertThat(resolver.toCandidate("〒543-0063 大阪府大阪市天王寺区茶臼山町5-55"))
+                .isEqualTo("天王寺区");
+    }
+
+    @Test
+    void fallsBackToSingleCardNameWhenNoLocationCandidateExists() {
+        assertThat(resolver.resolveValues(List.of("unknown"), List.of("덴노지 공원"), List.of("오사카")))
+                .isEqualTo("덴노지 공원");
+    }
+
+    @Test
+    void fallsBackToDestinationForMultiCardClusterWithoutLocationCandidates() {
+        assertThat(resolver.resolveValues(
+                List.of("unknown", "주소 미정"),
+                List.of("A", "B"),
+                List.of("오사카")))
+                .isEqualTo("오사카");
+    }
+
+    @Test
+    void usesFallbackLabelOnlyWhenNoCandidateCardNameOrDestinationExists() {
+        assertThat(resolver.resolveValues(List.of("unknown"), List.of(""), List.of()))
+                .isEqualTo("기타");
+    }
+
+    @Test
+    void resolvesDominantCandidateWithinCluster() {
+        assertThat(resolver.resolveValues(
+                List.of(
+                        "5-55 Chausuyamacho, Tennoji Ward, Osaka",
+                        "1-82 Kintaicho, Tennoji Ward, Osaka",
+                        "Dotonbori, Osaka"),
+                List.of("A", "B", "C"),
+                List.of("오사카")))
+                .isEqualTo("Tennoji");
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
@@ -317,6 +317,84 @@ class GroupServiceTest {
     }
 
     @Test
+    void getGroups04ShortensRawStreetAddressToWardLabel() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(135.5063, 34.6543), "5-55 Chausuyamacho, Tennoji Ward, Osaka", at(10, 0));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.<Object[]>of(new Object[]{a.getInstanceId(), 0}));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(1);
+        assertThat(response.available().get(0).label()).isEqualTo("Tennoji");
+    }
+
+    @Test
+    void getGroups04NormalizesDifferentStreetAddressesWithSameWardIntoOneLabel() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(135.5063, 34.6543), "5-55 Chausuyamacho, Tennoji Ward, Osaka", at(10, 0));
+        PlaceCard b = stockCard(tripId, "ready_partial", "completed",
+                point(135.5100, 34.6550), "1-82 Kintaicho, Tennoji Ward, Osaka", at(10, 1));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a, b));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.of(
+                        new Object[]{a.getInstanceId(), 0},
+                        new Object[]{b.getInstanceId(), 0}
+                ));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(1);
+        assertThat(response.available().get(0).label()).isEqualTo("Tennoji");
+        assertThat(response.available().get(0).cards()).hasSize(2);
+    }
+
+    @Test
+    void getGroups04FallsBackToCityTokenWhenNoWardInAddress() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(135.5010, 34.6687), "Dotonbori, Osaka", at(10, 0));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.<Object[]>of(new Object[]{a.getInstanceId(), 0}));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(1);
+        assertThat(response.available().get(0).label()).isEqualTo("Osaka");
+    }
+
+    @Test
+    void getGroups04KeepsAlreadyShortLocationNameUnchanged() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard a = stockCard(tripId, "ready_partial", "completed",
+                point(139.7016, 35.6586), "시부야", at(10, 0));
+
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(a));
+        when(placeCardRepository.clusterAvailableCards(eq(tripId), anyDouble(), anyInt()))
+                .thenReturn(List.<Object[]>of(new Object[]{a.getInstanceId(), 0}));
+
+        Groups04Response response = groupService.getGroups04(tripId);
+
+        assertThat(response.available()).hasSize(1);
+        assertThat(response.available().get(0).label()).isEqualTo("시부야");
+    }
+
+    @Test
     void reorderGroupsThrowsTripNotFoundWhenTripMissing() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(false);

--- a/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/group/GroupServiceTest.java
@@ -3,6 +3,7 @@ package com.tripkey.domain.group;
 import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripDestinationRepository;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.card.CardDto;
 import com.tripkey.dto.group.Groups03Response;
@@ -16,6 +17,7 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
@@ -43,6 +45,12 @@ class GroupServiceTest {
 
     @Mock
     private PlaceCardRepository placeCardRepository;
+
+    @Mock
+    private TripDestinationRepository tripDestinationRepository;
+
+    @Spy
+    private GroupRegionLabelResolver groupRegionLabelResolver = new GroupRegionLabelResolver();
 
     @InjectMocks
     private GroupService groupService;
@@ -299,7 +307,7 @@ class GroupServiceTest {
     }
 
     @Test
-    void getGroups04LabelsClusterAsFallbackWhenNoLocation() {
+    void getGroups04LabelsSingleCardClusterWithCardNameWhenNoLocation() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);
 
@@ -313,7 +321,7 @@ class GroupServiceTest {
         Groups04Response response = groupService.getGroups04(tripId);
 
         assertThat(response.available()).hasSize(1);
-        assertThat(response.available().get(0).label()).isEqualTo("기타");
+        assertThat(response.available().get(0).label()).isEqualTo("테스트 카드");
     }
 
     @Test
@@ -373,7 +381,7 @@ class GroupServiceTest {
         Groups04Response response = groupService.getGroups04(tripId);
 
         assertThat(response.available()).hasSize(1);
-        assertThat(response.available().get(0).label()).isEqualTo("Osaka");
+        assertThat(response.available().get(0).label()).isEqualTo("Dotonbori");
     }
 
     @Test


### PR DESCRIPTION
Closes #226

## 문제

SCR-04 그룹 화면에서 그룹 제목이 `"5-55 Chausuyamacho, Tennoji Ward, Osaka"` 같은 Places 주소 요약 원문으로 노출됨.

## 원인

클러스터링(DBSCAN)/eps 문제가 아님. 클러스터링은 정상 동작하나 `MIN_POINTS=1`이라 멀리 떨어진 장소는 1장짜리 클러스터가 되고, `GroupService.dominantLocation()`이 클러스터 내 `location` 최빈값을 라벨로 쓰기 때문에 카드가 1장이면 그 카드의 주소 원문이 그대로 그룹 제목이 됨.

## 변경

`dominantLocation()`이 `location` 원문을 그대로 쓰지 않고 `toRegionLabel()`로 정규화:

- `"5-55 Chausuyamacho, Tennoji Ward, Osaka"` -> `"Tennoji"` (`~ Ward` 행정구 추출)
- `"Dotonbori, Osaka"` -> `"Osaka"` (Ward 없으면 마지막 토큰 = 도시명)
- `"시부야"` -> `"시부야"` (콤마 없는 짧은 지역명은 그대로)
- 축약 불가 시 -> `"기타"` 폴백

## 테스트

- TDD: 주소 원문이 라벨로 새는 케이스를 재현하는 실패 테스트 작성 후 구현
- `GroupServiceTest` 21개 + 전체 백엔드 스위트 통과 (무회귀)

## 테스트 - 리팩토링 부분

- `./gradlew test` 통과
- `GroupServiceTest`, `GroupRegionLabelResolverTest` 포함 전체 백엔드 테스트 통과

## 한계 / 후속

- 본 PR은 백엔드 문자열 휴리스틱(1단계 즉시 수정)으로 Google Places 영어 콤마 주소 형식 기준. 한국어/일본어/콤마 없는 형식은 일부 빗나갈 수 있으나, 마지막 토큰 폴백으로 "주소 원문 통째 노출"은 제거됨.
- 정확도 향상은 후속 이슈로 `region_label` 컬럼 + Places `address_components` 구조화 추출(2단계) 권장.

## 추가 리팩토링 - oevinqu
초기 구현은 `GroupService` 내부 `toRegionLabel()`에서 `Ward` 중심으로 주소를 축약했지만, 그룹 라벨 정책이 영어/원어 지명, 한국어·일본어 주소, 숫자 주소, fallback까지 다뤄야 해서 별도 resolver로 분리했습니다.

- `GroupRegionLabelResolver` 추가
  - raw `location`을 화면 표시 가능한 그룹 라벨 후보로 변환
  - 영어/원어 지명은 유효한 라벨 후보로 허용
  - 단, 숫자 주소/우편번호/상세 주소 원문은 라벨 후보에서 제외
  - 영어 지명을 한국어로 번역/음역하지는 않음

- 주소 라벨 후보 추출 정책 확장
  - 행정 suffix 처리: `Tennoji Ward` -> `Tennoji`
  - 숫자 prefix 제거: `1-chome-10-28 Nishishinsaibashi` -> `Nishishinsaibashi`
  - 콤마 주소에서 구체 지명 우선: `Dotonbori, Osaka` -> `Dotonbori`
  - 한국어 주소 일부 처리: `서울특별시 마포구 ...` -> `마포구`
  - 일본어 주소 일부 처리: `大阪市天王寺区...` -> `天王寺区`

- fallback 정책 추가
  - 지역 후보 없음 -> 단일 카드명 -> 여행지명 -> `기타`
  - `기타 1`, `기타 2`처럼 의미가 약한 그룹명이 남발되는 것을 줄임

- `GroupService` 책임 정리
  - `GroupService`는 카드 필터링, 좌표 기반 클러스터링, `StockGroup` 조립만 담당
  - 그룹 라벨 결정은 `GroupRegionLabelResolver`에 위임