### PR TITLE
Fix/248 scr04 enter with unresolved cards

### DIFF
--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -562,6 +562,32 @@ const ArrangePage = () => {
     }
   };
 
+  // 배치된 카드 중 좌표(지도 위치)가 없는 카드에 대한 안내 경고를 합성한다.
+  // 백엔드 RouteValidator 는 geom 이 null 인 카드를 거리 검증에서 조용히 제외하고
+  // 경고를 내려주지 않으므로(배치 자체는 허용), FE 가 검증 흐름에서 보완 안내한다.
+  const buildMissingLocationWarnings = (): RouteWarning[] => {
+    const noCoordsNames = new Map(
+      (cardsQuery.data?.cards ?? [])
+        .filter((card) => card.coordinates == null)
+        .map((card) => [card.instance_id, card.name])
+    );
+    const warnings: RouteWarning[] = [];
+    days.forEach((day, index) => {
+      day.cards.forEach((card) => {
+        if (!noCoordsNames.has(card.id)) return;
+        warnings.push({
+          type: 'missing_location',
+          day: index + 1,
+          instance_ids: [card.id],
+          message: `'${noCoordsNames.get(card.id) ?? card.name}' 카드는 위치 정보가 없어 거리 검증에서 제외됐어요. 정확한 장소를 확인해 주세요.`,
+          distance_meters: null,
+          total_minutes: null,
+        });
+      });
+    });
+    return warnings;
+  };
+
   // 동선 검증 — POST /verify. 경고 목록을 배너로 표시.
   const handleVerify = async () => {
     if (!tripId) return;
@@ -571,11 +597,13 @@ const ArrangePage = () => {
       const result = await verifyMutation.mutateAsync(
         buildPlacementRequest(days, durationByInstance)
       );
-      setRouteWarnings(result.route_warnings);
+      const warnings = [
+        ...result.route_warnings,
+        ...buildMissingLocationWarnings(),
+      ];
+      setRouteWarnings(warnings);
       setNotice(
-        result.route_warnings.length === 0
-          ? '동선 문제가 발견되지 않았어요.'
-          : null
+        warnings.length === 0 ? '동선 문제가 발견되지 않았어요.' : null
       );
     } catch (error) {
       setActionError(errorMessageOf(error, '동선 검증에 실패했습니다.'));
@@ -591,7 +619,10 @@ const ArrangePage = () => {
       const result = await confirmMutation.mutateAsync(
         buildPlacementRequest(days, durationByInstance)
       );
-      setRouteWarnings(result.route_warnings);
+      setRouteWarnings([
+        ...result.route_warnings,
+        ...buildMissingLocationWarnings(),
+      ]);
       setConfirmed(true);
       setNotice('일정이 확정되었습니다.');
     } catch (error) {

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -301,22 +301,16 @@ const GroupingPage = () => {
       ...state.groups.review_only,
     ].some((card) => card.processing_status === 'processing');
 
-  // 아직 입력/선택/수정이 필요한 카드가 남아 있으면(진행률 100% 미만) 다음 단계 차단.
-  const hasUnresolvedCards =
-    state.phase === 'ready' &&
-    state.groups.input_required.length +
-      state.groups.select_required.length +
-      state.groups.fix_required.length >
-      0;
+  // SCR-04 진입은 미해결 카드(input/select/fix_required) 잔존 여부로 차단하지 않는다.
+  // 기획상 SCR-04는 "완성된 카드만 배치하는 화면"이 아니라, 위치/좌표가 아직 없는
+  // 카드도 사용자가 Day에 올려보며 적합성을 확인하는 화면이기 때문이다.
+  // (재파싱 processing 중인 카드만 일시적으로 대기시킨다.)
+  const nextDisabled = busy || hasProcessingCard;
 
-  const nextDisabled = busy || hasProcessingCard || hasUnresolvedCards;
-
-  // 차단 사유에 맞는 안내 문구. 미해결 카드가 우선(사용자가 할 일이 있음).
-  const nextGuideText = hasUnresolvedCards
-    ? '모든 카드를 확인·선택한 뒤 다음 단계로 진행할 수 있어요.'
-    : hasProcessingCard
-      ? '카드 정보를 정리하는 중이에요. 잠시 후 다시 시도해 주세요.'
-      : undefined;
+  // 재파싱 진행 중일 때만 안내. 미해결 카드는 차단 사유가 아니므로 문구를 띄우지 않는다.
+  const nextGuideText = hasProcessingCard
+    ? '카드 정보를 정리하는 중이에요. 잠시 후 다시 시도해 주세요.'
+    : undefined;
 
   const loading = state.phase === 'loading';
 

--- a/apps/frontend/src/utils/arrange-mapper.ts
+++ b/apps/frontend/src/utils/arrange-mapper.ts
@@ -186,6 +186,21 @@ const canResolveByNotes = (card: Card): boolean =>
   (card.processing_status === 'failed' &&
     card.classification !== 'open_question');
 
+/**
+ * 좌표(지도 위치)만 없을 뿐, 그 외에는 배치 가능한 카드인지 판정한다.
+ * 백엔드 GroupService.getGroups04 의 버킷 순서를 그대로 미러링한다:
+ * blocked/needs_input/failed 가 아니면서 geom 만 null 이라 unavailable 로 분류된 케이스.
+ *
+ * 기획상 위치/좌표 없음은 자동 묶기·동선 검증의 제약 사유일 뿐, 사용자가 Day 에
+ * 직접 올려 확인하는 행위 자체를 막는 사유는 아니다. 이런 카드는 드래그 가능한
+ * 스톡 카드("위치 확인 필요" 배지)로 노출한다. (needs_input 은 PRD 상 배치 불가이므로 제외)
+ */
+const isPlaceableDespiteMissingLocation = (card: Card): boolean =>
+  card.coordinates == null &&
+  card.placement_status !== 'needs_input' &&
+  card.placement_status !== 'blocked' &&
+  card.processing_status !== 'failed';
+
 const flightLabel = (card: Card): string | undefined => {
   const date = parseDate(card.flight_datetime);
   const time = fmtTime(card.flight_datetime);
@@ -360,8 +375,25 @@ export const mapToArrangeViewModel = (
     });
   }
 
-  const unavailable = groups04.unavailable
-    .filter(isUnplaced)
+  // 백엔드 unavailable 은 (a) 좌표만 없는 배치 가능 카드와 (b) 입력·확인이 필요한
+  // 진짜 처리 필요 카드가 섞여 있다. (a)는 드래그 가능한 스톡 카드로, (b)는 기존대로
+  // 드래그 불가 안내 카드로 분리한다.
+  const unavailableCards = groups04.unavailable.filter(isUnplaced);
+
+  const placeableNoLocation = unavailableCards
+    .filter(isPlaceableDespiteMissingLocation)
+    .map(cardToStockCard);
+  if (placeableNoLocation.length > 0) {
+    groups.push({
+      id: 'needs-location',
+      title: '위치 확인이 필요한 카드',
+      description: '지도 위치만 아직 없어요. 직접 Day에 올려 확인할 수 있어요.',
+      cards: placeableNoLocation,
+    });
+  }
+
+  const unavailable = unavailableCards
+    .filter((card) => !isPlaceableDespiteMissingLocation(card))
     .map((card) => cardToAttentionCard(card, 'unavailable'));
   if (unavailable.length > 0) {
     groups.push({


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- SCR-03 → SCR-04 전환을 **미해결 카드(action_type) 잔존 여부로 차단하지 않도록** 풀고, **위치/좌표만 없을 뿐 배치 가능한 카드**를 SCR-04에서 사용자가 직접 Day에 올려 확인할 수 있게 했습니다. 위치/좌표 부족은 배치 차단이 아니라 **동선 검증 단계의 안내 경고**로 드러납니다.

## 🔗 관련 이슈

- `closes #248`
- 브랜치: `fix/248-scr04-enter-with-unresolved-cards`
- 기획 근거: `shared/docs/TripKey_Screen_Impl_Spec_v1.0.md`(03→04 전환은 action_type으로 차단하지 않음), `shared/docs/TripKey_PRD_v3.2.md`(04 진입 항상 가능, needs_input은 해당 카드 배치 불가일 뿐 화면 이동 차단 아님)

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

변경 파일 (`develop` 기준 3 files, +80 / -23):

- `pages/GroupingPage.tsx` — SCR-03 "다음 단계로" 차단 로직에서 `hasUnresolvedCards`(input/select/fix_required 잔존) 및 차단성 안내 문구 제거
- `utils/arrange-mapper.ts` — 백엔드 `unavailable`을 "좌표만 없는 배치 가능 카드"와 "진짜 처리 필요 카드"로 분리(`isPlaceableDespiteMissingLocation`)
- `pages/ArrangePage.tsx` — 동선 검증/확정 시 좌표 없는 배치 카드에 대한 "거리 검증 제외" 경고를 FE에서 합성해 배너에 노출

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

기획상 SCR-04는 "완성된 카드만 배치하는 화면"이 아니라, 위치/좌표가 아직 없어도 사용자가 Day에 올려보며 위치·동선·일정 적합성을 확인하는 화면입니다. 기존 구현은 위치/좌표 없음이나 미해결 상태를 "04에 가기 전 해결해야 하는" 차단 사유로 취급해 확인 흐름을 막고 있었습니다. 이를 세 지점에서 풀었습니다.

- **SCR-03 진입 차단 제거 를 빼고 `busy || hasProcessingCard`만 남겼습니다. 
- 차단성 문구 `'모든 카드를 확인·선택한 뒤 다음 단계로 진행할 수 있어요.'`를 삭제했습니다.
-  **재파싱(`processing`) 중 카드만** 일시 대기시키는데, 이는 수초짜리 일시 상태이고 04에서 `pending_reorder`로 안전하게 분류되므로 유실 없이 정합적입니다.

- **좌표만 없는 배치 가능 카드 드래그 허용 
- `blocked`/`needs_input`/`failed`가 아니어도 `geom == null`이면 `unavailable`로 보냅니다. FE에 `coordinates`/`placement_status`/`processing_status`가 모두 있으므로 백엔드 버킷 순서를 그대로 미러링하는 `isPlaceableDespiteMissingLocation()`로 `unavailable`을 둘로 나눴습니다.
  - (a) 좌표만 없는 카드 → 기존 `cardToStockCard` 재사용(자동으로 `draggable: true` + "위치 확인 필요" 배지) → 새 좌측 그룹 **"위치 확인이 필요한 카드"**.
  - (b) 그 외(`needs_input`/`blocked`/`failed`) → 기존대로 `cardToAttentionCard`(드래그 불가) "처리가 필요한 카드" 유지.
  - PRD "needs_input은 해당 카드 배치 불가"와 정합: needs_input은 (b)에 남아 비활성 유지됩니다.

- **위치 없음 경고를 검증 흐름에서 노출 (`ArrangePage.tsx`)**: 백엔드 `VerifyService`/`ConfirmService`는 좌표 없는 카드의 Day 배치를 **거부 없이 허용**하지만, `RouteValidator`(및 `PlaceCardRepository`의 `geom is not null` SQL 필터)가 거리 검증에서 **조용히 제외**하고 경고를 내려주지 않습니다. 이 공백을 FE에서 보완: `buildMissingLocationWarnings()`가 보드에 배치된 카드 중 `coordinates == null`인 것을 `type: 'missing_location'` 경고로 합성해 `POST /verify`·`POST /confirm` 결과 경고와 함께 amber 배너에 노출합니다. (배치 차단이 아니라 안내로 드러남)

> 집중 리뷰 포인트: ① `isPlaceableDespiteMissingLocation`의 분기 기준이 백엔드 `getGroups04` 버킷 순서와 일치하는지, ② `processing` 카드만 차단 유지하는 결정의 타당성, ③ 좌표 없음 경고를 FE에서 합성하는 접근(BE authoritative 경고는 후속 이슈로 분리 권장).

## 📸 스크린샷

> UI 변경이 있는 경우에만 첨부해주세요.

- [ ] SCR-03: 미해결 카드(input/select/fix_required)가 남아 있어도 "다음 단계로" 활성
- [ ] SCR-04: "위치 확인이 필요한 카드" 그룹에서 카드 드래그하여 Day 배치
- [ ] SCR-04: 좌표 없는 카드 배치 후 동선 검증 시 "거리 검증 제외" 경고 노출
