### PR TITLE
fix(infra): #240 prod 헬스체크 유료 Places API 호출 제거 (무사용 과금)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,11 +34,13 @@ services:
       ai-engine:
         condition: service_started
     restart: unless-stopped
+    # 컨테이너 liveness 전용: 외부 유료 API(Google Places)를 호출하지 않는 로컬 health 엔드포인트만 사용한다.
+    # (이전엔 /v1/trips/destinations/search?q=health 를 30초마다 호출해 무사용 시에도 Places Autocomplete 비용이 발생했다.)
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "curl -fsS 'http://localhost:8080/v1/trips/destinations/search?q=health' >/dev/null",
+          "curl -fsS 'http://localhost:8080/v1/health' >/dev/null",
         ]
       interval: 30s
       timeout: 5s

--- a/infra/DEPLOY_RUNBOOK.md
+++ b/infra/DEPLOY_RUNBOOK.md
@@ -173,7 +173,7 @@ curl -G 'http://<EC2_PUBLIC_IP>/api/trips/destinations/search' --data-urlencode 
 backend와 ai-engine이 EC2 외부에서 직접 접근되지 않는지 확인합니다.
 
 ```bash
-curl --connect-timeout 5 http://<EC2_PUBLIC_IP>:8080/v1/trips/destinations/search?q=health
+curl --connect-timeout 5 http://<EC2_PUBLIC_IP>:8080/v1/health
 curl --connect-timeout 5 http://<EC2_PUBLIC_IP>:8000/health
 ```
 


### PR DESCRIPTION
## 📝 작업 내용

- prod `backend` 헬스체크가 30초마다 유료 Google Places Autocomplete를 호출하던 문제를 제거 (무사용 시에도 하루 약 1만원 과금)

## 🔗 관련 이슈

closes #240

## 🗂️ 변경 범위

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서 (docker-compose.prod.yml, infra/DEPLOY_RUNBOOK.md)

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (`/v1/health` = 기존 `HealthController`, 외부 호출 없이 200 응답)
- [x] 기존 기능이 깨지지 않았나요? (헬스체크는 liveness 용도로 더 적합해짐 — 외부 의존성 다운 시에도 컨테이너 재시작 방지)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- 원인: `TripService.searchDestinations`가 캐시·최소길이 검증 없이 무조건 AI 엔진 → Google Places Autocomplete를 호출하는데, 헬스체크가 이 엔드포인트를 30초마다 때리고 있었습니다.
- 신규 EKS k8s probe(`infra/k8s/backend-deployment.yaml`)는 이미 `/v1/health`를 사용 중이라 변경하지 않았고, 본 PR은 레거시 `docker-compose.prod.yml` 경로의 동일 문제를 정리합니다.
- 후속(별도 이슈 권장): 목적지 Autocomplete 캐시 부재, `/test/ai/parse`·`destinations/search` 무인증 노출 등 Places 비용 관련 잠재 리스크.