### PR TITLE
Feat/199 be confirm summary contract

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/common/exception/ConfirmSummaryNotFoundException.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/ConfirmSummaryNotFoundException.java
@@ -1,0 +1,10 @@
+package com.tripkey.common.exception;
+
+import java.util.UUID;
+
+public class ConfirmSummaryNotFoundException extends RuntimeException {
+
+    public ConfirmSummaryNotFoundException(UUID tripId) {
+        super("확정 요약을 찾을 수 없어요. tripId=" + tripId);
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/com/tripkey/common/exception/GlobalExceptionHandler.java
@@ -72,6 +72,12 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse("CONFIRM_ALL_EXCLUDED", e.getMessage()));
     }
 
+    @ExceptionHandler(ConfirmSummaryNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleConfirmSummaryNotFound(ConfirmSummaryNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("CONFIRM_SUMMARY_NOT_FOUND", "확정 요약을 찾을 수 없어요"));
+    }
+
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ErrorResponse> handleMissingParam(MissingServletRequestParameterException e) {
         if ("view".equals(e.getParameterName())) {

--- a/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmService.java
@@ -30,6 +30,7 @@ public class ConfirmService {
     private final TripRepository tripRepository;
     private final PlaceCardRepository placeCardRepository;
     private final VerifyService verifyService;
+    private final ConfirmSummaryService confirmSummaryService;
 
     @Transactional
     public PlacementSaveResponse confirmAndSave(UUID tripId, PlacementSaveRequest request) {
@@ -45,6 +46,11 @@ public class ConfirmService {
 
         PlacementSaveResponse verifyResponse = verifyService.verifyAndSave(tripId, request);
         trip.confirm();
+        confirmSummaryService.generateRuleBasedSummary(
+                tripId,
+                verifyResponse.routeWarnings(),
+                verifyResponse.routeLegs()
+        );
 
         return PlacementSaveResponse.of(
                 tripId,

--- a/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmSummary.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmSummary.java
@@ -1,0 +1,78 @@
+package com.tripkey.domain.confirm;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "confirm_summaries")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConfirmSummary {
+
+    public static final String STATUS_COMPLETED = "completed";
+    public static final String GENERATION_MODE_RULE_BASED = "rule_based";
+
+    @Id
+    @Column(name = "trip_id", columnDefinition = "uuid")
+    private UUID tripId;
+
+    @Column(name = "status", nullable = false, columnDefinition = "text")
+    private String status;
+
+    @Column(name = "generation_mode", nullable = false, columnDefinition = "text")
+    private String generationMode;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "summary_json", nullable = false, columnDefinition = "jsonb")
+    private String summaryJson;
+
+    @Column(name = "generated_at")
+    private OffsetDateTime generatedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public static ConfirmSummary createRuleBased(UUID tripId, String summaryJson) {
+        ConfirmSummary summary = new ConfirmSummary();
+        summary.tripId = tripId;
+        summary.status = STATUS_COMPLETED;
+        summary.generationMode = GENERATION_MODE_RULE_BASED;
+        summary.summaryJson = summaryJson;
+        summary.generatedAt = OffsetDateTime.now();
+        return summary;
+    }
+
+    public void replaceRuleBasedSnapshot(String summaryJson) {
+        this.status = STATUS_COMPLETED;
+        this.generationMode = GENERATION_MODE_RULE_BASED;
+        this.summaryJson = summaryJson;
+        this.generatedAt = OffsetDateTime.now();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmSummaryController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmSummaryController.java
@@ -1,0 +1,24 @@
+package com.tripkey.domain.confirm;
+
+import com.tripkey.dto.confirm.ConfirmSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/trips/{tripId}/confirm-summary")
+@RequiredArgsConstructor
+public class ConfirmSummaryController {
+
+    private final ConfirmSummaryService confirmSummaryService;
+
+    @GetMapping
+    public ResponseEntity<ConfirmSummaryResponse> getConfirmSummary(@PathVariable UUID tripId) {
+        return ResponseEntity.ok(confirmSummaryService.getConfirmSummary(tripId));
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmSummaryRepository.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmSummaryRepository.java
@@ -1,0 +1,8 @@
+package com.tripkey.domain.confirm;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ConfirmSummaryRepository extends JpaRepository<ConfirmSummary, UUID> {
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmSummaryService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/confirm/ConfirmSummaryService.java
@@ -1,0 +1,492 @@
+package com.tripkey.domain.confirm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tripkey.common.exception.ConfirmSummaryNotFoundException;
+import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.Trip;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.confirm.ConfirmSummaryResponse;
+import com.tripkey.dto.placement.RouteLeg;
+import com.tripkey.dto.placement.RouteWarning;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ConfirmSummaryService {
+
+    private static final LocalTime DAY_START = LocalTime.of(9, 0);
+    private static final DateTimeFormatter HH_MM = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final TripRepository tripRepository;
+    private final PlaceCardRepository placeCardRepository;
+    private final ConfirmSummaryRepository confirmSummaryRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public ConfirmSummaryResponse getConfirmSummary(UUID tripId) {
+        if (!tripRepository.existsById(tripId)) {
+            throw new TripNotFoundException(tripId);
+        }
+
+        ConfirmSummary summary = confirmSummaryRepository.findById(tripId)
+                .orElseThrow(() -> new ConfirmSummaryNotFoundException(tripId));
+
+        return ConfirmSummaryResponse.of(summary, parseSummaryJson(summary.getSummaryJson()));
+    }
+
+    @Transactional
+    public ConfirmSummary generateRuleBasedSummary(
+            UUID tripId,
+            List<RouteWarning> routeWarnings,
+            List<RouteLeg> routeLegs
+    ) {
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new TripNotFoundException(tripId));
+
+        List<PlaceCard> placedCards = placeCardRepository.findAllByTripId(tripId).stream()
+                .filter(card -> card.getDay() != null)
+                .filter(card -> !Boolean.TRUE.equals(card.getIsExcluded()))
+                .sorted(Comparator
+                        .comparing(PlaceCard::getDay)
+                        .thenComparing(card -> card.getDayOrder() == null ? Short.MAX_VALUE : card.getDayOrder())
+                        .thenComparing(PlaceCard::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+
+        SummarySnapshot snapshot = buildSnapshot(trip, placedCards, safeList(routeWarnings), safeList(routeLegs));
+        String json = writeSnapshot(snapshot);
+
+        ConfirmSummary summary = confirmSummaryRepository.findById(tripId)
+                .orElseGet(() -> ConfirmSummary.createRuleBased(tripId, json));
+        if (summary.getTripId() != null) {
+            summary.replaceRuleBasedSnapshot(json);
+        }
+        return confirmSummaryRepository.save(summary);
+    }
+
+    private JsonNode parseSummaryJson(String json) {
+        try {
+            return objectMapper.readTree(json);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to parse confirm summary JSON", e);
+        }
+    }
+
+    private SummarySnapshot buildSnapshot(
+            Trip trip,
+            List<PlaceCard> placedCards,
+            List<RouteWarning> routeWarnings,
+            List<RouteLeg> routeLegs
+    ) {
+        Map<Integer, List<PlaceCard>> cardsByDay = placedCards.stream()
+                .collect(Collectors.groupingBy(
+                        PlaceCard::getDay,
+                        LinkedHashMap::new,
+                        Collectors.toList()));
+
+        Map<Integer, List<RouteWarning>> warningsByDay = routeWarnings.stream()
+                .filter(warning -> warning.day() != null)
+                .collect(Collectors.groupingBy(
+                        RouteWarning::day,
+                        LinkedHashMap::new,
+                        Collectors.toList()));
+
+        Set<Integer> dayNumbers = new LinkedHashSet<>();
+        for (int day = 1; day <= trip.getTravelDays(); day++) {
+            dayNumbers.add(day);
+        }
+        dayNumbers.addAll(cardsByDay.keySet());
+        dayNumbers.addAll(warningsByDay.keySet());
+
+        List<DaySnapshot> days = dayNumbers.stream()
+                .sorted()
+                .map(day -> buildDaySnapshot(
+                        day,
+                        cardsByDay.getOrDefault(day, List.of()),
+                        warningsByDay.getOrDefault(day, List.of()),
+                        routeLegs))
+                .toList();
+
+        return new SummarySnapshot(buildTripChecklist(placedCards), buildAlertCards(routeWarnings), days);
+    }
+
+    private DaySnapshot buildDaySnapshot(
+            int day,
+            List<PlaceCard> cards,
+            List<RouteWarning> warnings,
+            List<RouteLeg> routeLegs
+    ) {
+        List<ChecklistItem> checklist = new ArrayList<>();
+        int sequence = 1;
+
+        for (RouteWarning warning : warnings) {
+            checklist.add(new ChecklistItem(
+                    "day-%d-route-%d".formatted(day, sequence++),
+                    routeWarningLabel(warning),
+                    "route_warning",
+                    false,
+                    warning.instanceIds() == null ? List.of() : warning.instanceIds()
+            ));
+        }
+
+        for (PlaceCard card : cards) {
+            for (ChecklistItem item : cardChecklistItems(day, card)) {
+                checklist.add(item);
+            }
+        }
+
+        int totalMoveMinutes = routeLegs.stream()
+                .filter(leg -> leg.day() != null && leg.day() == day)
+                .map(RouteLeg::durationSeconds)
+                .filter(Objects::nonNull)
+                .mapToInt(seconds -> (int) Math.ceil(seconds / 60.0))
+                .sum();
+        int totalSpendMinutes = cards.stream()
+                .map(PlaceCard::getEstimatedDurationMin)
+                .filter(Objects::nonNull)
+                .mapToInt(Short::intValue)
+                .sum();
+
+        String primaryRegion = primaryRegion(cards);
+        String pace = pace(cards.size(), totalSpendMinutes);
+        Map<UUID, String> scheduledTimes = scheduledTimes(cards, routeLegs, day);
+        List<DayCardSnapshot> cardSnapshots = new ArrayList<>();
+        for (int i = 0; i < cards.size(); i++) {
+            PlaceCard card = cards.get(i);
+            cardSnapshots.add(dayCardSnapshot(card, i + 1, scheduledTimes.get(card.getInstanceId())));
+        }
+
+        return new DaySnapshot(
+                day,
+                dayTitle(day, cards, primaryRegion),
+                daySummary(primaryRegion, pace, totalSpendMinutes, totalMoveMinutes),
+                primaryRegion,
+                pace,
+                cards.size(),
+                cardSnapshots,
+                checklist,
+                totalMoveMinutes,
+                totalSpendMinutes
+        );
+    }
+
+    private List<AlertCardSnapshot> buildAlertCards(List<RouteWarning> routeWarnings) {
+        List<AlertCardSnapshot> alerts = new ArrayList<>();
+        int sequence = 1;
+        for (RouteWarning warning : routeWarnings) {
+            if (alerts.size() >= 4) {
+                break;
+            }
+            alerts.add(new AlertCardSnapshot(
+                    "alert-route-%d".formatted(sequence++),
+                    "실무 알림",
+                    "practical",
+                    routeWarningLabel(warning),
+                    warning.day(),
+                    warning.instanceIds() == null ? List.of() : warning.instanceIds()
+            ));
+        }
+        return alerts;
+    }
+
+    private List<ChecklistItem> buildTripChecklist(List<PlaceCard> placedCards) {
+        List<ChecklistItem> checklist = new ArrayList<>(List.of(
+                new ChecklistItem("trip-passport", "여권 유효기간을 확인하세요.", "template", false, List.of()),
+                new ChecklistItem("trip-insurance", "여행자 보험 가입 여부를 확인하세요.", "template", false, List.of()),
+                new ChecklistItem("trip-payment", "환전 또는 해외 결제 수단을 준비하세요.", "template", false, List.of()),
+                new ChecklistItem("trip-connectivity", "로밍 또는 eSIM 등 현지 통신 수단을 준비하세요.", "template", false, List.of())
+        ));
+
+        boolean hasFlight = placedCards.stream().anyMatch(card -> "transport".equals(card.getCategory())
+                && hasText(card.getFlightNumber()));
+        if (hasFlight) {
+            checklist.add(new ChecklistItem(
+                    "trip-flight-documents",
+                    "항공권을 모바일에 저장하고 탑승 시간을 확인하세요.",
+                    "card_rule",
+                    false,
+                    placedCards.stream()
+                            .filter(card -> "transport".equals(card.getCategory()) && hasText(card.getFlightNumber()))
+                            .map(PlaceCard::getInstanceId)
+                            .toList()
+            ));
+        }
+
+        return checklist;
+    }
+
+    private List<ChecklistItem> cardChecklistItems(int day, PlaceCard card) {
+        List<ChecklistItem> items = new ArrayList<>();
+        String prefix = "day-%d-card-%s".formatted(day, card.getInstanceId());
+
+        if ("accommodation".equals(card.getCategory())) {
+            items.add(new ChecklistItem(
+                    prefix + "-accommodation",
+                    "%s 체크인 시간과 예약 바우처를 확인하세요.".formatted(card.getName()),
+                    "card_rule",
+                    false,
+                    List.of(card.getInstanceId())
+            ));
+        }
+
+        if ("transport".equals(card.getCategory()) && hasText(card.getFlightNumber())) {
+            items.add(new ChecklistItem(
+                    prefix + "-flight",
+                    "%s 항공권과 탑승 시간을 확인하세요.".formatted(card.getName()),
+                    "card_rule",
+                    false,
+                    List.of(card.getInstanceId())
+            ));
+        }
+
+        if (hasText(card.getTimeConstraint())) {
+            items.add(new ChecklistItem(
+                    prefix + "-time",
+                    "%s의 시간 제약을 다시 확인하세요.".formatted(card.getName()),
+                    "card_rule",
+                    false,
+                    List.of(card.getInstanceId())
+            ));
+        }
+
+        if ("food".equals(card.getCategory())) {
+            items.add(new ChecklistItem(
+                    prefix + "-reservation",
+                    "%s 예약 필요 여부를 확인하세요.".formatted(card.getName()),
+                    "card_rule",
+                    false,
+                    List.of(card.getInstanceId())
+            ));
+        }
+
+        return items;
+    }
+
+    private Map<UUID, String> scheduledTimes(List<PlaceCard> cards, List<RouteLeg> routeLegs, int day) {
+        Map<UUID, Integer> travelSecondsByFromInstance = routeLegs.stream()
+                .filter(leg -> leg.day() != null && leg.day() == day)
+                .filter(leg -> leg.fromInstanceId() != null)
+                .collect(Collectors.toMap(
+                        RouteLeg::fromInstanceId,
+                        leg -> leg.durationSeconds() == null ? 0 : leg.durationSeconds(),
+                        (a, b) -> a,
+                        LinkedHashMap::new));
+
+        Map<UUID, String> result = new LinkedHashMap<>();
+        LocalTime clock = DAY_START;
+        for (PlaceCard card : cards) {
+            result.put(card.getInstanceId(), clock.format(HH_MM));
+            int durationMin = card.getEstimatedDurationMin() == null ? 0 : card.getEstimatedDurationMin();
+            int travelSeconds = travelSecondsByFromInstance.getOrDefault(card.getInstanceId(), 0);
+            clock = clock.plusMinutes(durationMin).plusSeconds(travelSeconds);
+        }
+        return result;
+    }
+
+    private DayCardSnapshot dayCardSnapshot(PlaceCard card, int order, String scheduledTime) {
+        return new DayCardSnapshot(
+                card.getInstanceId(),
+                order,
+                card.getName(),
+                card.getCategory(),
+                card.getLocation(),
+                scheduledTime,
+                card.getEstimatedDurationMin(),
+                card.getUserContext(),
+                card.getTips()
+        );
+    }
+
+    private String routeWarningLabel(RouteWarning warning) {
+        if ("distance".equals(warning.type())) {
+            return warning.message() + ". 이동 수단과 소요 시간을 미리 확인하세요.";
+        }
+        if ("duration".equals(warning.type())) {
+            return warning.message() + ". Day 일정에 휴식 시간을 확보하세요.";
+        }
+        return warning.message();
+    }
+
+    private String primaryRegion(List<PlaceCard> cards) {
+        Map<String, Long> counts = cards.stream()
+                .map(PlaceCard::getLocation)
+                .filter(ConfirmSummaryService::hasText)
+                .collect(Collectors.groupingBy(
+                        String::trim,
+                        LinkedHashMap::new,
+                        Collectors.counting()));
+        if (counts.isEmpty()) {
+            return "배치된 카드";
+        }
+
+        long maxCount = counts.values().stream().mapToLong(Long::longValue).max().orElse(0);
+        for (PlaceCard card : cards) {
+            String location = card.getLocation();
+            if (hasText(location) && counts.getOrDefault(location.trim(), 0L) == maxCount) {
+                return location.trim();
+            }
+        }
+        return counts.keySet().iterator().next();
+    }
+
+    private String pace(int cardCount, int totalSpendMinutes) {
+        if (cardCount == 0) {
+            return "buffer";
+        }
+        if (totalSpendMinutes <= 240) {
+            return "relaxed";
+        }
+        if (totalSpendMinutes <= 420) {
+            return "moderate";
+        }
+        return "busy";
+    }
+
+    private String dayTitle(int day, List<PlaceCard> cards, String primaryRegion) {
+        if (cards.isEmpty()) {
+            return "Day %d - 비워둔 완충 Day".formatted(day);
+        }
+
+        long transportCount = countCategory(cards, "transport");
+        long accommodationCount = countCategory(cards, "accommodation");
+        long foodCount = countCategory(cards, "food");
+        long placeActivityCount = countCategory(cards, "place") + countCategory(cards, "activity");
+
+        if (transportCount + accommodationCount == cards.size()) {
+            return "Day %d - 숙소와 이동 정리".formatted(day);
+        }
+        if (transportCount > placeActivityCount && transportCount >= foodCount) {
+            return "Day %d - 이동 정리 Day".formatted(day);
+        }
+        if (foodCount >= 2 && foodCount >= placeActivityCount) {
+            return "Day %d - 맛집 중심 일정".formatted(day);
+        }
+        if (!"배치된 카드".equals(primaryRegion)) {
+            return "Day %d - %s 일정".formatted(day, primaryRegion);
+        }
+        return "Day %d 일정".formatted(day);
+    }
+
+    private String daySummary(String primaryRegion, String pace, int totalSpendMinutes, int totalMoveMinutes) {
+        if ("buffer".equals(pace)) {
+            return "현재는 완충일로 남겨둔 상태예요. 쇼핑 후보나 제외했던 카드를 다시 넣을 수 있습니다.";
+        }
+
+        String paceLabel = switch (pace) {
+            case "relaxed" -> "여유로운";
+            case "busy" -> "빡빡한";
+            default -> "적당한";
+        };
+        String region = "배치된 카드".equals(primaryRegion) ? "배치된 카드" : primaryRegion;
+        String spend = formatMinutes(totalSpendMinutes);
+        if (totalMoveMinutes > 0) {
+            return "%s 중심의 %s 일정입니다. 체류 시간은 약 %s, 이동 시간은 약 %s입니다."
+                    .formatted(region, paceLabel, spend, formatMinutes(totalMoveMinutes));
+        }
+        return "%s 중심의 %s 일정입니다. 체류 시간은 약 %s입니다."
+                .formatted(region, paceLabel, spend);
+    }
+
+    private static long countCategory(List<PlaceCard> cards, String category) {
+        return cards.stream().filter(card -> category.equals(card.getCategory())).count();
+    }
+
+    private static String formatMinutes(int minutes) {
+        int hours = minutes / 60;
+        int rest = minutes % 60;
+        if (hours == 0) {
+            return "%d분".formatted(rest);
+        }
+        if (rest == 0) {
+            return "%d시간".formatted(hours);
+        }
+        return "%d시간 %d분".formatted(hours, rest);
+    }
+
+    private String writeSnapshot(SummarySnapshot snapshot) {
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize confirm summary snapshot", e);
+        }
+    }
+
+    private static <T> List<T> safeList(List<T> list) {
+        return list == null ? List.of() : list;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private record SummarySnapshot(
+            List<ChecklistItem> tripChecklist,
+            List<AlertCardSnapshot> alertCards,
+            List<DaySnapshot> days
+    ) {
+    }
+
+    private record DaySnapshot(
+            int day,
+            String title,
+            String summary,
+            String primaryRegion,
+            String pace,
+            int cardCount,
+            List<DayCardSnapshot> cards,
+            List<ChecklistItem> checklist,
+            int totalMoveMinutes,
+            int totalSpendMinutes
+    ) {
+    }
+
+    private record DayCardSnapshot(
+            UUID instanceId,
+            int order,
+            String name,
+            String category,
+            String location,
+            String scheduledTime,
+            Short estimatedDurationMin,
+            String userContext,
+            String tips
+    ) {
+    }
+
+    private record AlertCardSnapshot(
+            String id,
+            String kind,
+            String category,
+            String message,
+            Integer relatedDay,
+            List<UUID> relatedInstanceIds
+    ) {
+    }
+
+    private record ChecklistItem(
+            String id,
+            String label,
+            String source,
+            boolean done,
+            List<UUID> relatedInstanceIds
+    ) {
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/confirm/ConfirmSummaryResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/confirm/ConfirmSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.tripkey.dto.confirm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.tripkey.domain.confirm.ConfirmSummary;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ConfirmSummaryResponse(
+        UUID tripId,
+        String status,
+        String generationMode,
+        JsonNode summary,
+        OffsetDateTime generatedAt
+) {
+    public static ConfirmSummaryResponse of(ConfirmSummary entity, JsonNode summary) {
+        return new ConfirmSummaryResponse(
+                entity.getTripId(),
+                entity.getStatus(),
+                entity.getGenerationMode(),
+                summary,
+                entity.getGeneratedAt()
+        );
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
+++ b/apps/backend/src/test/java/com/tripkey/common/json/JsonNamingStrategyTest.java
@@ -1,6 +1,7 @@
 package com.tripkey.common.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tripkey.dto.confirm.ConfirmSummaryResponse;
 import com.tripkey.dto.dump.ParseJobStatusResponse;
 import com.tripkey.dto.trip.TripCreateResponse;
 import com.tripkey.dto.trip.TripDetailResponse;
@@ -149,5 +150,28 @@ class JsonNamingStrategyTest {
                 .doesNotContain("travelDays")
                 .doesNotContain("companionCount")
                 .doesNotContain("createdAt");
+    }
+
+    @Test
+    void serializesConfirmSummaryResponseFieldsAsSnakeCase() throws Exception {
+        ConfirmSummaryResponse response = new ConfirmSummaryResponse(
+                UUID.randomUUID(),
+                "completed",
+                "rule_based",
+                objectMapper.readTree("{\"trip_checklist\":[],\"days\":[]}"),
+                OffsetDateTime.parse("2026-06-18T12:00:00+09:00")
+        );
+
+        String json = objectMapper.writeValueAsString(response);
+
+        assertThat(json)
+                .contains("trip_id")
+                .contains("generation_mode")
+                .contains("generated_at")
+                .contains("summary")
+                .contains("trip_checklist")
+                .doesNotContain("tripId")
+                .doesNotContain("generationMode")
+                .doesNotContain("generatedAt");
     }
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmServiceTest.java
@@ -48,6 +48,9 @@ class ConfirmServiceTest {
     @Mock
     private VerifyService verifyService;
 
+    @Mock
+    private ConfirmSummaryService confirmSummaryService;
+
     @InjectMocks
     private ConfirmService confirmService;
 
@@ -144,6 +147,7 @@ class ConfirmServiceTest {
         assertThat(response.tripId()).isEqualTo(tripId);
         assertThat(trip.getConfirmedAt()).isNotNull();
         verify(verifyService).verifyAndSave(eq(tripId), eq(request));
+        verify(confirmSummaryService).generateRuleBasedSummary(eq(tripId), any(), any());
     }
 
     @Test
@@ -166,6 +170,7 @@ class ConfirmServiceTest {
         assertThat(response.saved()).isTrue();
         assertThat(trip.getConfirmedAt()).isNotNull();
         verify(verifyService).verifyAndSave(tripId, request);
+        verify(confirmSummaryService).generateRuleBasedSummary(eq(tripId), any(), any());
     }
 
     @Test
@@ -190,6 +195,7 @@ class ConfirmServiceTest {
         assertThat(second.saved()).isTrue();
         assertThat(trip.getConfirmedAt()).isNotNull();
         verify(verifyService, times(2)).verifyAndSave(tripId, request);
+        verify(confirmSummaryService, times(2)).generateRuleBasedSummary(eq(tripId), any(), any());
     }
 
     @Test
@@ -219,6 +225,7 @@ class ConfirmServiceTest {
 
         assertThat(response.skippedInstanceIds()).containsExactly(stale);
         assertThat(response.routeWarnings()).containsExactly(warning);
+        verify(confirmSummaryService).generateRuleBasedSummary(eq(tripId), eq(List.of(warning)), any());
     }
 
     @Test
@@ -246,6 +253,7 @@ class ConfirmServiceTest {
         PlacementSaveResponse response = confirmService.confirmAndSave(tripId, request);
 
         assertThat(response.routeLegs()).containsExactly(leg);
+        verify(confirmSummaryService).generateRuleBasedSummary(eq(tripId), any(), eq(List.of(leg)));
     }
 
     private PlaceCard placeCard(UUID tripId) {

--- a/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmSummaryControllerTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmSummaryControllerTest.java
@@ -1,0 +1,45 @@
+package com.tripkey.domain.confirm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tripkey.dto.confirm.ConfirmSummaryResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConfirmSummaryControllerTest {
+
+    @Mock
+    private ConfirmSummaryService confirmSummaryService;
+
+    @InjectMocks
+    private ConfirmSummaryController controller;
+
+    @Test
+    void getConfirmSummaryReturns200WithBody() throws Exception {
+        UUID tripId = UUID.randomUUID();
+        ConfirmSummaryResponse body = new ConfirmSummaryResponse(
+                tripId,
+                "completed",
+                "rule_based",
+                new ObjectMapper().readTree("{\"days\":[]}"),
+                OffsetDateTime.parse("2026-06-18T12:00:00+09:00")
+        );
+        when(confirmSummaryService.getConfirmSummary(tripId)).thenReturn(body);
+
+        ResponseEntity<ConfirmSummaryResponse> response = controller.getConfirmSummary(tripId);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(body);
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmSummaryServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmSummaryServiceTest.java
@@ -1,0 +1,150 @@
+package com.tripkey.domain.confirm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.tripkey.common.exception.ConfirmSummaryNotFoundException;
+import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.Trip;
+import com.tripkey.dto.confirm.ConfirmSummaryResponse;
+import com.tripkey.dto.placement.RouteLeg;
+import com.tripkey.dto.placement.RouteWarning;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConfirmSummaryServiceTest {
+
+    private final com.tripkey.domain.trip.TripRepository tripRepository =
+            mock(com.tripkey.domain.trip.TripRepository.class);
+    private final PlaceCardRepository placeCardRepository =
+            mock(PlaceCardRepository.class);
+    private final ConfirmSummaryRepository confirmSummaryRepository =
+            mock(ConfirmSummaryRepository.class);
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+    private final ConfirmSummaryService service =
+            new ConfirmSummaryService(tripRepository, placeCardRepository, confirmSummaryRepository, objectMapper);
+
+    @Test
+    void getConfirmSummaryReturnsStoredSnapshot() {
+        UUID tripId = UUID.randomUUID();
+        ConfirmSummary summary = ConfirmSummary.createRuleBased(
+                tripId,
+                "{\"trip_checklist\":[],\"days\":[{\"day\":1,\"checklist\":[]}]}"
+        );
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(confirmSummaryRepository.findById(tripId)).thenReturn(Optional.of(summary));
+
+        ConfirmSummaryResponse response = service.getConfirmSummary(tripId);
+
+        assertThat(response.tripId()).isEqualTo(tripId);
+        assertThat(response.status()).isEqualTo("completed");
+        assertThat(response.generationMode()).isEqualTo("rule_based");
+        assertThat(response.summary().get("trip_checklist").isArray()).isTrue();
+        assertThat(response.summary().get("days").get(0).get("day").asInt()).isEqualTo(1);
+        assertThat(response.generatedAt()).isNotNull();
+    }
+
+    @Test
+    void getConfirmSummaryThrowsTripNotFoundWhenTripMissing() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getConfirmSummary(tripId))
+                .isInstanceOf(TripNotFoundException.class);
+    }
+
+    @Test
+    void getConfirmSummaryThrowsSummaryNotFoundWhenSnapshotMissing() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(confirmSummaryRepository.findById(tripId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getConfirmSummary(tripId))
+                .isInstanceOf(ConfirmSummaryNotFoundException.class);
+    }
+
+    @Test
+    void generateRuleBasedSummaryStoresChecklistSnapshot() throws Exception {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard hotel = placeCard(tripId, "난바 호텔", "accommodation", 1, 1);
+        setField(hotel, "userContext", "체크인 이후 난바 근처를 잡았어요.");
+        setField(hotel, "tips", "숙소 바우처를 모바일에 저장해두면 좋아요.");
+        UUID nextId = UUID.randomUUID();
+        RouteWarning warning = RouteWarning.distance(1, hotel.getInstanceId(), nextId, 12_000);
+        RouteLeg leg = new RouteLeg(1, hotel.getInstanceId(), nextId, 900, 12_000, "transit", "google");
+
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(new Trip((short) 2, (short) 2)));
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(hotel));
+        when(confirmSummaryRepository.findById(tripId)).thenReturn(Optional.empty());
+        when(confirmSummaryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ConfirmSummary summary = service.generateRuleBasedSummary(
+                tripId,
+                List.of(warning),
+                List.of(leg)
+        );
+
+        var json = objectMapper.readTree(summary.getSummaryJson());
+        assertThat(summary.getStatus()).isEqualTo("completed");
+        assertThat(summary.getGenerationMode()).isEqualTo("rule_based");
+        assertThat(json.get("trip_checklist")).isNotNull();
+        assertThat(json.get("alert_cards").get(0).get("category").asText()).isEqualTo("practical");
+        assertThat(json.get("days").get(0).get("day").asInt()).isEqualTo(1);
+        assertThat(json.get("days").get(0).get("title").asText()).isEqualTo("Day 1 - 숙소와 이동 정리");
+        assertThat(json.get("days").get(0).get("summary").asText())
+                .isEqualTo("오사카 중심의 여유로운 일정입니다. 체류 시간은 약 1시간, 이동 시간은 약 15분입니다.");
+        assertThat(json.get("days").get(0).get("primary_region").asText()).isEqualTo("오사카");
+        assertThat(json.get("days").get(0).get("pace").asText()).isEqualTo("relaxed");
+        assertThat(json.get("days").get(0).get("card_count").asInt()).isEqualTo(1);
+        assertThat(json.get("days").get(0).get("total_move_minutes").asInt()).isEqualTo(15);
+        assertThat(json.get("days").get(0).get("cards").get(0).get("name").asText()).isEqualTo("난바 호텔");
+        assertThat(json.get("days").get(0).get("cards").get(0).get("scheduled_time").asText()).isEqualTo("09:00");
+        assertThat(json.get("days").get(0).get("cards").get(0).get("user_context").asText())
+                .isEqualTo("체크인 이후 난바 근처를 잡았어요.");
+        assertThat(json.get("days").get(0).get("cards").get(0).get("tips").asText())
+                .isEqualTo("숙소 바우처를 모바일에 저장해두면 좋아요.");
+        assertThat(json.get("days").get(0).get("checklist").get(0).get("source").asText())
+                .isEqualTo("route_warning");
+        assertThat(json.get("days").get(0).get("checklist").toString())
+                .contains("난바 호텔 체크인 시간과 예약 바우처를 확인하세요.");
+        assertThat(json.get("days").get(1).get("title").asText()).isEqualTo("Day 2 - 비워둔 완충 Day");
+        assertThat(json.get("days").get(1).get("pace").asText()).isEqualTo("buffer");
+        verify(confirmSummaryRepository).save(any(ConfirmSummary.class));
+    }
+
+    private PlaceCard placeCard(UUID tripId, String name, String category, int day, int order) {
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, name, category, "오사카", (short) 60, null, null, "15:00", null, null
+        );
+        setField(card, "instanceId", UUID.randomUUID());
+        setField(card, "day", day);
+        setField(card, "dayOrder", (short) order);
+        return card;
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field field = PlaceCard.class.getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmSummaryTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/confirm/ConfirmSummaryTest.java
@@ -1,0 +1,35 @@
+package com.tripkey.domain.confirm;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfirmSummaryTest {
+
+    @Test
+    void createRuleBasedInitializesCompletedSnapshot() {
+        UUID tripId = UUID.randomUUID();
+
+        ConfirmSummary summary = ConfirmSummary.createRuleBased(tripId, "{\"days\":[]}");
+
+        assertThat(summary.getTripId()).isEqualTo(tripId);
+        assertThat(summary.getStatus()).isEqualTo("completed");
+        assertThat(summary.getGenerationMode()).isEqualTo("rule_based");
+        assertThat(summary.getSummaryJson()).isEqualTo("{\"days\":[]}");
+        assertThat(summary.getGeneratedAt()).isNotNull();
+    }
+
+    @Test
+    void replaceRuleBasedSnapshotOverwritesPayloadAndMetadata() {
+        ConfirmSummary summary = ConfirmSummary.createRuleBased(UUID.randomUUID(), "{\"days\":[]}");
+
+        summary.replaceRuleBasedSnapshot("{\"trip_checklist\":[]}");
+
+        assertThat(summary.getStatus()).isEqualTo("completed");
+        assertThat(summary.getGenerationMode()).isEqualTo("rule_based");
+        assertThat(summary.getSummaryJson()).isEqualTo("{\"trip_checklist\":[]}");
+        assertThat(summary.getGeneratedAt()).isNotNull();
+    }
+}

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -135,3 +135,13 @@ create table route_legs_cache (
   created_at       timestamptz not null default now(),
   constraint uq_route_legs unique (origin_lat, origin_lng, dest_lat, dest_lng)
 );
+
+create table confirm_summaries (
+  trip_id          uuid        primary key references trips(trip_id),
+  status           text        not null,
+  generation_mode  text        not null,
+  summary_json     jsonb       not null,
+  generated_at     timestamptz,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);

--- a/shared/docs/migrations/V012__confirm_summaries.sql
+++ b/shared/docs/migrations/V012__confirm_summaries.sql
@@ -1,0 +1,13 @@
+-- TripKey migration: confirm_summaries table
+-- Scope: SCR-05 confirmed itinerary snapshot generated after confirm.
+-- Stores BE/AI generated output separately from existing parse/enrichment alert_cards.
+
+create table if not exists public.confirm_summaries (
+  trip_id          uuid        primary key references public.trips(trip_id),
+  status           text        not null,                       -- completed | pending | fallback | failed (initial MVP: completed)
+  generation_mode  text        not null,                       -- rule_based | ai | mixed
+  summary_json     jsonb       not null,                       -- SCR-05 internal snapshot payload
+  generated_at     timestamptz,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -164,3 +164,15 @@ create table if not exists public.route_legs_cache (
   created_at       timestamptz not null default now(),
   constraint uq_route_legs unique (origin_lat, origin_lng, dest_lat, dest_lng)
 );
+
+-- SCR-05 확정 일정 요약 Snapshot
+-- 기존 parse/enrichment alert_cards 와 분리된 확정 화면 전용 저장본
+create table if not exists public.confirm_summaries (
+  trip_id          uuid        primary key references public.trips(trip_id),
+  status           text        not null,                       -- completed | pending | fallback | failed
+  generation_mode  text        not null,                       -- rule_based | ai | mixed
+  summary_json     jsonb       not null,                       -- SCR-05 내부 Snapshot payload
+  generated_at     timestamptz,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);


### PR DESCRIPTION
## 📋 작업 개요

SCR-05 확정 화면에서 사용할 수 있는 `confirm summary` snapshot 저장/조회 구조를 추가했습니다.

`POST /trips/{tripId}/confirm` 성공 시점에 확정된 Day 배치와 카드 정보를 기반으로 rule-based summary를 생성해 `confirm_summaries` 테이블에 저장하고, `GET /trips/{tripId}/confirm-summary`로 조회할 수 있도록 구현했습니다.

이번 PR에서는 SCR-05 진입 시점에 AI를 새로 호출하지 않고, 기존 카드에 저장된 AI 결과(`user_context`, `tips`)와 BE가 계산 가능한 배치/동선 정보를 조합해 화면 데이터를 구성합니다.

## 관련 이슈
closes #199 

## 변경 범위
- [x] BE
- [x] shared/sql

## ✅ 변경 사항

- `confirm_summaries` 테이블 추가
- `ConfirmSummary` 엔티티 및 Repository 추가
- `/confirm` 성공 시 confirm summary snapshot 생성
- `GET /trips/{tripId}/confirm-summary` API 추가
- SCR-05용 summary payload 구성
  - `trip_checklist`
  - `alert_cards`
  - `days[].title`
  - `days[].summary`
  - `days[].primary_region`
  - `days[].pace`
  - `days[].cards[]`
  - `days[].checklist[]`
  - `days[].total_move_minutes`
  - `days[].total_spend_minutes`
- `days[].cards[]`에 기존 카드 맥락 정보 포함
  - `instance_id`
  - `order`
  - `name`
  - `category`
  - `location`
  - `scheduled_time`
  - `estimated_duration_min`
  - `user_context`
  - `tips`
- summary 응답 필드 snake_case 직렬화 테스트 추가
- confirm summary 생성/조회 서비스 및 컨트롤러 테스트 추가

## 🧠 설계 의도

SCR-05는 확정 이후 화면에 가깝고, 사용자가 확정 버튼을 누른 직후 바로 확인해야 하는 화면입니다.

따라서 이 시점에 AI를 새로 호출하면 다음 문제가 생길 수 있습니다.

- 화면 전환 latency 증가
- AI 응답 실패 시 SCR-05 진입 실패 가능성
- Day 배치 변경과 AI 재생성 타이밍 불일치
- 체크리스트 품질/형식 검증을 위한 추가 계약 필요

이번 PR에서는 SCR-05를 “AI가 새로 해석하는 화면”이 아니라, “확정된 배치와 기존 카드 맥락을 기반으로 최종 점검하는 화면”으로 정리했습니다.

## 🤖 AI 응답 계약을 확장하지 않은 이유

현재 AI parse/enrichment 응답에는 card/day checklist 배열이 없습니다.

체크리스트를 AI 응답에 추가하려면 다음 변경이 함께 필요합니다.

- AI Engine schema 확장
- prompt 수정
- BE AI DTO 확장
- 저장 위치 정의
- enrichment 결과 반영 로직 수정
- 잘못된 AI checklist에 대한 validation/fallback 정의

이 변경은 SCR-05 snapshot 저장 구조보다 범위가 크기 때문에 이번 PR에서는 제외했습니다.

대신 기존 AI가 이미 생성해 DB에 저장하는 `user_context`, `tips`는 `days[].cards[]`에 포함했습니다.  
즉, AI 맥락은 카드 맥락 영역에서 활용하고, 체크리스트는 이번 PR에서 rule-based action item으로 제한했습니다.

## 🧾 Summary Payload 예시

```json
{
  "trip_id": "00000000-0000-0000-0000-000000000000",
  "status": "completed",
  "generation_mode": "rule_based",
  "summary": {
    "trip_checklist": [
      {
        "id": "trip-passport",
        "label": "여권 유효기간을 확인하세요.",
        "source": "template",
        "done": false,
        "related_instance_ids": []
      }
    ],
    "alert_cards": [
      {
        "id": "alert-route-1",
        "kind": "실무 알림",
        "category": "practical",
        "message": "인접 카드 간 거리 12.0km. 이동 수단과 소요 시간을 미리 확인하세요.",
        "related_day": 1,
        "related_instance_ids": []
      }
    ],
    "days": [
      {
        "day": 1,
        "title": "Day 1 - 오사카 일정",
        "summary": "오사카 중심의 적당한 일정입니다. 체류 시간은 약 6시간, 이동 시간은 약 42분입니다.",
        "primary_region": "오사카",
        "pace": "moderate",
        "card_count": 2,
        "cards": [
          {
            "instance_id": "00000000-0000-0000-0000-000000000000",
            "order": 1,
            "name": "유니버설 스튜디오 재팬",
            "category": "place",
            "location": "오사카",
            "scheduled_time": "09:00",
            "estimated_duration_min": 480,
            "user_context": "하루 종일 볼 예정이에요",
            "tips": "오픈런 추천, 인기 어트랙션은 오전에 먼저 방문하세요"
          }
        ],
        "checklist": [
          {
            "id": "day-1-route-1",
            "label": "인접 카드 간 거리 12.0km. 이동 수단과 소요 시간을 미리 확인하세요.",
            "source": "route_warning",
            "done": false,
            "related_instance_ids": []
          }
        ],
        "total_move_minutes": 42,
        "total_spend_minutes": 360
      }
    ]
  },
  "generated_at": "2026-06-18T00:00:00Z"
}
```

## 📌 Rule-based 생성 기준

### Trip checklist

기본 실무 항목을 생성합니다.

- 여권 유효기간 확인
- 여행자 보험 가입 여부 확인
- 환전 또는 해외 결제 수단 준비
- 로밍/eSIM 등 현지 통신 수단 준비
- 항공편 카드가 있을 경우 항공권/탑승 시간 확인 항목 추가

### Day checklist

다음 조건에 따라 생성합니다.

- route warning 존재  
  → 이동 수단/소요 시간 확인, 휴식 시간 확보 등
- 숙소 카드  
  → 체크인 시간 및 예약 바우처 확인
- 항공편 카드  
  → 항공권과 탑승 시간 확인
- 시간 제약 카드  
  → 시간 제약 재확인
- 음식점 카드  
  → 예약 필요 여부 확인

조건에 해당하지 않으면 `days[].checklist`는 빈 배열로 내려갑니다.

## 🔗 API

### POST `/trips/{tripId}/confirm`

기존 확정 API입니다.

이번 PR에서 기존 응답 계약은 유지하고, 내부적으로 confirm summary snapshot 생성 단계를 추가했습니다.

### GET `/trips/{tripId}/confirm-summary`

SCR-05용 confirm summary snapshot을 조회합니다.

응답:

- `trip_id`
- `status`
- `generation_mode`
- `summary`
- `generated_at`

예외:

- 여행이 없으면 기존 `TRIP_NOT_FOUND`
- summary가 없으면 `CONFIRM_SUMMARY_NOT_FOUND`

## 🧪 테스트

추가/수정한 테스트:

- `ConfirmSummaryTest`
- `ConfirmSummaryServiceTest`
- `ConfirmSummaryControllerTest`
- `ConfirmServiceTest`
- `JsonNamingStrategyTest`

실행한 테스트:

```bash
./gradlew test \
  --tests com.tripkey.domain.confirm.ConfirmServiceTest \
  --tests com.tripkey.domain.confirm.ConfirmSummaryTest \
  --tests com.tripkey.domain.confirm.ConfirmSummaryServiceTest \
  --tests com.tripkey.domain.confirm.ConfirmSummaryControllerTest \
  --tests com.tripkey.common.json.JsonNamingStrategyTest
```

결과:

```text
BUILD SUCCESSFUL
```


## 🚧 이번 PR에서 하지 않은 것

- FE SCR-05 API 연동
- SCR-05 화면에서 `confirm-summary` 단일 조회 사용
- 체크리스트 완료 상태 저장
- AI Engine checklist 응답 계약 추가
- AI 기반 Day insight / Trip insight 생성
- PDF 저장/공유 기능

## 📝 후속 작업

- FE에서 `GET /trips/{tripId}/confirm-summary` 연동
- 04 화면에서 `/confirm` 성공 후 `/confirm?tripId=...` 이동 처리
- SCR-05 화면에서 `summary.days[].cards[]` 기반 카드 맥락 표시
- SCR-05 화면에서 `summary.days[].checklist[]` 기반 Day checklist 표시
- 체크리스트 완료 상태 저장 여부 결정
- 필요 시 AI checklist 후보 생성 계약 별도 이슈로 분리


## 추가적으로 관련한 SCR-05 문서를 작성했습니다. 노션에 추가해놓은 상태입니다.
작업 및 테스트 진행하실때 문서를 에이전트에게 넣으면 작업에 수월합니다..
05 화면 작업 완료 후 3가지 내부 문서에 업데이트하겠습니다.