### PR TITLE
chore: migrate deploy workflow to EKS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,86 @@
-name: Deploy to EC2
+name: Deploy to EKS
 
 on:
   push:
     branches:
       - develop
 
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-eks-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || secrets.AWS_REGION }}
+  EKS_CLUSTER_NAME: ${{ vars.EKS_CLUSTER_NAME || 'tripkey-prod' }}
+  K8S_NAMESPACE: tripkey
+
 jobs:
   build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      ecr-registry: ${{ steps.login-ecr.outputs.registry }}
+      image-tag: ${{ steps.image-meta.outputs.image-tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Prepare image metadata
+        id: image-meta
+        run: echo "image-tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push frontend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.image-meta.outputs.image-tag }}
+        run: |
+          docker build \
+            --build-arg VITE_API_BASE_URL=/api \
+            -t "$ECR_REGISTRY/tripkey-frontend:$IMAGE_TAG" \
+            -t "$ECR_REGISTRY/tripkey-frontend:latest" \
+            apps/frontend
+          docker push "$ECR_REGISTRY/tripkey-frontend:$IMAGE_TAG"
+          docker push "$ECR_REGISTRY/tripkey-frontend:latest"
+
+      - name: Build and push backend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.image-meta.outputs.image-tag }}
+        run: |
+          docker build \
+            -t "$ECR_REGISTRY/tripkey-backend:$IMAGE_TAG" \
+            -t "$ECR_REGISTRY/tripkey-backend:latest" \
+            apps/backend
+          docker push "$ECR_REGISTRY/tripkey-backend:$IMAGE_TAG"
+          docker push "$ECR_REGISTRY/tripkey-backend:latest"
+
+      - name: Build and push ai-engine
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.image-meta.outputs.image-tag }}
+        run: |
+          docker build \
+            -t "$ECR_REGISTRY/tripkey-ai-engine:$IMAGE_TAG" \
+            -t "$ECR_REGISTRY/tripkey-ai-engine:latest" \
+            apps/ai-engine
+          docker push "$ECR_REGISTRY/tripkey-ai-engine:$IMAGE_TAG"
+          docker push "$ECR_REGISTRY/tripkey-ai-engine:latest"
+
+  deploy:
+    needs: build-and-push
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -15,91 +89,43 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
 
-      - name: Login to ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+      - name: Configure kubeconfig
+        run: |
+          aws eks update-kubeconfig \
+            --region "$AWS_REGION" \
+            --name "$EKS_CLUSTER_NAME"
 
-      - name: Build and push frontend
+      - name: Apply Kubernetes manifests
+        run: kubectl apply -k infra/k8s/
+
+      - name: Deploy pushed images
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ needs.build-and-push.outputs.ecr-registry }}
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image-tag }}
         run: |
-          docker build -t $ECR_REGISTRY/tripkey-frontend:latest \
-            --build-arg VITE_API_BASE_URL=/api \
-            apps/frontend
-          docker push $ECR_REGISTRY/tripkey-frontend:latest
+          kubectl -n "$K8S_NAMESPACE" set image deployment/tripkey-frontend \
+            frontend="$ECR_REGISTRY/tripkey-frontend:$IMAGE_TAG"
 
-      - name: Build and push backend
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          kubectl -n "$K8S_NAMESPACE" set image deployment/tripkey-backend \
+            backend="$ECR_REGISTRY/tripkey-backend:$IMAGE_TAG"
+
+          kubectl -n "$K8S_NAMESPACE" set image deployment/tripkey-ai-engine \
+            ai-engine="$ECR_REGISTRY/tripkey-ai-engine:$IMAGE_TAG"
+
+          kubectl -n "$K8S_NAMESPACE" set image deployment/tripkey-ai-worker \
+            ai-worker="$ECR_REGISTRY/tripkey-backend:$IMAGE_TAG"
+
+      - name: Wait for rollout
         run: |
-          docker build -t $ECR_REGISTRY/tripkey-backend:latest apps/backend
-          docker push $ECR_REGISTRY/tripkey-backend:latest
+          kubectl -n "$K8S_NAMESPACE" rollout status deployment/tripkey-frontend --timeout=5m
+          kubectl -n "$K8S_NAMESPACE" rollout status deployment/tripkey-backend --timeout=8m
+          kubectl -n "$K8S_NAMESPACE" rollout status deployment/tripkey-ai-engine --timeout=8m
+          kubectl -n "$K8S_NAMESPACE" rollout status deployment/tripkey-ai-worker --timeout=8m
 
-      - name: Build and push ai-engine
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      - name: Show deployed resources
+        if: always()
         run: |
-          docker build -t $ECR_REGISTRY/tripkey-ai-engine:latest apps/ai-engine
-          docker push $ECR_REGISTRY/tripkey-ai-engine:latest
-
-  deploy:
-    needs: build-and-push
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Deploy via SSM
-        run: |
-          COMMAND_ID=$(aws ssm send-command \
-            --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
-            --document-name "AWS-RunShellScript" \
-            --parameters commands='[
-              "sudo -u ec2-user -H bash /home/ec2-user/tripkey-main/infra/deploy.sh"
-            ]' \
-            --query "Command.CommandId" \
-            --output text)
-
-          print_ssm_output() {
-            echo "---- SSM stdout ----"
-            aws ssm get-command-invocation \
-              --command-id $COMMAND_ID \
-              --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
-              --query "StandardOutputContent" \
-              --output text || true
-            echo "---- SSM stderr ----"
-            aws ssm get-command-invocation \
-              --command-id $COMMAND_ID \
-              --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
-              --query "StandardErrorContent" \
-              --output text || true
-          }
-
-          for i in {1..60}; do
-            STATUS=$(aws ssm get-command-invocation \
-              --command-id $COMMAND_ID \
-              --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
-              --query "Status" \
-              --output text)
-            echo "Status: $STATUS"
-            if [ "$STATUS" = "Success" ]; then
-              echo "Deploy succeeded"
-              exit 0
-            elif [ "$STATUS" = "Failed" ]; then
-              echo "Deploy failed"
-              print_ssm_output
-              exit 1
-            fi
-            sleep 10
-          done
-          echo "Timeout"
-          print_ssm_output
-          exit 1
+          kubectl -n "$K8S_NAMESPACE" get deploy,pods,svc,ingress,hpa

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -84,7 +84,7 @@ frontend Nginx 이미지 안에도 `/api` proxy fallback이 남아 있을 수 �
 
 이 workflow는 Kubernetes Secret 값을 생성하거나 갱신하지 않는다. 앱 Secret은 기존 EKS `tripkey-secrets`, `tripkey-config`를 계속 사용한다.
 
-기존 EC2 SSM 기반 Docker Compose 배포는 더 이상 수행하지 않는다. `usetripkey.com`이 EKS Ingress ALB를 바라보는 상태에서는 ECR push만으로는 Pod가 자동 갱신되지 않으므로, EKS rollout 단계가 필요하다.
+기존 EC2 SSM 기반 Docker Compose 배포는 더 이상 수행하지 않는다. `usetripkey.com`이 EKS Ingress ALB를 바라보므로, ECR에 이미지를 push하는 것만으로는 실행 중인 EKS Pod가 바뀌지 않는다. 따라서 workflow에서 `kubectl set image`와 `kubectl rollout status`를 실행해 EKS Deployment를 자동 갱신한다.
 
 ## Secret / ConfigMap 주의사항
 

--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -54,6 +54,38 @@ kubectl apply -k infra/k8s/
 
 frontend Nginx 이미지 안에도 `/api` proxy fallback이 남아 있을 수 있지만, EKS 운영 환경의 외부 트래픽은 기본적으로 ALB Ingress에서 먼저 라우팅한다.
 
+## GitHub Actions 배포
+
+`.github/workflows/deploy.yml`은 `develop` branch push 시 ECR 이미지를 build/push한 뒤 EKS Deployment를 갱신한다.
+
+배포 흐름:
+
+1. GitHub Actions가 AWS IAM Role을 OIDC로 assume한다.
+2. frontend, backend, ai-engine 이미지를 ECR에 push한다.
+3. 각 이미지는 `latest`와 `GITHUB_SHA` 태그를 함께 push한다.
+4. `kubectl apply -k infra/k8s/`로 매니페스트를 적용한다.
+5. `kubectl set image`로 Deployment 이미지를 `GITHUB_SHA` 태그로 갱신한다.
+6. `kubectl rollout status`로 rollout 성공 여부를 확인한다.
+
+필요한 GitHub 설정:
+
+- Repository secret
+  - `AWS_ROLE_TO_ASSUME`: GitHub Actions가 assume할 AWS IAM Role ARN
+- Repository variable 또는 secret
+  - `AWS_REGION`: `ap-northeast-2`
+  - `EKS_CLUSTER_NAME`: `tripkey-prod`
+
+권장 AWS 권한 구성:
+
+- GitHub OIDC provider를 IAM에 등록한다.
+- GitHub Actions용 IAM Role을 만든다.
+- 해당 Role에 ECR image push 권한과 EKS cluster 조회 권한을 부여한다.
+- EKS Access Entry 또는 `aws-auth` ConfigMap을 통해 해당 IAM Role이 Kubernetes 리소스를 apply/patch/get 할 수 있게 한다.
+
+이 workflow는 Kubernetes Secret 값을 생성하거나 갱신하지 않는다. 앱 Secret은 기존 EKS `tripkey-secrets`, `tripkey-config`를 계속 사용한다.
+
+기존 EC2 SSM 기반 Docker Compose 배포는 더 이상 수행하지 않는다. `usetripkey.com`이 EKS Ingress ALB를 바라보는 상태에서는 ECR push만으로는 Pod가 자동 갱신되지 않으므로, EKS rollout 단계가 필요하다.
+
 ## Secret / ConfigMap 주의사항
 
 `tripkey-config`와 `tripkey-secrets`의 실제 값은 이 디렉터리의 YAML에 커밋하지 않는다. 특히 DB URL, API key, Supabase key는 Kubernetes Secret 또는 별도 Secret 관리 도구에서 주입한다.


### PR DESCRIPTION
## 📝 작업 내용

- GitHub Actions 배포 대상을 EC2 SSM/Docker Compose에서 EKS rollout 방식으로 전환했습니다.

## 🔗 관련 이슈

closes #234 

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- 기존 EC2 SSM 배포 단계를 제거하고 EKS 배포 단계로 교체했습니다.
- 이미지는 `latest`와 `GITHUB_SHA` 태그를 함께 push하고, EKS Deployment에는 `GITHUB_SHA` 태그를 반영합니다.
- `ai-worker`는 backend 이미지를 재사용하므로 `tripkey-backend:${GITHUB_SHA}`로 갱신합니다.
- 이 workflow는 Kubernetes Secret/ConfigMap 값을 생성하거나 갱신하지 않습니다.
- 실행 전 GitHub `AWS_ROLE_TO_ASSUME` secret과 AWS IAM OIDC/EKS Access Entry 설정이 필요합니다.

검증:
- workflow YAML 파싱 확인
- `kubectl kustomize infra/k8s/` 성공
- `git diff --check` 성공

## 📸 스크린샷

없음