### PR TITLE
Fix: SCR-04 배치 화면 처리필요 카드 notes 보완→재처리 승격 연동 (#230)

### DIFF
--- a/apps/frontend/src/components/arrange/ArrangeCardDetailPanel.tsx
+++ b/apps/frontend/src/components/arrange/ArrangeCardDetailPanel.tsx
@@ -1,6 +1,9 @@
 // ArrangeCardDetailPanel — 배치 화면(SCR-04) 좌측 카드 클릭 시 우측에서 열리는 상세 패널.
 // 정리 화면(SCR-03)의 CardDetailPanel 과 동일한 조립 부품
 // (SidePanel / StatusInfoBox / DetailRow / UserMemoField / PanelActions / PlaceCardBadge)을 재사용한다.
+//
+// 처리필요(unavailable) 카드 중 자연어 재파싱으로 해결 가능한 카드(detail.canResolveByNotes)는
+// "장소 정보 보완"(notes) 입력 + "확인하기"(저장+재처리) 푸터를 보여준다. 그 외 카드는 기존 메모 UI.
 
 import { Clock, Info, MapPin, Plane, User, X } from 'lucide-react';
 import { Dialog } from 'radix-ui';
@@ -23,6 +26,12 @@ type ArrangeCardDetailPanelProps = {
   onOpenChange: (open: boolean) => void;
   card: ArrangeCardViewModel | null;
   onSaveMemo?: (memo: string) => void;
+  /** 처리필요 카드의 notes 보완 입력 → 저장+재처리(self-heal) 트리거 */
+  onResolveByNotes?: (notes: string) => void;
+  /** 재처리 요청~폴링이 진행 중이면 true (확인하기 버튼 로딩/잠금) */
+  resolving?: boolean;
+  /** 재처리가 실패했거나 시간 내에 끝나지 않은 경우의 안내(재시도 가능) */
+  resolveError?: string | null;
 };
 
 const ArrangeCardDetailPanel = ({
@@ -30,16 +39,22 @@ const ArrangeCardDetailPanel = ({
   onOpenChange,
   card,
   onSaveMemo,
+  onResolveByNotes,
+  resolving = false,
+  resolveError = null,
 }: ArrangeCardDetailPanelProps) => {
   return (
     <SidePanel open={open} onOpenChange={onOpenChange}>
       {card?.detail ? (
-        // key={card.id}: 다른 카드로 다시 열렸을 때 메모 입력 state 가 초기화되도록.
+        // key={card.id}: 다른 카드로 다시 열렸을 때 입력 state 가 초기화되도록.
         <ArrangeCardDetailBody
           key={card.id}
           card={card}
           onClose={() => onOpenChange(false)}
           onSaveMemo={onSaveMemo}
+          onResolveByNotes={onResolveByNotes}
+          resolving={resolving}
+          resolveError={resolveError}
         />
       ) : null}
     </SidePanel>
@@ -53,18 +68,30 @@ const ArrangeCardDetailBody = ({
   card,
   onClose,
   onSaveMemo,
+  onResolveByNotes,
+  resolving,
+  resolveError,
 }: {
   card: ArrangeCardViewModel;
   onClose: () => void;
   onSaveMemo?: (memo: string) => void;
+  onResolveByNotes?: (notes: string) => void;
+  resolving: boolean;
+  resolveError: string | null;
 }) => {
   const detail = card.detail!;
   // 고정 카드(항공권 등)는 상단 상태 pill 을 파란색(info), 일반 카드는 초록색(done)으로.
   const isFixed = card.draggable === false;
+  // 처리필요 카드(클릭 시 안내가 있는 카드)인지 / 그중 notes 재파싱으로 해결 가능한지.
+  const isAttention = card.actionGuide != null;
+  const isResolvable = detail.canResolveByNotes === true;
 
   const initialMemo = detail.memo ?? '';
   const [memo, setMemo] = useState(initialMemo);
   const memoDirty = memo.trim() !== initialMemo.trim();
+
+  const [notes, setNotes] = useState(detail.notes ?? '');
+  const canConfirm = notes.trim().length > 0 && !resolving;
 
   const categoryBadge = card.badges?.find((badge) => badge.kind === 'category');
 
@@ -149,8 +176,28 @@ const ArrangeCardDetailBody = ({
 
         <Separator />
 
-        {/* 사용자 메모 */}
-        <UserMemoField value={memo} onChange={setMemo} />
+        {/* 처리필요 카드 안내(인플레이스). 해결 가능/불가 모두 사유를 보여준다. */}
+        {isAttention && card.actionGuide && (
+          <div className="rounded-xl border border-amber-200 bg-amber-50/70 p-4 dark:border-amber-900/50 dark:bg-amber-950/30">
+            <p className="flex gap-2 text-sm leading-relaxed whitespace-pre-line text-amber-800 dark:text-amber-200">
+              <Info className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+              <span>{card.actionGuide}</span>
+            </p>
+          </div>
+        )}
+
+        {isResolvable ? (
+          // 자연어 재파싱(notes)으로 해결: 장소명·주소 보완 입력 → "확인하기"로 저장+재처리.
+          <ResolveByNotesField
+            value={notes}
+            onChange={setNotes}
+            disabled={resolving}
+            error={resolveError}
+          />
+        ) : (
+          // 그 외 카드(배치 가능/고정/해결 불가)는 기존 메모 UI 유지.
+          <UserMemoField value={memo} onChange={setMemo} />
+        )}
       </div>
 
       {/* 푸터 */}
@@ -163,15 +210,58 @@ const ArrangeCardDetailBody = ({
         >
           닫기
         </Button>
-        <Button
-          type="button"
-          className="h-11 flex-1 text-sm font-semibold"
-          disabled={!memoDirty}
-          onClick={() => onSaveMemo?.(memo)}
-        >
-          메모 저장
-        </Button>
+        {isResolvable ? (
+          <Button
+            type="button"
+            className="h-11 flex-1 text-sm font-semibold"
+            disabled={!canConfirm}
+            onClick={() => onResolveByNotes?.(notes.trim())}
+          >
+            {resolving ? '재처리 중…' : '확인하기'}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            className="h-11 flex-1 text-sm font-semibold"
+            disabled={!memoDirty}
+            onClick={() => onSaveMemo?.(memo)}
+          >
+            메모 저장
+          </Button>
+        )}
       </PanelActions>
     </>
   );
 };
+
+// 처리필요 카드의 "장소 정보 보완"(notes) 입력 필드.
+const ResolveByNotesField = ({
+  value,
+  onChange,
+  disabled,
+  error,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+  error: string | null;
+}) => (
+  <section>
+    <h3 className="text-sm font-semibold text-foreground">장소 정보 보완</h3>
+    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+      장소명이나 주소를 더 정확히 입력하면 AI 가 다시 분석해 지도 위치를
+      찾아드려요.
+    </p>
+    <textarea
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      disabled={disabled}
+      placeholder="예) 도톤보리 글리코 사인 앞 / 오사카시 추오구 도톤보리 1-10-2"
+      rows={3}
+      className="mt-3 w-full resize-none rounded-xl border border-input bg-background px-3.5 py-3 text-sm text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none disabled:opacity-60"
+    />
+    {error && (
+      <p className="mt-2 text-xs leading-relaxed text-destructive">{error}</p>
+    )}
+  </section>
+);

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -39,6 +39,7 @@ import type {
 import type { RouteWarning } from '@/types/arrange-api';
 import type { ArrangeDragPayload } from '@/utils/arrange-dnd';
 
+import { fetchGroups04 } from '../utils/arrange-api';
 import {
   buildPlacementRequest,
   cardToStockCard,
@@ -50,12 +51,17 @@ import {
   useCalendarStore,
   formatDateRangeLabel,
 } from '../utils/calendar-store';
-import { parseGroupingApiError } from '../utils/grouping-api';
+import { fetchCards, parseGroupingApiError } from '../utils/grouping-api';
 import { toCardAddRequest } from '../utils/grouping-mapper';
 import { useOnboardingStore } from '../utils/onboarding-store';
 
 // 직접 추가한 카드가 모이는 좌측 그룹(첫 추가 시 생성).
 const ADDED_GROUP_ID = 'added';
+
+// 처리필요 카드 해결(재파싱) 후 processing 이 풀릴 때까지의 폴링 주기/타임아웃.
+// 정리 화면(GroupingPage)의 pollUntilCardSettled 와 동일한 값.
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 30000;
 
 // 좌측 목록 카드 → Day 보드에 배치되는 일정 카드로 변환(로컬 드래그앤드롭용).
 const toScheduledCard = (
@@ -184,6 +190,9 @@ const ArrangePage = () => {
     null
   );
   const [detailOpen, setDetailOpen] = useState(false);
+  // 처리필요 카드 해결(notes 재파싱) 상태: 재처리 진행 중 / 실패·미해결 안내.
+  const [resolving, setResolving] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
   const [addCardOpen, setAddCardOpen] = useState(false);
   const [routeWarnings, setRouteWarnings] = useState<RouteWarning[] | null>(
     null
@@ -191,6 +200,19 @@ const ArrangePage = () => {
   const [notice, setNotice] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [confirmed, setConfirmed] = useState(false);
+
+  // 진행 중인 재처리 폴링 취소 핸들. 카드 전환/언마운트 시 정리한다.
+  const resolvePollRef = useRef<(() => void) | null>(null);
+  // 폴링 콜백(비동기)이 최신 보드/패널 상태를 읽도록 ref 로 보관한다.
+  const daysRef = useRef<DayColumnViewModel[]>([]);
+  const detailCardIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    daysRef.current = days;
+  }, [days]);
+  useEffect(() => {
+    detailCardIdRef.current = detailCard?.id ?? null;
+  }, [detailCard]);
+  useEffect(() => () => resolvePollRef.current?.(), [tripId]);
 
   // 좌측 패널 카운트(전체/미배치)는 현재 상태에서 파생한다.
   const remainingCards = groups.reduce(
@@ -202,10 +224,11 @@ const ArrangePage = () => {
     .filter((card) => card.draggable !== false).length;
 
   const openCardDetail = (card: ArrangeCardViewModel) => {
-    // "처리가 필요한 카드"(배치 불가)는 사용자가 무엇을 해야 하는지 먼저 브라우저 알림으로 안내한다.
-    if (card.actionGuide) {
-      window.alert(card.actionGuide);
-    }
+    // 처리필요 카드도 alert 로 끝내지 않고, 해결 패널을 그대로 열어 인플레이스로 해결한다.
+    // (안내 문구 card.actionGuide 는 패널 안에서 표시)
+    resolvePollRef.current?.();
+    setResolving(false);
+    setResolveError(null);
     setDetailCard(card);
     setDetailOpen(true);
   };
@@ -410,6 +433,106 @@ const ArrangePage = () => {
     } catch (error) {
       setActionError(errorMessageOf(error, '메모 저장에 실패했습니다.'));
     }
+  };
+
+  // 좌측 그룹을 서버 최신(groups04)으로 다시 그린다.
+  // 단, 우측 보드에 배치(로컬·미저장)된 카드는 좌측에 다시 나타나지 않도록 제외해
+  // "mutation 후 query invalidate 안 함" 불변식(미저장 배치 보존)을 깨지 않는다.
+  const refreshLeftGroupsPreservingBoard = async (): Promise<{
+    groups: ArrangeCardGroup[];
+    unavailableIds: Set<string>;
+  } | null> => {
+    if (!tripId) return null;
+    const [groupsRes, cardsRes] = await Promise.all([
+      fetchGroups04(tripId),
+      fetchCards(tripId),
+    ]);
+    const placedIds = new Set(
+      daysRef.current.flatMap((day) => day.cards.map((card) => card.id))
+    );
+    const fresh = mapToArrangeViewModel(groupsRes, cardsRes, meta).groups.map(
+      (group) => ({
+        ...group,
+        cards: group.cards.filter((card) => !placedIds.has(card.id)),
+      })
+    );
+    setGroups(fresh);
+    return {
+      groups: fresh,
+      unavailableIds: new Set(groupsRes.unavailable.map((c) => c.instance_id)),
+    };
+  };
+
+  // 처리필요 카드 해결 — 자연어(notes) 보완 입력으로 카드 레벨 AI 재파싱을 트리거하고,
+  // 재처리(processing)가 끝날 때까지 폴링한 뒤 결과를 좌측 목록에 반영한다.
+  // 성공(배치 가능 승격) → 패널 닫기 / 미해결·타임아웃 → 패널 유지(재시도 가능).
+  const handleResolveByNotes = async (notes: string) => {
+    if (!tripId || !detailCard) return;
+    const instanceId = detailCard.id;
+    setResolveError(null);
+    setResolving(true);
+    resolvePollRef.current?.();
+
+    try {
+      await patchCardMutation.mutateAsync({
+        instanceId,
+        payload: { notes },
+      });
+    } catch (error) {
+      setResolving(false);
+      setResolveError(errorMessageOf(error, '재처리 요청에 실패했습니다.'));
+      return;
+    }
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    resolvePollRef.current = () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+    const startedAt = Date.now();
+
+    // 폴링 종료 처리: 좌측 목록을 갱신하고, 승격 여부에 따라 패널을 닫거나 재시도 안내를 띄운다.
+    const settle = async (timedOut: boolean) => {
+      const result = await refreshLeftGroupsPreservingBoard().catch(() => null);
+      if (cancelled) return;
+      setResolving(false);
+      const promoted = result != null && !result.unavailableIds.has(instanceId);
+      if (promoted) {
+        setNotice('카드가 배치 가능 목록으로 이동했어요.');
+        // 패널이 아직 이 카드를 보여주는 중일 때만 닫는다.
+        if (detailCardIdRef.current === instanceId) setDetailOpen(false);
+        return;
+      }
+      // 아직 해결 안 됨 — 패널을 열어둔 채 최신 카드 상태로 갱신해 다시 시도할 수 있게 한다.
+      if (detailCardIdRef.current === instanceId) {
+        const refreshed = result?.groups
+          .flatMap((group) => group.cards)
+          .find((card) => card.id === instanceId);
+        if (refreshed) setDetailCard(refreshed);
+        setResolveError(
+          timedOut
+            ? '재처리가 시간 내에 끝나지 않았어요. 잠시 후 다시 시도해 주세요.'
+            : '아직 배치할 수 없어요. 장소명·주소를 더 정확히 입력해 다시 시도해 주세요.'
+        );
+      }
+    };
+
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        const cardsRes = await fetchCards(tripId);
+        if (cancelled) return;
+        const card = cardsRes.cards.find((c) => c.instance_id === instanceId);
+        const done = !card || card.processing_status !== 'processing';
+        if (done) return void settle(false);
+      } catch {
+        // 일시적 조회 실패는 다음 tick 에서 재시도(타임아웃 내라면).
+      }
+      if (Date.now() - startedAt > POLL_TIMEOUT_MS) return void settle(true);
+      if (!cancelled) timer = setTimeout(tick, POLL_INTERVAL_MS);
+    };
+    timer = setTimeout(tick, POLL_INTERVAL_MS);
   };
 
   // 정리 반영 — POST /groups/reorder. "재정렬이 필요한 카드"를 클러스터로 재편입한 뒤
@@ -671,6 +794,9 @@ const ArrangePage = () => {
         onOpenChange={setDetailOpen}
         card={detailCard}
         onSaveMemo={handleSaveMemo}
+        onResolveByNotes={handleResolveByNotes}
+        resolving={resolving}
+        resolveError={resolveError}
       />
 
       {/* "카드 추가하기" 모달 — 정리 화면(SCR-03)의 AddCardModal 재사용 */}

--- a/apps/frontend/src/types/arrange.ts
+++ b/apps/frontend/src/types/arrange.ts
@@ -27,7 +27,7 @@ export type ArrangeCardViewModel = {
   detail?: ArrangeCardDetailViewModel;
   /**
    * "처리가 필요한 카드"(배치 불가)에만 채워지는 안내 문구.
-   * 카드를 클릭하면 사용자가 무엇을 해야 하는지 브라우저 알림(window.alert)으로 띄운다.
+   * 카드를 클릭하면 상세 패널 안에 "무엇을 해야 하는지" 안내로 표시한다(인플레이스 해결).
    * 배치 가능 카드/제외 카드에는 undefined.
    */
   actionGuide?: string;
@@ -55,6 +55,17 @@ export type ArrangeCardDetailViewModel = {
   aiHint?: string;
   /** "사용자 메모" textarea 초기값. 보통 ''. 입력값이 달라지면 "메모 저장"이 활성화된다 */
   memo?: string;
+  /**
+   * 자연어 재파싱(notes)으로 해결 가능한 "처리 필요" 카드의 현재 notes 값.
+   * 해결 패널의 "장소 정보 보완" textarea 초기값으로 쓰인다.
+   */
+  notes?: string;
+  /**
+   * true면 notes 보완 입력 → 카드 레벨 AI 재파싱(self-heal)으로 배치 가능 상태로 승격될 수 있다.
+   * (BE canStartNaturalLanguageParsingFromNotes 조건을 FE 에서 미러링)
+   * 처리 필요(unavailable) 카드에만 true 일 수 있고, 그 외에는 undefined/false.
+   */
+  canResolveByNotes?: boolean;
 };
 
 /** 좌측 카드 그룹 한 덩어리(항공권 / 숙소 / 지역 그룹 등). */

--- a/apps/frontend/src/utils/arrange-mapper.ts
+++ b/apps/frontend/src/utils/arrange-mapper.ts
@@ -156,22 +156,35 @@ const attentionLabel = (card: Card): string => {
 const attentionGuide = (card: Card): string => {
   const name = card.name?.trim() || '이 카드';
   if (card.processing_status === 'failed') {
-    return `'${name}' 카드는 처리 중 문제가 생겨 일정에 배치할 수 없어요.\n\n정리 화면에서 카드를 열어 장소 정보를 다시 입력한 뒤 시도해 주세요.`;
+    return `'${name}' 카드는 처리 중 문제가 생겨 일정에 배치할 수 없어요.\n\n아래에 장소명·주소 등 장소 정보를 다시 입력한 뒤 확인해 주세요.`;
   }
   if (card.placement_status === 'needs_input') {
-    return `'${name}' 카드는 배치에 필요한 정보가 부족해요.\n\n정리 화면에서 카드를 열어 빠진 정보를 입력해 주세요.`;
+    return `'${name}' 카드는 배치에 필요한 정보가 부족해요.\n\n아래에 빠진 장소명·주소를 입력한 뒤 확인해 주세요.`;
   }
   if (card.placement_status === 'blocked') {
-    return `'${name}' 카드는 먼저 확인이 필요해요.\n\n정리 화면에서 카드 내용을 확인·정리한 뒤 다시 배치해 주세요.`;
+    return `'${name}' 카드는 먼저 확인이 필요해요.\n\n카드 내용을 확인·정리한 뒤 다시 배치해 주세요.`;
   }
   // 좌표(지도 위치)가 없어 배치 불가인 케이스. placement_status 추론 대신
   // API 가 내려주는 coordinates 로 직접 판정한다(ready/ready_partial 모두 포함).
   if (card.coordinates == null) {
-    return `'${name}' 카드는 지도 위치를 찾지 못해 일정에 배치할 수 없어요.\n\n정리 화면에서 카드를 열어 장소명·주소를 더 정확히 입력한 뒤 다시 시도해 주세요.`;
+    return `'${name}' 카드는 지도 위치를 찾지 못해 일정에 배치할 수 없어요.\n\n아래에 장소명·주소를 더 정확히 입력한 뒤 확인해 주세요.`;
   }
   // 위 어느 사유에도 해당하지 않는 경우(정상 동작 시 도달하지 않음) — 일반 안내.
-  return `'${name}' 카드는 아직 일정에 배치할 수 없어요.\n\n정리 화면에서 카드 상태를 확인해 주세요.`;
+  return `'${name}' 카드는 아직 일정에 배치할 수 없어요.\n\n카드 상태를 확인해 주세요.`;
 };
+
+/**
+ * BE canStartNaturalLanguageParsingFromNotes(PlaceCard.java:259-263) 미러링.
+ * notes 보완 입력으로 카드 레벨 AI 재파싱(self-heal)을 트리거할 수 있는 카드인지 판정한다.
+ *  - undecided && (needs_input | ready_partial)
+ *  - failed && classification != open_question
+ */
+const canResolveByNotes = (card: Card): boolean =>
+  (card.classification === 'undecided' &&
+    (card.placement_status === 'needs_input' ||
+      card.placement_status === 'ready_partial')) ||
+  (card.processing_status === 'failed' &&
+    card.classification !== 'open_question');
 
 const flightLabel = (card: Card): string | undefined => {
   const date = parseDate(card.flight_datetime);
@@ -200,6 +213,7 @@ const cardToDetail = (card: Card): ArrangeCardDetailViewModel => ({
   userIntent: card.user_context ?? undefined,
   aiHint: card.tips ?? card.blocked_reason ?? undefined,
   memo: card.memo ?? '',
+  notes: card.notes ?? '',
 });
 
 /** 좌측 목록의 배치 가능 카드(드래그 가능). add 응답 등에서도 재사용한다. */
@@ -232,7 +246,11 @@ const cardToAttentionCard = (
     accent: kind === 'excluded' ? 'muted' : 'red',
     badges: [...buildBadges(card), statusBadge],
     draggable: false,
-    detail: cardToDetail(card),
+    // 처리필요 카드만 notes 재파싱(self-heal) 가능 플래그를 채운다. 제외 카드는 해결 대상이 아니다.
+    detail:
+      kind === 'unavailable'
+        ? { ...cardToDetail(card), canResolveByNotes: canResolveByNotes(card) }
+        : cardToDetail(card),
     // 제외 카드는 의도적으로 뺀 항목이므로 안내하지 않는다.
     actionGuide: kind === 'unavailable' ? attentionGuide(card) : undefined,
   };


### PR DESCRIPTION

## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 배치 화면(SCR-04)에서 "처리가 필요한 카드"를 클릭하면 `window.alert` 안내만 뜨고 화면 안에서 해결할 수 없던 문제를, **자연어(`notes`) 보완 입력 → 재처리(self-heal) → 배치 가능 목록으로 승격**까지 인플레이스로 해결하도록 연동했습니다. (Phase 1: 동작이 보장된 `notes` 경로만)

## 🔗 관련 이슈

closes #230

- 상위 이슈: SCR-04 처리필요 카드 해결 FE 연동(편집/재파싱)
- 후속(Phase 2) 선행 BE 작업: 구조화 편집 재처리 트리거 누락 — 별도 BE 이슈로 핸드오프

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

**변경 파일 (4):**
- `types/arrange.ts` 
- `utils/arrange-mapper.ts` — `canResolveByNotes` 헬퍼, 처리필요 카드에 플래그 매핑, `attentionGuide` 문구를 인플레이스 안내로 수정
- `pages/ArrangePage.tsx` — `openCardDetail`의 `window.alert` 제거`
- `components/arrange/ArrangeCardDetailPanel.tsx` — "장소 정보 보완"(notes) 입력 + "확인하기"(저장+재처리) 푸터, 재처리 로딩/재시도, 사유 callout

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? — 처리필요 카드 `notes` 보완 → 재처리 → 배치 가능 승격 / 미해결 시 재시도
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — 편집 대상 아닌 카드는 기존 메모 저장 UI 그대로, 드래그·verify·confirm 미변경
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요? — 폴링 상수(2초/30초)는 정리 화면과 동일 값으로 상단 상수화
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? — Phase 1(`notes` 경로)만, 구조화 편집(Phase 2)은 제외

## 👀 리뷰어에게

- **`refreshLeftGroupsPreservingBoard`** (`ArrangePage.tsx`): 폴링 후 좌측 그룹을 서버 최신으로 다시 그리되, 우측 보드에 배치(미저장)된 카드는 제외합니다. 이 화면은 mutation 후 query를 invalidate하지 않고 로컬 배치를 보존하는 구조라, 이 불변식을 지키기 위한 처리입니다.
- **`canResolveByNotes`** (`arrange-mapper.ts`): BE의 `canStartNaturalLanguageParsingFromNotes`(`PlaceCard.java:259-263`) 조건을 FE에서 미러링합니다. BE 조건이 바뀌면 동기화가 필요합니다.
- **Phase 2(구조화 편집) 의도적 제외**: 숙소/항공·교통 구조화 편집은 BE에서 `processing`만 세팅하고 재처리 트리거가 없어(no-op) 승격되지 않습니다. FE만으로 동작 불가라 이번 PR에서 제외했고, BE 핸드오프 문서로 분리했습니다.
- 폴링은 카드 전환/언마운트 시 취소되며, 패널이 다른 카드로 바뀌면 이전 폴링 결과가 패널 상태를 건드리지 않도록 가드했습니다.

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요.

- (첨부 예정) 처리필요 카드 클릭 → "장소 정보 보완" 패널
- (첨부 예정) "확인하기" → 재처리 로딩 → 배치 가능 목록 이동
