### PR TITLE
Feat: SCR-05 지도 마커 UI 개선 (교통 구분·호버 카드·동선 표시)

### DIFF
--- a/apps/frontend/src/components/confirm/MapCard.tsx
+++ b/apps/frontend/src/components/confirm/MapCard.tsx
@@ -11,6 +11,7 @@ import {
 } from '@vis.gl/react-google-maps';
 import { useEffect } from 'react';
 
+import type { CardCategory } from '@/types/grouping-api';
 import { GOOGLE_MAPS_API_KEY } from '@/utils/constants';
 
 export type MapMarker = {
@@ -19,6 +20,7 @@ export type MapMarker = {
   name: string;
   lat: number;
   lng: number;
+  category?: CardCategory;
 };
 
 type MapCardProps = {

--- a/apps/frontend/src/components/confirm/MapCard.tsx
+++ b/apps/frontend/src/components/confirm/MapCard.tsx
@@ -99,6 +99,9 @@ const MapCard = ({ markers }: MapCardProps) => {
           gestureHandling="cooperative"
           mapId="tripkey-confirm-map"
           style={{ width: '100%', height: '360px' }}
+          disableDefaultUI
+          zoomControl
+          clickableIcons={false}
         >
           {markers.map((m) => {
             const isTransport = m.category === 'transport';

--- a/apps/frontend/src/components/confirm/MapCard.tsx
+++ b/apps/frontend/src/components/confirm/MapCard.tsx
@@ -8,7 +8,7 @@ import {
   Map,
   useMap,
 } from '@vis.gl/react-google-maps';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { CardCategory } from '@/types/grouping-api';
 import { GOOGLE_MAPS_API_KEY } from '@/utils/constants';
@@ -52,8 +52,35 @@ const FitBounds = ({ markers }: { markers: MapMarker[] }) => {
   return null;
 };
 
+// 장소 마커를 순서대로 잇는 단순 동선 폴리라인 (vis.gl 2D Polyline 미제공 → 직접 생성).
+const RoutePolyline = ({ path }: { path: { lat: number; lng: number }[] }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map || path.length < 2) return;
+
+    const line = new google.maps.Polyline({
+      path,
+      geodesic: true,
+      strokeColor: '#7c3aed',
+      strokeOpacity: 0.8,
+      strokeWeight: 3,
+    });
+    line.setMap(map);
+    return () => line.setMap(null);
+  }, [map, path]);
+
+  return null;
+};
+
 const MapCard = ({ markers }: MapCardProps) => {
   const [activeId, setActiveId] = useState<string | null>(null);
+
+  // 동선은 모든 마커를 순서대로 연결 (교통/공항 포함).
+  const routePath = useMemo(
+    () => markers.map((m) => ({ lat: m.lat, lng: m.lng })),
+    [markers]
+  );
 
   if (!GOOGLE_MAPS_API_KEY) {
     return (
@@ -125,6 +152,7 @@ const MapCard = ({ markers }: MapCardProps) => {
               </AdvancedMarker>
             );
           })}
+          <RoutePolyline path={routePath} />
           <FitBounds markers={markers} />
         </Map>
       </APIProvider>

--- a/apps/frontend/src/components/confirm/MapCard.tsx
+++ b/apps/frontend/src/components/confirm/MapCard.tsx
@@ -6,10 +6,9 @@ import {
   AdvancedMarker,
   APIProvider,
   Map,
-  Pin,
   useMap,
 } from '@vis.gl/react-google-maps';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { CardCategory } from '@/types/grouping-api';
 import { GOOGLE_MAPS_API_KEY } from '@/utils/constants';
@@ -21,6 +20,7 @@ export type MapMarker = {
   lat: number;
   lng: number;
   category?: CardCategory;
+  region?: string;
 };
 
 type MapCardProps = {
@@ -53,6 +53,8 @@ const FitBounds = ({ markers }: { markers: MapMarker[] }) => {
 };
 
 const MapCard = ({ markers }: MapCardProps) => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
   if (!GOOGLE_MAPS_API_KEY) {
     return (
       <div className="rounded-2xl bg-card p-6 text-center text-xs text-muted-foreground ring-1 ring-foreground/10">
@@ -71,21 +73,58 @@ const MapCard = ({ markers }: MapCardProps) => {
           mapId="tripkey-confirm-map"
           style={{ width: '100%', height: '360px' }}
         >
-          {markers.map((m) => (
-            <AdvancedMarker
-              key={m.id}
-              position={{ lat: m.lat, lng: m.lng }}
-              title={m.name}
-            >
-              <Pin
-                background="#7c3aed"
-                borderColor="#5b21b6"
-                glyphColor="#ffffff"
+          {markers.map((m) => {
+            const isTransport = m.category === 'transport';
+            const isActive = activeId === m.id;
+            return (
+              <AdvancedMarker
+                key={m.id}
+                position={{ lat: m.lat, lng: m.lng }}
+                title={m.name}
               >
-                {m.order}
-              </Pin>
-            </AdvancedMarker>
-          ))}
+                <div className="relative flex flex-col items-center">
+                  {/* 호버 카드 — 핀 위에 떠서 레이아웃에 영향 안 줌 (핀 고정) */}
+                  {isActive && (
+                    <div className="absolute bottom-full left-1/2 mb-2 flex w-max max-w-50 -translate-x-1/2 items-center gap-2 rounded-xl bg-card px-2.5 py-1.5 shadow-md ring-1 ring-foreground/10">
+                      <span
+                        aria-hidden="true"
+                        className="flex size-5 shrink-0 items-center justify-center rounded-full bg-foreground text-[10px] font-bold text-background"
+                      >
+                        {m.order}
+                      </span>
+                      <div className="min-w-0">
+                        <p className="truncate text-xs font-semibold text-foreground">
+                          {m.name}
+                        </p>
+                        {m.region && (
+                          <p className="truncate text-[10px] text-muted-foreground">
+                            {m.region}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* 숫자 원형 마커 — 교통(항공편 등)은 ✈, 일반 장소는 순서 번호 */}
+                  <div
+                    className={`flex size-7 items-center justify-center rounded-full font-bold text-white shadow-md ring-2 ring-white ${
+                      isTransport ? 'bg-blue-600' : 'bg-violet-600'
+                    }`}
+                    onMouseEnter={() => setActiveId(m.id)}
+                    onMouseLeave={() =>
+                      setActiveId((id) => (id === m.id ? null : id))
+                    }
+                  >
+                    {isTransport ? (
+                      <span className="text-base leading-none">✈</span>
+                    ) : (
+                      <span className="text-xs">{m.order}</span>
+                    )}
+                  </div>
+                </div>
+              </AdvancedMarker>
+            );
+          })}
           <FitBounds markers={markers} />
         </Map>
       </APIProvider>

--- a/apps/frontend/src/pages/ConfirmPage.tsx
+++ b/apps/frontend/src/pages/ConfirmPage.tsx
@@ -109,6 +109,7 @@ const ConfirmPage = () => {
           lat: card.coordinates!.lat,
           lng: card.coordinates!.lng,
           category: card.category,
+          region: card.region,
         })),
     [activeDay]
   );

--- a/apps/frontend/src/pages/ConfirmPage.tsx
+++ b/apps/frontend/src/pages/ConfirmPage.tsx
@@ -98,15 +98,20 @@ const ConfirmPage = () => {
   };
 
   // 활성 Day 카드 중 좌표 있는 것만 마커로 (좌표 없는 카드는 스킵).
-  const mapMarkers = (activeDay?.contextCards ?? [])
-    .filter((card) => card.coordinates)
-    .map((card) => ({
-      id: card.id,
-      order: card.order,
-      name: card.name,
-      lat: card.coordinates!.lat,
-      lng: card.coordinates!.lng,
-    }));
+  const mapMarkers = useMemo(
+    () =>
+      (activeDay?.contextCards ?? [])
+        .filter((card) => card.coordinates)
+        .map((card) => ({
+          id: card.id,
+          order: card.order,
+          name: card.name,
+          lat: card.coordinates!.lat,
+          lng: card.coordinates!.lng,
+          category: card.category,
+        })),
+    [activeDay]
+  );
 
   return (
     <div className="flex min-h-screen flex-col bg-muted">
@@ -174,7 +179,7 @@ const ConfirmPage = () => {
             <>
               <TripHeroCard {...hero} />
 
-              {showMap && <MapCard markers={mapMarkers} />}
+              {showMap && !isLoading && <MapCard markers={mapMarkers} />}
 
               {isLoading ? (
                 <EmptyState

--- a/apps/frontend/src/types/confirm.ts
+++ b/apps/frontend/src/types/confirm.ts
@@ -42,7 +42,7 @@ export type ConfirmCardViewModel = {
   aiTip?: string;
   /** 지도 마커용 좌표 — 없으면 마커 스킵 */
   coordinates?: Coordinates;
-  /** 카드 종류 — 마커 디자인 분기용 (항공편/장소 구분 등) */
+  /** 카드 종류 — 마커 디자인 분기용 (교통/장소 구분 등) */
   category?: CardCategory;
 };
 

--- a/apps/frontend/src/types/confirm.ts
+++ b/apps/frontend/src/types/confirm.ts
@@ -1,7 +1,7 @@
 // SCR-05 (확정 전 최종 점검) 화면 ViewModel 타입.
 // 백엔드 응답(GET /trips·/cards·/days)을 confirm-mapper 가 이 형태로 변환한다.
 import type { PlaceCardBadgeSpec } from '@/types/grouping';
-import type { Coordinates } from '@/types/grouping-api';
+import type { CardCategory, Coordinates } from '@/types/grouping-api';
 
 export type ConfirmStat = {
   label: string;
@@ -42,6 +42,8 @@ export type ConfirmCardViewModel = {
   aiTip?: string;
   /** 지도 마커용 좌표 — 없으면 마커 스킵 */
   coordinates?: Coordinates;
+  /** 카드 종류 — 마커 디자인 분기용 (항공편/장소 구분 등) */
+  category?: CardCategory;
 };
 
 export type ConfirmDayChecklistItem = {

--- a/apps/frontend/src/utils/confirm-mapper.ts
+++ b/apps/frontend/src/utils/confirm-mapper.ts
@@ -96,6 +96,7 @@ const cardToConfirmCard = (
   userNote: card.user_context ?? undefined,
   aiTip: card.tips ?? undefined,
   coordinates: card.coordinates ?? undefined,
+  category: card.category,
 });
 
 // BE 내러티브(narrative) 부재 → 카드 수 기반으로 "Day N · M곳" 합성.


### PR DESCRIPTION
## 📝 작업 내용

> SCR-05 확정 화면 지도 마커의 표시/UX를 개선한다 (#242 후속 폴리시).

- 마커를 번호 원형으로 교체 (교통은 ✈, 일반 장소는 순서 번호) + 호버 시 번호·이름·지역 카드 표시
- 교통 구분 기준을 `category === 'transport'`로 통일해 카드 ✈ 배지와 일치 (flightRole 의존 제거)
- Day 마커를 순서대로 잇는 동선 폴리라인 추가 (교통/공항 포함)
- 로딩 중 마커 깜빡임 보정 (`mapMarkers` 메모이즈 + 로딩 완료 후 렌더)
- 지도 기본 컨트롤 정리 (disableDefaultUI + 줌만 유지, 기본 POI 클릭 비활성화)

## 🔗 관련 이슈

closes #247

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (마커·호버 카드·동선·탭 전환 확인)
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [ ] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요? — `mapId="tripkey-confirm-map"`(임시값)·`DEFAULT_CENTER`(도쿄) 존재, 아래 참고
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

**판단 기준**
- 지도 마커의 교통 구분을`category === 'transport'`(카드 배지와 동일 기준) . .

**구현 참고**
- vis.gl이 2D Polyline 컴포넌트를 제공하지 않아 `google.maps.Polyline`을 `useMap`으로 직접 생성/정리합니다 (`RoutePolyline`).
- 마커/동선은 `activeDay` 변경 시에만 재계산되도록 메모이즈 (불필요한 `fitBounds`/폴리라인 재생성 방지).

**남은 임시값 (후속 예정)**
- `mapId="tripkey-confirm-map"`는 임시 문자열입니다. 베이스맵 클라우드 스타일링을 적용하려면 GCP에서 실제 Map ID 발급 후 교체 필요.

**후순위 (별도/후속 작업)**
- 베이스맵 스타일 단순화  — `mapId` 클라우드 스타일링 + 실제 Map ID 발급 필요
- 확정 화면 데이터 신선도(배치 변경 후 stale 좌표) — 지도와 무관한 사전 존재 이슈, 별도 이슈로 분리

## 📸 스크린샷
<img width="1203" height="465" alt="image" src="https://github.com/user-attachments/assets/af46e8ba-3013-4970-947d-87d758c944eb" />
