### PR TITLE
feat: 덤프 입력 예시 채우기 버튼 추가

### DIFF
--- a/apps/frontend/src/components/dump/DumpForm.css
+++ b/apps/frontend/src/components/dump/DumpForm.css
@@ -8,11 +8,40 @@
   gap: 12px;
 }
 
+.dump-form__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .dump-form__title {
   margin: 0;
   font-size: 15px;
   font-weight: 600;
   color: #111827;
+}
+
+.dump-form__example-btn {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #6c5ce7;
+  background-color: #f3f1fd;
+  border: 1px solid #d9d3f7;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.dump-form__example-btn:hover {
+  background-color: #e9e4fb;
+  border-color: #c4baf2;
+}
+
+.dump-form__example-btn:active {
+  background-color: #ddd5f7;
 }
 
 .dump-form__required {

--- a/apps/frontend/src/components/dump/DumpForm.tsx
+++ b/apps/frontend/src/components/dump/DumpForm.tsx
@@ -13,6 +13,11 @@ const PLACEHOLDER = `도쿄 여행 3박 4일 계획중이야`;
 const HELPER_TEXT =
   '메모, 카톡 대화, 검색 기록 등을 자유롭게 붙여넣어 주세요 (최소 10자 이상)';
 
+const EXAMPLE_TEXT = `꼭 가보고 싶은 명소가 몇 군데 있어, 여긴 무조건 갈 거야.
+현지에서 유명한 맛집이랑 분위기 좋은 카페 추천 받고 싶어.
+체험거리도 하나쯤 하고 싶은데 뭐가 좋을지 모르겠어.
+쇼핑은 어디가 좋을지 아직 못 정했어.`;
+
 const DumpForm = ({ dumpText, dumpTextCount, onTextChange }: DumpFormProps) => {
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onTextChange(event.target.value);
@@ -37,9 +42,18 @@ const DumpForm = ({ dumpText, dumpTextCount, onTextChange }: DumpFormProps) => {
 
   return (
     <div className="dump-form">
-      <h2 className="dump-form__title">
-        여행 정보 <span className="dump-form__required">*</span>
-      </h2>
+      <div className="dump-form__header">
+        <h2 className="dump-form__title">
+          여행 정보 <span className="dump-form__required">*</span>
+        </h2>
+        <button
+          type="button"
+          className="dump-form__example-btn"
+          onClick={() => onTextChange(EXAMPLE_TEXT)}
+        >
+          가이드 문장 채우기
+        </button>
+      </div>
 
       <div className="dump-textarea-wrapper">
         <textarea


### PR DESCRIPTION
## 📝 작업 내용

> 덤프 화면에서 버튼 한 번으로 입력란에 예시 문장을 채워, 사용성 개선.

- 덤프 폼 우측 상단에 '가이드 문장 채우기' 버튼 추가
- 클릭 시 입력란(dumpText)을 지역명 없는 공통 예시 문장으로 채움
- 버튼 스타일 및 우측 정렬 적용

## 🔗 관련 이슈

closes #243

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게


## 📸 스크린샷
<img width="690" height="433" alt="image" src="https://github.com/user-attachments/assets/22390c7b-e884-4085-befc-bcd67995cfc4" />

