### PR TITLE
Feat: SCR-04 일정 확정 성공 시 SCR-05 확정 화면으로 이동

### DIFF
--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -11,7 +11,7 @@
 import { format } from 'date-fns';
 import { ArrowLeft, ArrowRight, Plus } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import ArrangeCardDetailPanel from '@/components/arrange/ArrangeCardDetailPanel';
 import CardListPanel from '@/components/arrange/CardListPanel';
@@ -97,6 +97,7 @@ const errorMessageOf = (error: unknown, fallback: string): string => {
 };
 
 const ArrangePage = () => {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const urlTripId = searchParams.get('tripId');
   const storeTripId = useOnboardingStore((s) => s.tripId);
@@ -625,6 +626,8 @@ const ArrangePage = () => {
       ]);
       setConfirmed(true);
       setNotice('일정이 확정되었습니다.');
+      // 확정 성공 → SCR-05(확정 전 최종 점검) 화면으로 이동.
+      navigate(`/confirm${tripId ? `?tripId=${tripId}` : ''}`);
     } catch (error) {
       setActionError(errorMessageOf(error, '일정 확정에 실패했습니다.'));
     }


### PR DESCRIPTION
## 📝 작업 내용

- SCR-04 일정 확정 성공 시 SCR-05 확정 화면으로 자동 이동하도록 연결

## 🔗 관련 이슈

closes #257

## 🗂️ 변경 범위

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게


## 📸 스크린샷

