### PR TITLE
fix(be): #245 구조화 편집(숙소/항공) 위치 변경 시 재처리 트리거 + 계약 일치

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/place/CardController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/CardController.java
@@ -55,7 +55,11 @@ public class CardController {
                     2. 구조화 필드 수정
                     - 숙소 카드: location / check_in / check_out
                     - 교통 카드: location / time_constraint / flight_number
-                    - 구조화 필드 수정 시 processing_status가 processing으로 전환되고 enrichment가 재처리됩니다.
+                    - 위치(location, 교통은 공항)가 변경되면 processing_status가 processing으로 전환되고
+                      Places lookup/enrichment가 비동기로 재처리됩니다. 성공 시 processing_status가
+                      processing이 아닌 상태(completed 또는 좌표 미확보 시 needs_input)로 종료됩니다.
+                    - 위치 외 필드(check_in / check_out / time_constraint / flight_number)만 변경 시에는
+                      값만 저장되고 재처리하지 않습니다.
 
                     3. notes 입력
                     - notes는 모든 카드에 저장됩니다.

--- a/apps/backend/src/main/java/com/tripkey/domain/place/CardService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/CardService.java
@@ -121,22 +121,38 @@ public class CardService {
         }
         boolean shouldTriggerNotesParsing = notesInput != null && card.canStartNaturalLanguageParsingFromNotes();
 
+        // 구조화 편집: 위치(좌표/장소에 영향)가 실제로 바뀐 경우에만 재처리를 트리거한다.
+        // 체크인/체크아웃·시간·편명만 바뀌면 값만 저장(불필요한 processing 강등 방지).
+        boolean structuredReprocessNeeded = false;
+
         boolean accommodationEdit = "accommodation".equals(card.getCategory())
                 && (request.location() != null || request.checkIn() != null || request.checkOut() != null);
         if (accommodationEdit) {
-            card.applyAccommodationEdit(request.location(), request.checkIn(), request.checkOut());
+            structuredReprocessNeeded |= card.applyAccommodationEdit(
+                    request.location(), request.checkIn(), request.checkOut());
         }
 
         boolean transportEdit = "transport".equals(card.getCategory())
                 && (request.location() != null || request.timeConstraint() != null || request.flightNumber() != null);
         if (transportEdit) {
-            card.applyTransportEdit(request.location(), request.timeConstraint(), request.flightNumber());
+            structuredReprocessNeeded |= card.applyTransportEdit(
+                    request.location(), request.timeConstraint(), request.flightNumber());
         }
 
+        // notes 자연어 재파싱이 우선. (FE는 구조화 편집과 notes를 분리 전송)
         if (shouldTriggerNotesParsing) {
             card.markCardLevelParsingStarted();
             placeCardRepository.save(card);
             triggerInputParsingAfterCommit(tripId, instanceId, notesInput);
+            return CardDto.from(card);
+        }
+
+        // 구조화 위치 변경 → notes 경로와 동일한 비동기 재처리(Places lookup/enrichment) 트리거.
+        // naturalLanguageInput=null 이면 AI 가 카드의 구조화 필드 기준으로 재파싱한다.
+        if (structuredReprocessNeeded) {
+            card.markCardLevelParsingStarted();
+            placeCardRepository.save(card);
+            triggerInputParsingAfterCommit(tripId, instanceId, null);
             return CardDto.from(card);
         }
 

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -11,6 +11,7 @@ import org.locationtech.jts.geom.Point;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -230,9 +231,17 @@ public class PlaceCard {
         this.dayOrder = null;
     }
 
-    public void applyAccommodationEdit(String location, String checkIn, String checkOut) {
+    /**
+     * 숙소 구조화 편집. 위치(좌표에 영향)가 실제로 바뀐 경우에만 true 를 반환해
+     * 호출부가 재처리(Places lookup) 트리거 여부를 결정한다. 체크인/체크아웃만 바뀌면
+     * 값만 저장하고 재처리하지 않는다(불필요한 processing 강등 방지).
+     */
+    public boolean applyAccommodationEdit(String location, String checkIn, String checkOut) {
+        boolean locationChanged = false;
         if (location != null) {
-            this.location = trimToNull(location);
+            String normalized = trimToNull(location);
+            locationChanged = !Objects.equals(normalized, this.location);
+            this.location = normalized;
         }
         if (checkIn != null) {
             this.checkIn = trimToNull(checkIn);
@@ -240,12 +249,20 @@ public class PlaceCard {
         if (checkOut != null) {
             this.checkOut = trimToNull(checkOut);
         }
-        markReprocessing();
+        return locationChanged;
     }
 
-    public void applyTransportEdit(String location, String timeConstraint, String flightNumber) {
+    /**
+     * 교통(항공 포함) 구조화 편집. 위치(공항)가 실제로 바뀐 경우에만 true 를 반환한다.
+     * 시간(time_constraint)·편명만 바뀌면 값만 저장한다. 항공 시각의 flight_datetime 정규화는
+     * 위치 변경으로 재처리가 트리거될 때 AI 파싱 결과로 반영된다.
+     */
+    public boolean applyTransportEdit(String location, String timeConstraint, String flightNumber) {
+        boolean locationChanged = false;
         if (location != null) {
-            this.location = trimToNull(location);
+            String normalized = trimToNull(location);
+            locationChanged = !Objects.equals(normalized, this.location);
+            this.location = normalized;
         }
         if (timeConstraint != null) {
             this.timeConstraint = trimToNull(timeConstraint);
@@ -253,7 +270,7 @@ public class PlaceCard {
         if (flightNumber != null) {
             this.flightNumber = trimToNull(flightNumber);
         }
-        markReprocessing();
+        return locationChanged;
     }
 
     public boolean canStartNaturalLanguageParsingFromNotes() {
@@ -339,11 +356,6 @@ public class PlaceCard {
 
     public void markFailed() {
         this.processingStatus = "failed";
-        recomputeActionType();
-    }
-
-    private void markReprocessing() {
-        this.processingStatus = "processing";
         recomputeActionType();
     }
 

--- a/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
@@ -339,10 +339,35 @@ class CardServiceTest {
     }
 
     @Test
-    void patchCardAccommodationEditTriggersReprocessing() {
+    void patchCardAccommodationLocationChangeTriggersReprocessing() {
+        UUID tripId = UUID.randomUUID();
+        UUID instanceId = UUID.randomUUID();
+        PlaceCard card = userAccommodationCard(tripId); // location 없음
+        card.markProcessingCompleted();
+
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findByInstanceIdAndTripId(instanceId, tripId))
+                .thenReturn(Optional.of(card));
+        when(placeCardRepository.save(any(PlaceCard.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CardPatchRequest request = new CardPatchRequest(
+                null, null, null, null, null, null, null, null, "오사카 난바", null
+        );
+
+        CardDto updated = cardService.patchCard(tripId, instanceId, request);
+
+        assertThat(updated.processingStatus()).isEqualTo("processing");
+        assertThat(updated.location()).isEqualTo("오사카 난바");
+        verify(cardInputParsingProcessor).parseAndEnrich(tripId, instanceId, null);
+    }
+
+    @Test
+    void patchCardAccommodationCheckInOnlyDoesNotTriggerReprocessing() {
         UUID tripId = UUID.randomUUID();
         UUID instanceId = UUID.randomUUID();
         PlaceCard card = userAccommodationCard(tripId);
+        card.markProcessingCompleted();
 
         when(tripRepository.existsById(tripId)).thenReturn(true);
         when(placeCardRepository.findByInstanceIdAndTripId(instanceId, tripId))
@@ -356,9 +381,88 @@ class CardServiceTest {
 
         CardDto updated = cardService.patchCard(tripId, instanceId, request);
 
-        assertThat(updated.processingStatus()).isEqualTo("processing");
+        assertThat(updated.processingStatus()).isEqualTo("completed");
         assertThat(updated.checkIn()).isEqualTo("2025-08-02");
         assertThat(updated.checkOut()).isEqualTo("2025-08-05");
+        verify(cardInputParsingProcessor, never()).parseAndEnrich(any(), any(), any());
+    }
+
+    @Test
+    void patchCardAccommodationSameLocationDoesNotTriggerReprocessing() {
+        UUID tripId = UUID.randomUUID();
+        UUID instanceId = UUID.randomUUID();
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, "난바 호텔", "accommodation", "오사카 난바", null, null, null,
+                "2025-08-01", "2025-08-04", null);
+        card.markProcessingCompleted();
+
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findByInstanceIdAndTripId(instanceId, tripId))
+                .thenReturn(Optional.of(card));
+        when(placeCardRepository.save(any(PlaceCard.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CardPatchRequest request = new CardPatchRequest(
+                null, null, null, null, null, "2025-08-03", null, null, "오사카 난바", null
+        );
+
+        CardDto updated = cardService.patchCard(tripId, instanceId, request);
+
+        assertThat(updated.processingStatus()).isEqualTo("completed");
+        assertThat(updated.checkIn()).isEqualTo("2025-08-03");
+        verify(cardInputParsingProcessor, never()).parseAndEnrich(any(), any(), any());
+    }
+
+    @Test
+    void patchCardTransportAirportChangeTriggersReprocessing() {
+        UUID tripId = UUID.randomUUID();
+        UUID instanceId = UUID.randomUUID();
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, "김포 → 오사카", "transport", "김포공항", null, "08:30 출발", null,
+                null, null, "KE723");
+        card.markProcessingCompleted();
+
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findByInstanceIdAndTripId(instanceId, tripId))
+                .thenReturn(Optional.of(card));
+        when(placeCardRepository.save(any(PlaceCard.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CardPatchRequest request = new CardPatchRequest(
+                null, null, null, null, null, null, null, null, "인천공항", null
+        );
+
+        CardDto updated = cardService.patchCard(tripId, instanceId, request);
+
+        assertThat(updated.processingStatus()).isEqualTo("processing");
+        assertThat(updated.location()).isEqualTo("인천공항");
+        verify(cardInputParsingProcessor).parseAndEnrich(tripId, instanceId, null);
+    }
+
+    @Test
+    void patchCardTransportTimeOnlyDoesNotTriggerReprocessing() {
+        UUID tripId = UUID.randomUUID();
+        UUID instanceId = UUID.randomUUID();
+        PlaceCard card = PlaceCard.createUserCard(
+                tripId, "김포 → 오사카", "transport", "김포공항", null, "08:30 출발", null,
+                null, null, "KE723");
+        card.markProcessingCompleted();
+
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findByInstanceIdAndTripId(instanceId, tripId))
+                .thenReturn(Optional.of(card));
+        when(placeCardRepository.save(any(PlaceCard.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CardPatchRequest request = new CardPatchRequest(
+                null, null, null, null, null, null, null, null, null, "09:00 출발"
+        );
+
+        CardDto updated = cardService.patchCard(tripId, instanceId, request);
+
+        assertThat(updated.processingStatus()).isEqualTo("completed");
+        assertThat(updated.timeConstraint()).isEqualTo("09:00 출발");
+        verify(cardInputParsingProcessor, never()).parseAndEnrich(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용

- 숙소/항공·교통 구조화 편집(PATCH /cards)이 `processing`만 찍고 소비자가 없어 카드가 영구 정지하던 버그 수정
- notes 경로와 동일한 비동기 재처리(Places lookup/enrichment)를 재사용 → 좌표/분류 확정 후 `processing_status != processing`으로 종료
- 문서(Swagger)와 구현 간 계약 불일치 해소

## 🔗 관련 이슈

closes #245
관련: #230(Phase 1 notes), #181(좌표 미확보 강등 패턴)

## 🗂️ 변경 범위

- [ ] Frontend
- [x] Backend (apps/backend)
- [ ] AI Engine
- [ ] 공통/설정/문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (`CardServiceTest` 25개 통과, 0 실패)
- [x] 기존 기능이 깨지지 않았나요? (notes 경로/PlaceCardTest 회귀 통과)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 🔧 핵심 변경

- `PlaceCard.applyAccommodationEdit/applyTransportEdit`: 무조건 `markReprocessing()` 하던 것을 제거하고 **위치(공항) 실제 변경 여부**를 boolean 반환. (미사용된 `markReprocessing()` 제거)
- `CardService.patchCard`: **위치 변경 시에만** `markCardLevelParsingStarted()` + `triggerInputParsingAfterCommit(..., null)`로 재처리 트리거. 위치 외 필드(체크인/체크아웃/시간/편명)만 변경 시 저장만. notes 경로 우선.
- `CardController` Swagger 문구를 실제 동작에 맞게 정정.

## 🧩 product 결정 (확정)

1. 재처리 시점: **위치(공항) 변경 시에만**
2. 항공 시간: 재처리 AI가 `flight_datetime`으로 정규화 (위치 트리거 재처리 시 반영)
3. 입력 포맷: 자유 텍스트(현행 유지)
4. 실패 종료 상태: **#181 패턴 통일** (좌표 미확보 시 undecided+needs_input 강등, 그 외 failed)

## 👀 리뷰어에게

- `naturalLanguageInput=null`로 `CardInputParsingProcessor.parseAndEnrich`를 재사용합니다. `AiCardParseRequest`는 `@JsonInclude(NON_NULL)`이라 null 안전, AI가 카드 구조화 필드 기준으로 재파싱합니다.
- 위치만 트리거하므로, 항공 "시간"만 단독 수정 시엔 `time_constraint`에 저장되고 다음 위치-트리거 재처리 때 `flight_datetime`으로 정규화됩니다. (결정 1+2의 상호작용 — 의도된 동작)
- notes + 구조화 동시 전송 시 notes 경로가 우선합니다(FE는 분리 전송 예정).