### PR TITLE
fix: normalize generic recommendation cards to undecided

### DIFF
--- a/apps/ai-engine/app/prompts/core_parse.py
+++ b/apps/ai-engine/app/prompts/core_parse.py
@@ -82,7 +82,12 @@ def build_core_parse_prompt(req: ParseRequest) -> str:
   - the user asks for general recommendations without a specific type or category, or
   - the dump only contains destination-level context with no specific places at all.
 - Even then, generate at most 3 recommendation cards.
-- If recommendation cards are generated, classification must be open_question and question_text/options must stay null.
+- Do not create generic category cards such as "{{destination}} restaurants", "{{destination}} attractions",
+  "{{destination}} activities", "{{destination}} shopping", "{{destination}} cafes", or "{{destination}} nightlife" as open_question.
+- If a generated recommendation card is not a concrete venue/place, classify it as undecided:
+  - Use placement_status = ready_partial with 2~4 concrete venue options when possible.
+  - Use placement_status = needs_input with question_text and options = null only when concrete options cannot be suggested.
+- Use open_question for generated recommendation cards only when the card itself is a concrete venue/place that the user has not approved yet.
 - Recommendations, tips, options, and context_summary must be destination-aware.
 - Do not assume Japan, Japanese transit, Japanese venues, or Japanese naming unless the destinations or dump_text clearly indicate Japan.
 - If the destination is unclear or broad, use general travel guidance instead of country-specific facts.
@@ -116,8 +121,9 @@ def build_core_parse_prompt(req: ParseRequest) -> str:
 ### classification Rules
 - confirmed: 장소명이 명확히 특정되고 의도가 확정된 완성형 카드.
   Examples: "{{specific_venue}} 꼭 가야해", "{{specific_venue}} 예약했어"
-- open_question: 사용자가 특정 장소명을 언급했지만 갈지 말지 불확실하거나, AI가 자체 추가한 일반 추천 카드.
-  Examples: "{{specific_venue}} 있으면 좋겠다", is_ai_generated: true 카드
+- open_question: 구체 장소명은 있지만 사용자가 갈지 말지 불확실하거나, AI가 제안한 구체 venue/place를 아직 사용자가 승인하지 않은 카드.
+  Examples: "{{specific_venue}} 있으면 좋겠다", is_ai_generated: true + concrete venue card
+  - Generic recommendation/category cards must not be open_question.
 - undecided: 의도는 있지만 장소/내용이 특정되지 않은 카드.
   - AI가 후보 제시 가능하면 placement_status는 ready_partial, question_text와 options를 함께 생성
     Examples: "{{food_type}} 꼭 먹고 싶어", "{{venue_type}} 한 군데 가고 싶어"

--- a/apps/ai-engine/app/services/core_parse.py
+++ b/apps/ai-engine/app/services/core_parse.py
@@ -219,6 +219,7 @@ def _parse_cards(raw_cards: list[dict]) -> list[ParsedCard]:
     for index, raw_card in enumerate(raw_cards):
         try:
             normalized_card = _ensure_card_name(raw_card)
+            normalized_card = _normalize_generic_open_question(normalized_card)
             cards.append(ParsedCard.model_validate(normalized_card))
         except Exception as exc:
             logger.warning("Skipping invalid card at index=%d | error=%s | raw=%s", index, exc, raw_card)
@@ -241,6 +242,89 @@ def _normalize_for_match(value: str | None) -> str:
     if not value:
         return ""
     return re.sub(r"[^0-9a-zA-Z가-힣ぁ-ゔァ-ヴー々〆〤一-龥]", "", value).lower()
+
+
+GENERIC_RECOMMENDATION_TERMS = {
+    "attractions",
+    "activities",
+    "cafes",
+    "coffee",
+    "dining",
+    "food",
+    "foods",
+    "landmarks",
+    "markets",
+    "museums",
+    "nightlife",
+    "restaurants",
+    "shopping",
+    "sightseeing",
+    "things to do",
+    "tours",
+    "관광",
+    "관광지",
+    "랜드마크",
+    "맛집",
+    "먹거리",
+    "미식",
+    "박물관",
+    "쇼핑",
+    "시장",
+    "야경",
+    "액티비티",
+    "음식",
+    "음식점",
+    "주요 관광지",
+    "체험",
+    "카페",
+    "현지 맛집",
+}
+
+
+def _contains_generic_recommendation_term(value: str | None) -> bool:
+    if not value:
+        return False
+    normalized = re.sub(r"\s+", " ", value.strip().lower())
+    squashed = _normalize_for_match(value)
+    return any(
+        term in normalized or _normalize_for_match(term) in squashed
+        for term in GENERIC_RECOMMENDATION_TERMS
+    )
+
+
+def _is_generic_recommendation_card(card: ParsedCard) -> bool:
+    return (
+        card.is_ai_generated
+        and card.classification == Classification.OPEN_QUESTION
+        and not card.place_id
+        and not card.coordinates
+        and _contains_generic_recommendation_term(card.name)
+    )
+
+
+def _normalize_generic_open_question(raw_card: dict) -> dict:
+    if raw_card.get("classification") != Classification.OPEN_QUESTION.value:
+        return raw_card
+    if raw_card.get("is_ai_generated") is not True:
+        return raw_card
+    if raw_card.get("place_id") or raw_card.get("coordinates"):
+        return raw_card
+    if not _contains_generic_recommendation_term(raw_card.get("name")):
+        return raw_card
+
+    patched = dict(raw_card)
+    patched["classification"] = Classification.UNDECIDED.value
+    if patched.get("options"):
+        patched["placement_status"] = PlacementStatus.READY_PARTIAL.value
+    else:
+        patched["placement_status"] = PlacementStatus.NEEDS_INPUT.value
+        patched["options"] = None
+    patched["question_text"] = patched.get("question_text") or f"{patched.get('name', '장소')} 중 어떤 곳을 원하시나요?"
+    patched["place_id"] = None
+    patched["coordinates"] = None
+    patched["address"] = None
+    logger.info("Normalized generic open_question card to undecided | name=%s", patched.get("name"))
+    return patched
 
 
 def _is_name_match(card: ParsedCard, place_name: str) -> bool:
@@ -506,6 +590,8 @@ async def _enrich_card(card: ParsedCard, req: ParseRequest, api_key: str) -> Par
     if card.classification == Classification.UNASSIGNED:
         return card
     if card.classification == Classification.UNDECIDED:
+        return card
+    if _is_generic_recommendation_card(card):
         return card
     if card.placement_status == PlacementStatus.NEEDS_INPUT:
         return card

--- a/apps/ai-engine/tests/test_parse_service.py
+++ b/apps/ai-engine/tests/test_parse_service.py
@@ -145,6 +145,7 @@ def test_core_parse_prompt_requires_destination_aware_responses() -> None:
     assert "create one undecided card for that requested type" in prompt
     assert "Treat requested recommendation types as user intent" in prompt
     assert "Do not satisfy a requested recommendation type by choosing only one concrete venue" in prompt
+    assert "Generic recommendation/category cards must not be open_question" in prompt
     assert "classification Decision Tree" in prompt
     assert "Day placement alone must not promote it to confirmed" in prompt
     assert "Do not invent aliases for generic category cards or undecided cards" in prompt
@@ -434,6 +435,60 @@ def test_ensure_card_name_infers_from_question_text() -> None:
     assert normalized["name"] == "오코노미야끼 맛집"
 
 
+def test_parse_cards_normalizes_generic_ai_open_question_to_needs_input() -> None:
+    raw_cards = [
+        {
+            "name": "오사카 맛집",
+            "category": "food",
+            "classification": "open_question",
+            "placement_status": "ready_partial",
+            "is_ai_generated": True,
+            "allow_duplicate": False,
+            "estimated_duration_min": 60,
+            "place_id": None,
+            "coordinates": None,
+            "address": None,
+            "question_text": None,
+            "options": None,
+        }
+    ]
+
+    cards = core_parse._parse_cards(raw_cards)
+
+    assert len(cards) == 1
+    assert cards[0].classification == Classification.UNDECIDED
+    assert cards[0].placement_status == PlacementStatus.NEEDS_INPUT
+    assert cards[0].question_text == "오사카 맛집 중 어떤 곳을 원하시나요?"
+    assert cards[0].options is None
+
+
+def test_parse_cards_normalizes_generic_ai_open_question_with_options_to_selectable() -> None:
+    raw_cards = [
+        {
+            "name": "Bangkok restaurants",
+            "category": "food",
+            "classification": "open_question",
+            "placement_status": "ready_partial",
+            "is_ai_generated": True,
+            "allow_duplicate": False,
+            "estimated_duration_min": 60,
+            "place_id": None,
+            "coordinates": None,
+            "address": None,
+            "question_text": None,
+            "options": ["Nai Mong Hoi Thod", "Jay Fai"],
+        }
+    ]
+
+    cards = core_parse._parse_cards(raw_cards)
+
+    assert len(cards) == 1
+    assert cards[0].classification == Classification.UNDECIDED
+    assert cards[0].placement_status == PlacementStatus.READY_PARTIAL
+    assert cards[0].question_text == "Bangkok restaurants 중 어떤 곳을 원하시나요?"
+    assert cards[0].options == ["Nai Mong Hoi Thod", "Jay Fai"]
+
+
 def test_apply_place_match_keeps_original_name() -> None:
     card = ParsedCard(
         name="도톤보리",
@@ -546,6 +601,37 @@ async def test_enrich_card_skips_undecided_lookup() -> None:
             allow_duplicate=False,
             question_text="어떤 스시집에 가시겠어요?",
             options=["스시 다이", "스시잔마이"],
+        )
+
+        updated = await core_parse._enrich_card(card, _request(), "test-key")
+
+        assert updated == card
+        assert called is False
+    finally:
+        core_parse._search_place = original
+
+
+@pytest.mark.asyncio
+async def test_enrich_card_skips_generic_ai_open_question_lookup() -> None:
+    called = False
+
+    async def fake_search_place(
+        query: str, api_key: str, region_code: str | None = None
+    ) -> dict | None:
+        nonlocal called
+        called = True
+        return {"places": []}
+
+    original = core_parse._search_place
+    core_parse._search_place = fake_search_place
+    try:
+        card = ParsedCard(
+            name="Paris attractions",
+            category=Category.PLACE,
+            classification=Classification.OPEN_QUESTION,
+            placement_status=PlacementStatus.READY_PARTIAL,
+            is_ai_generated=True,
+            allow_duplicate=False,
         )
 
         updated = await core_parse._enrich_card(card, _request(), "test-key")


### PR DESCRIPTION
## 📝 작업 요약

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.
- AI가 생성한 추천 카드가 open_question으로 분류되지 않도록 수정
- 일반 추천 형태의 open_question 카드를 undecided로 정규화하여 사용자 입력 또는 선택이 가능하도록 개선
- 잘못된 place_id 매핑을 방지하기 위해 추천 카드에 대해서는 places 조회를 수행하지 않도록 변경

## 작업 내용
### 수정 이유:
- `오사카 맛집 추천`과 같이 사용자가 추천을 요청한 경우 관련한 추천 카드를 생성
- 기존 추천 카드 생성시 ai 생성으로 처리되어 open_question/ready_partial/review_only로 생성
- 추천 카드의 경우는 실제 장소를 의미하는 것이 아니며 유효한 place_id가 존재해선 안됨
- 그러나 이러한 추천카드가 open_question으로 분류되며 후속 사용자 입력 차단 문제가 존재

### 변경 사항:
- open_question이 실제 장소 후보에만 사용되도록 프롬프트 수정
- is_ai_generated=true 카드에 대한 후처리 로직 추가
- 일반 추천 카드에 대해서는 places 조회를 수행하지 않도록 enrichment 단계에 guard 로직 추가
- 테스트 추가:
- - 한국어 추천 카드
- - 영어 일반 추천 카드
- - places 조회 건너뛰기 동작 검증

## 🔗 관련 이슈

closes #222 

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

관련하여 테스트 진행 시, 문제 생기면 바로 연락주세요

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요. 없으면 삭제해도 됩니다.