### PR TITLE
Chore: EKS k8s 메니페스트 및 HPA 구성 추가 

### DIFF
--- a/apps/backend/build.gradle
+++ b/apps/backend/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     // ── AWS SQS (Spring Cloud AWS) ───────────────────────
     implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0')
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
+    implementation 'software.amazon.awssdk:sts'
 
     // ── Test: LocalStack ─────────────────────────────────
     testImplementation 'org.testcontainers:localstack'

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/EnrichmentDlqListener.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/EnrichmentDlqListener.java
@@ -5,6 +5,7 @@ import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.role", havingValue = "ai-worker", matchIfMissing = true)
 public class EnrichmentDlqListener {
 
     private final EnrichmentQueueService queueService;

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/EnrichmentSqsListener.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/EnrichmentSqsListener.java
@@ -7,6 +7,7 @@ import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -19,6 +20,7 @@ import java.util.UUID;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.role", havingValue = "ai-worker", matchIfMissing = true)
 public class EnrichmentSqsListener {
 
     private final AiEngineClient aiEngineClient;

--- a/apps/backend/src/main/java/com/tripkey/domain/dump/OutboxRelay.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/dump/OutboxRelay.java
@@ -2,11 +2,13 @@ package com.tripkey.domain.dump;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@ConditionalOnProperty(name = "app.role", havingValue = "ai-worker", matchIfMissing = true)
 public class OutboxRelay {
 
     private final OutboxRelayService relayService;

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,0 +1,112 @@
+# TripKey Kubernetes Manifests
+
+This directory contains the first EKS-ready Kubernetes manifests for TripKey.
+
+## Scope
+
+- `frontend`: React/Vite static app served by Nginx.
+- `backend`: Spring Boot API service.
+- `ai-engine`: FastAPI AI service.
+- `ai-worker`: initial worker deployment using the backend image because SQS listeners currently live in the Spring Boot app.
+
+Secret and ConfigMap object definitions are intentionally excluded from this issue. Deployments only keep placeholder references to:
+
+- `tripkey-config`
+- `tripkey-secrets`
+
+Expected keys are documented in each app's `.env.example` file. Create those objects in a separate secret/config issue before rolling pods in EKS.
+
+## Image Tags
+
+The manifests target the current TripKey ECR repositories through `kustomization.yaml`:
+
+- `400524748280.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-frontend:latest`
+- `400524748280.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-backend:latest`
+- `400524748280.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-ai-engine:latest`
+
+In CI/CD, prefer `kubectl set image` or `kustomize edit set image` so the image tag comes from the deploy job, not from handwritten manifest edits.
+
+## Public Routing
+
+`ingress.yaml` is configured for AWS Load Balancer Controller:
+
+- Host: `usetripkey.com`
+- ACM certificate: `arn:aws:acm:ap-northeast-2:400524748280:certificate/7dd0095e-542b-4bc5-a965-8fb7f5083c8c`
+- HTTP 80 redirects to HTTPS 443.
+- `/api/*` routes directly to the backend Service.
+- `/*` routes to the frontend Service.
+
+The backend Spring app serves under `/v1`, while the frontend calls `/api`. The Ingress rewrites `/api/...` to `/v1/...` before forwarding to the backend target group.
+
+After applying the Ingress, get the generated ALB DNS name:
+
+```bash
+kubectl -n tripkey get ingress tripkey
+```
+
+Then create a Route53 `A` Alias record for `usetripkey.com` pointing to that ALB.
+
+## Apply Order
+
+```bash
+kubectl apply -k infra/k8s/
+```
+
+The frontend Nginx image still contains a `/api` proxy fallback, but EKS public traffic should normally be routed by ALB before it reaches the frontend container.
+
+## ai-worker Note
+
+`ai-worker` currently reuses the backend image because the SQS listener and outbox relay live in the Spring Boot application. The EKS backend Deployment sets `APP_ROLE=api`, while the worker Deployment sets `APP_ROLE=ai-worker`.
+
+Spring maps those environment variables to `app.role`. SQS consumers and the outbox relay are only registered when `app.role=ai-worker`. `matchIfMissing=true` preserves the existing local Docker Compose behavior when `APP_ROLE` is not set.
+
+Useful checks after rollout:
+
+```bash
+kubectl -n tripkey exec deploy/tripkey-backend -- printenv APP_ROLE
+kubectl -n tripkey exec deploy/tripkey-ai-worker -- printenv APP_ROLE
+kubectl -n tripkey logs deploy/tripkey-backend | grep -i sqs
+kubectl -n tripkey logs deploy/tripkey-ai-worker | grep -i sqs
+```
+
+The backend logs should not show active SQS listener consumption. The worker logs should show SQS listener activity when messages are available.
+
+## AWS Prerequisites
+
+Before applying these manifests to a new EKS cluster:
+
+1. Create or select the EKS cluster in `ap-northeast-2`.
+2. Add a managed node group or Fargate profile that can run the TripKey pods.
+3. Associate the cluster OIDC provider.
+4. Install AWS Load Balancer Controller with IAM permissions.
+5. Install `metrics-server` for HPA.
+6. Push the three Docker images to ECR.
+7. Create `tripkey-config` and `tripkey-secrets` in the `tripkey` namespace.
+8. Apply the manifests with `kubectl apply -k infra/k8s/`.
+9. Create or update the Route53 Alias record for `usetripkey.com` to point at the ALB created by the Ingress.
+
+If an ALB was created manually before introducing Ingress, prefer letting AWS Load Balancer Controller create and manage the EKS ALB. Reusing a manual ALB requires extra TargetGroupBinding work and is usually not worth it for this deployment.
+
+## Autoscaling
+
+HPA is configured for:
+
+- `tripkey-backend`: 2 to 6 replicas, CPU 65%.
+- `tripkey-ai-engine`: 2 to 8 replicas, CPU 60% or memory 70%.
+- `tripkey-ai-worker`: 1 to 5 replicas, CPU 50%.
+
+These HPAs require `metrics-server`. The worker HPA is a first step; queue-depth based scaling with KEDA/SQS would be a good follow-up once the base EKS deployment is stable.
+
+## Validation
+
+```bash
+kubectl apply --dry-run=client -k infra/k8s/
+```
+
+HPA requires `metrics-server` to be installed in the EKS cluster.
+
+If local `kubectl` is pointed at a stale or non-Kubernetes endpoint, schema discovery can fail before manifest validation. In that case, first verify the rendered output:
+
+```bash
+kubectl kustomize infra/k8s/
+```

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,66 +1,98 @@
-# TripKey Kubernetes Manifests
+# TripKey Kubernetes 매니페스트
 
-This directory contains the first EKS-ready Kubernetes manifests for TripKey.
+이 디렉터리는 TripKey 서비스를 EKS에서 실행하기 위한 Kubernetes 매니페스트를 담고 있다.
 
-## Scope
+## 구성 범위
 
-- `frontend`: React/Vite static app served by Nginx.
-- `backend`: Spring Boot API service.
-- `ai-engine`: FastAPI AI service.
-- `ai-worker`: initial worker deployment using the backend image because SQS listeners currently live in the Spring Boot app.
+- `frontend`: React/Vite 정적 파일을 Nginx로 서빙한다.
+- `backend`: Spring Boot API 서버다.
+- `ai-engine`: FastAPI 기반 AI 서비스다.
+- `ai-worker`: 현재는 backend 이미지를 재사용한다. SQS listener와 outbox relay가 Spring Boot 앱 안에 있기 때문이다.
 
-Secret and ConfigMap object definitions are intentionally excluded from this issue. Deployments only keep placeholder references to:
+Secret과 ConfigMap의 실제 값은 이 매니페스트에 포함하지 않는다. Deployment에서는 아래 리소스를 참조하는 위치만 정의한다.
 
 - `tripkey-config`
 - `tripkey-secrets`
 
-Expected keys are documented in each app's `.env.example` file. Create those objects in a separate secret/config issue before rolling pods in EKS.
+실제 key 목록과 값은 별도 Secret/ConfigMap 관리 이슈에서 다룬다. 새 클러스터에 배포할 때는 Pod를 띄우기 전에 `tripkey` namespace에 위 두 리소스를 먼저 만들어야 한다.
 
-## Image Tags
+## 이미지
 
-The manifests target the current TripKey ECR repositories through `kustomization.yaml`:
+`kustomization.yaml`에서 현재 TripKey ECR 저장소를 바라보도록 설정한다.
 
 - `400524748280.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-frontend:latest`
 - `400524748280.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-backend:latest`
 - `400524748280.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-ai-engine:latest`
 
-In CI/CD, prefer `kubectl set image` or `kustomize edit set image` so the image tag comes from the deploy job, not from handwritten manifest edits.
+운영 CD에서는 직접 manifest의 image 값을 손으로 고치기보다 `kubectl set image` 또는 `kustomize edit set image`로 배포 job의 태그를 주입하는 방식을 권장한다.
 
-## Public Routing
+## 공개 라우팅
 
-`ingress.yaml` is configured for AWS Load Balancer Controller:
+`ingress.yaml`은 AWS Load Balancer Controller 기준으로 작성되어 있다.
 
 - Host: `usetripkey.com`
-- ACM certificate: `arn:aws:acm:ap-northeast-2:400524748280:certificate/7dd0095e-542b-4bc5-a965-8fb7f5083c8c`
-- HTTP 80 redirects to HTTPS 443.
-- `/api/*` routes directly to the backend Service.
-- `/*` routes to the frontend Service.
+- ACM 인증서: `arn:aws:acm:ap-northeast-2:400524748280:certificate/7dd0095e-542b-4bc5-a965-8fb7f5083c8c`
+- HTTP 80은 HTTPS 443으로 redirect한다.
+- `/api/*`는 backend Service로 라우팅한다.
+- `/*`는 frontend Service로 라우팅한다.
 
-The backend Spring app serves under `/v1`, while the frontend calls `/api`. The Ingress rewrites `/api/...` to `/v1/...` before forwarding to the backend target group.
+Spring Boot backend는 `/v1` context path로 동작하고, frontend는 `/api`로 API를 호출한다. 따라서 Ingress에서 `/api/...` 요청을 backend로 보내기 전에 `/v1/...`로 rewrite한다.
 
-After applying the Ingress, get the generated ALB DNS name:
+Ingress 적용 후 생성된 ALB DNS 이름은 아래 명령으로 확인한다.
 
 ```bash
 kubectl -n tripkey get ingress tripkey
 ```
 
-Then create a Route53 `A` Alias record for `usetripkey.com` pointing to that ALB.
+Route53에서는 `usetripkey.com`의 `A` Alias record가 이 ALB를 바라보도록 설정한다.
 
-## Apply Order
+## 적용 순서
 
 ```bash
 kubectl apply -k infra/k8s/
 ```
 
-The frontend Nginx image still contains a `/api` proxy fallback, but EKS public traffic should normally be routed by ALB before it reaches the frontend container.
+frontend Nginx 이미지 안에도 `/api` proxy fallback이 남아 있을 수 있지만, EKS 운영 환경의 외부 트래픽은 기본적으로 ALB Ingress에서 먼저 라우팅한다.
 
-## ai-worker Note
+## Secret / ConfigMap 주의사항
 
-`ai-worker` currently reuses the backend image because the SQS listener and outbox relay live in the Spring Boot application. The EKS backend Deployment sets `APP_ROLE=api`, while the worker Deployment sets `APP_ROLE=ai-worker`.
+`tripkey-config`와 `tripkey-secrets`의 실제 값은 이 디렉터리의 YAML에 커밋하지 않는다. 특히 DB URL, API key, Supabase key는 Kubernetes Secret 또는 별도 Secret 관리 도구에서 주입한다.
 
-Spring maps those environment variables to `app.role`. SQS consumers and the outbox relay are only registered when `app.role=ai-worker`. `matchIfMissing=true` preserves the existing local Docker Compose behavior when `APP_ROLE` is not set.
+Supabase pooler를 사용하는 경우 `SUPABASE_DB_URL`에는 PostgreSQL JDBC 옵션 `prepareThreshold=0`을 포함해야 한다.
 
-Useful checks after rollout:
+예시:
+
+```text
+jdbc:postgresql://.../postgres?prepareThreshold=0
+```
+
+이미 다른 query parameter가 있다면 `?` 대신 `&`로 이어 붙인다.
+
+```text
+jdbc:postgresql://.../postgres?sslmode=require&prepareThreshold=0
+```
+
+이 옵션이 없으면 Spring/JPA가 DB 쿼리를 처리할 때 Supabase pooler와 PostgreSQL JDBC의 서버 사이드 prepared statement가 충돌할 수 있다. 운영에서 다음과 같은 오류가 발생하면 이 설정을 먼저 확인한다.
+
+```text
+ERROR: prepared statement "S_1" already exists
+ERROR: prepared statement "S_1" does not exist
+```
+
+현재 EKS 클러스터에는 Secret을 수동으로 patch해서 이 옵션을 반영했다. 하지만 Secret을 다시 만들거나 새 클러스터에 배포할 때는 이 옵션이 빠지지 않도록 주의해야 한다.
+
+## ai-worker
+
+`ai-worker`는 현재 backend 이미지를 재사용한다. SQS listener와 outbox relay가 Spring Boot 애플리케이션 안에 있기 때문이다.
+
+EKS에서는 backend Deployment에 `APP_ROLE=api`, ai-worker Deployment에 `APP_ROLE=ai-worker`를 설정한다. Spring은 이를 `app.role` property로 매핑한다.
+
+- `APP_ROLE=api`: API 서버만 동작한다.
+- `APP_ROLE=ai-worker`: SQS consumer와 outbox relay가 동작한다.
+
+`matchIfMissing=true`가 적용되어 있어 로컬 Docker Compose처럼 `APP_ROLE`이 없는 환경에서는 기존 동작을 유지한다.
+
+배포 후 확인 명령:
 
 ```bash
 kubectl -n tripkey exec deploy/tripkey-backend -- printenv APP_ROLE
@@ -69,44 +101,54 @@ kubectl -n tripkey logs deploy/tripkey-backend | grep -i sqs
 kubectl -n tripkey logs deploy/tripkey-ai-worker | grep -i sqs
 ```
 
-The backend logs should not show active SQS listener consumption. The worker logs should show SQS listener activity when messages are available.
+backend 로그에는 SQS listener 소비 로그가 없어야 한다. worker 로그에는 메시지가 있을 때 SQS listener 동작 로그가 보여야 한다.
 
-## AWS Prerequisites
+## AWS 사전 준비
 
-Before applying these manifests to a new EKS cluster:
+새 EKS 클러스터에 적용하기 전에 아래 작업이 필요하다.
 
-1. Create or select the EKS cluster in `ap-northeast-2`.
-2. Add a managed node group or Fargate profile that can run the TripKey pods.
-3. Associate the cluster OIDC provider.
-4. Install AWS Load Balancer Controller with IAM permissions.
-5. Install `metrics-server` for HPA.
-6. Push the three Docker images to ECR.
-7. Create `tripkey-config` and `tripkey-secrets` in the `tripkey` namespace.
-8. Apply the manifests with `kubectl apply -k infra/k8s/`.
-9. Create or update the Route53 Alias record for `usetripkey.com` to point at the ALB created by the Ingress.
+1. `ap-northeast-2` 리전에 EKS 클러스터를 생성한다.
+2. TripKey Pod를 실행할 managed node group 또는 Fargate profile을 구성한다.
+3. 클러스터 OIDC provider를 연결한다.
+4. AWS Load Balancer Controller와 필요한 IAM 권한을 설치한다.
+5. HPA 사용을 위해 `metrics-server`를 설치한다.
+6. Docker 이미지를 ECR에 push한다.
+7. `tripkey` namespace에 `tripkey-config`, `tripkey-secrets`를 생성한다.
+8. `kubectl apply -k infra/k8s/`로 매니페스트를 적용한다.
+9. Route53에서 `usetripkey.com` Alias record가 Ingress로 생성된 ALB를 바라보도록 설정한다.
 
-If an ALB was created manually before introducing Ingress, prefer letting AWS Load Balancer Controller create and manage the EKS ALB. Reusing a manual ALB requires extra TargetGroupBinding work and is usually not worth it for this deployment.
+Ingress 도입 전에 수동으로 만든 ALB가 있더라도, EKS 운영 환경에서는 AWS Load Balancer Controller가 생성한 ALB를 사용하는 것을 권장한다. 기존 ALB를 재사용하려면 TargetGroupBinding 등 추가 구성이 필요해서 초기 운영 구성에는 적합하지 않다.
 
-## Autoscaling
+## 오토스케일링
 
-HPA is configured for:
+현재 HPA 설정은 다음과 같다.
 
-- `tripkey-backend`: 2 to 6 replicas, CPU 65%.
-- `tripkey-ai-engine`: 2 to 8 replicas, CPU 60% or memory 70%.
-- `tripkey-ai-worker`: 1 to 5 replicas, CPU 50%.
+- `tripkey-backend`: 2~6 replicas, CPU 65%.
+- `tripkey-ai-engine`: 2~8 replicas, CPU 60% 또는 memory 70%.
+- `tripkey-ai-worker`: 1~5 replicas, CPU 50%.
 
-These HPAs require `metrics-server`. The worker HPA is a first step; queue-depth based scaling with KEDA/SQS would be a good follow-up once the base EKS deployment is stable.
+HPA가 동작하려면 EKS 클러스터에 `metrics-server`가 설치되어 있어야 한다.
 
-## Validation
+현재 worker HPA는 CPU 기준의 초기 구성이다. 운영이 안정화된 뒤에는 SQS queue depth 기반으로 KEDA를 붙이는 구성을 후속 작업으로 검토할 수 있다.
+
+## 검증
+
+로컬 dry-run:
 
 ```bash
 kubectl apply --dry-run=client -k infra/k8s/
 ```
 
-HPA requires `metrics-server` to be installed in the EKS cluster.
-
-If local `kubectl` is pointed at a stale or non-Kubernetes endpoint, schema discovery can fail before manifest validation. In that case, first verify the rendered output:
+렌더링 결과 확인:
 
 ```bash
 kubectl kustomize infra/k8s/
+```
+
+배포 후 기본 상태 확인:
+
+```bash
+kubectl -n tripkey get pods
+kubectl -n tripkey get ingress
+kubectl -n tripkey get hpa
 ```

--- a/infra/k8s/ai-engine-deployment.yaml
+++ b/infra/k8s/ai-engine-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tripkey-ai-engine
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: ai-engine
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tripkey
+      app.kubernetes.io/component: ai-engine
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tripkey
+        app.kubernetes.io/component: ai-engine
+    spec:
+      containers:
+        - name: ai-engine
+          image: 000000000000.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-ai-engine:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: tripkey-config
+                optional: true
+            - secretRef:
+                name: tripkey-secrets
+                optional: true
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+

--- a/infra/k8s/ai-engine-hpa.yaml
+++ b/infra/k8s/ai-engine-hpa.yaml
@@ -1,0 +1,28 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: tripkey-ai-engine
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: ai-engine
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tripkey-ai-engine
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infra/k8s/ai-engine-service.yaml
+++ b/infra/k8s/ai-engine-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tripkey-ai-engine
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: ai-engine
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: ai-engine
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+

--- a/infra/k8s/ai-worker-deployment.yaml
+++ b/infra/k8s/ai-worker-deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tripkey-ai-worker
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: ai-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tripkey
+      app.kubernetes.io/component: ai-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tripkey
+        app.kubernetes.io/component: ai-worker
+    spec:
+      containers:
+        - name: ai-worker
+          image: 000000000000.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: tripkey-config
+                optional: true
+            - secretRef:
+                name: tripkey-secrets
+                optional: true
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: APP_ROLE
+              value: ai-worker
+            - name: AI_ENGINE_URL
+              value: http://tripkey-ai-engine:8000
+            - name: ENRICHMENT_CONCURRENCY
+              value: "3"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+

--- a/infra/k8s/ai-worker-deployment.yaml
+++ b/infra/k8s/ai-worker-deployment.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/name: tripkey
         app.kubernetes.io/component: ai-worker
     spec:
+      serviceAccountName: tripkey-ai-worker
       containers:
         - name: ai-worker
           image: 000000000000.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-backend:latest
@@ -64,4 +65,3 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-

--- a/infra/k8s/ai-worker-hpa.yaml
+++ b/infra/k8s/ai-worker-hpa.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: tripkey-ai-worker
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: ai-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tripkey-ai-worker
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+

--- a/infra/k8s/ai-worker-service-account.yaml
+++ b/infra/k8s/ai-worker-service-account.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tripkey-ai-worker
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: ai-worker
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::400524748280:role/TripKeyAiWorkerRole
+

--- a/infra/k8s/ai-worker-service.yaml
+++ b/infra/k8s/ai-worker-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tripkey-ai-worker
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: ai-worker
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: ai-worker
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+

--- a/infra/k8s/backend-deployment.yaml
+++ b/infra/k8s/backend-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tripkey-backend
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tripkey
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tripkey
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: backend
+          image: 000000000000.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: tripkey-config
+                optional: true
+            - secretRef:
+                name: tripkey-secrets
+                optional: true
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: APP_ROLE
+              value: api
+            - name: AI_ENGINE_URL
+              value: http://tripkey-ai-engine:8000
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/infra/k8s/backend-hpa.yaml
+++ b/infra/k8s/backend-hpa.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: tripkey-backend
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: tripkey-backend
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 65

--- a/infra/k8s/backend-service.yaml
+++ b/infra/k8s/backend-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: backend
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: /v1/health
+    alb.ingress.kubernetes.io/success-codes: "200"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: backend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/infra/k8s/frontend-deployment.yaml
+++ b/infra/k8s/frontend-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tripkey-frontend
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tripkey
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tripkey
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: 000000000000.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+

--- a/infra/k8s/frontend-service.yaml
+++ b/infra/k8s/frontend-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tripkey-frontend
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tripkey
+    app.kubernetes.io/component: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+

--- a/infra/k8s/ingress.yaml
+++ b/infra/k8s/ingress.yaml
@@ -1,0 +1,50 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tripkey
+  namespace: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-2:400524748280:certificate/7dd0095e-542b-4bc5-a965-8fb7f5083c8c
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=180
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/success-codes: "200-399"
+    alb.ingress.kubernetes.io/transforms.backend: >
+      [
+        {
+          "type": "url-rewrite",
+          "urlRewriteConfig": {
+            "rewrites": [
+              {
+                "regex": "^/api/(.+)$",
+                "replace": "/v1/$1"
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  ingressClassName: alb
+  rules:
+    - host: usetripkey.com
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tripkey-frontend
+                port:
+                  number: 80

--- a/infra/k8s/kustomization.yaml
+++ b/infra/k8s/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: tripkey
+
+namespace: tripkey
+
+resources:
+  - namespace.yaml
+  - frontend-deployment.yaml
+  - frontend-service.yaml
+  - backend-deployment.yaml
+  - backend-service.yaml
+  - backend-hpa.yaml
+  - ai-engine-deployment.yaml
+  - ai-engine-service.yaml
+  - ai-engine-hpa.yaml
+  - ai-worker-deployment.yaml
+  - ai-worker-service.yaml
+  - ai-worker-hpa.yaml
+  - ingress.yaml
+
+images:
+  - name: 000000000000.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-frontend
+    newName: 400524748280.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-frontend
+    newTag: latest
+  - name: 000000000000.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-backend
+    newName: 400524748280.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-backend
+    newTag: latest
+  - name: 000000000000.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-ai-engine
+    newName: 400524748280.dkr.ecr.ap-northeast-2.amazonaws.com/tripkey-ai-engine
+    newTag: latest

--- a/infra/k8s/kustomization.yaml
+++ b/infra/k8s/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ai-engine-deployment.yaml
   - ai-engine-service.yaml
   - ai-engine-hpa.yaml
+  - ai-worker-service-account.yaml
   - ai-worker-deployment.yaml
   - ai-worker-service.yaml
   - ai-worker-hpa.yaml

--- a/infra/k8s/namespace.yaml
+++ b/infra/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tripkey
+  labels:
+    app.kubernetes.io/name: tripkey
+


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- Docker Compose 기반 TripKey 서비스를 EKS 운영 환경으로 확장할 수 있도록 Kubernetes 매니페스트와 HPA 초기 구성을 추가했습니다.

## 🔗 관련 이슈

closes #232

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- `infra/k8s/` 하위에 frontend, backend, ai-engine, ai-worker의 Deployment/Service 및 HPA 구성을 추가했습니다.
- AWS Load Balancer Controller 기준 Ingress를 추가했고, `usetripkey.com` / ACM 인증서 / HTTPS redirect / `/api` -> `/v1` rewrite 구성을 포함했습니다.
- `ai-worker`는 현재 backend 이미지를 재사용하며, `APP_ROLE=api` / `APP_ROLE=ai-worker`로 API 서버와 worker 역할을 분리했습니다.
- ai-worker의 IRSA 연동을 위해 ServiceAccount annotation을 추가했고, AWS SDK WebIdentity 사용을 위해 backend에 `software.amazon.awssdk:sts` 의존성을 추가했습니다.
- Secret/ConfigMap 실제 값은 이 PR 범위에서 제외하고 placeholder 참조만 남겼습니다.
- Supabase pooler 사용 시 `SUPABASE_DB_URL`에 `prepareThreshold=0`이 필요하므로 `infra/k8s/README.md`에 운영 주의사항으로 문서화했습니다.
- 현재 GitHub Actions 배포 워크플로우는 EC2 대상이므로, EKS 자동 배포 전환은 후속 작업으로 분리했습니다.

검증:
- `./gradlew test` 성공
- EKS 환경에서 `kubectl apply -k infra/k8s/` 적용 확인
- EKS Pod 정상 Running 확인
- HPA 확인
  - `tripkey-backend`: min 2 / max 6
  - `tripkey-ai-engine`: min 2 / max 8
  - `tripkey-ai-worker`: min 1 / max 5
- ALB Ingress 생성 및 Route53 `usetripkey.com` HTTPS 접근 확인
- frontend 실제 dump 흐름 통과 확인

## 📸 스크린샷

없음