### PR TITLE
Fix: SCR-04 장소확인 입력/이전단계 버튼 + SCR-03 에러표시

### DIFF
--- a/apps/frontend/src/components/arrange/ArrangeCardDetailPanel.tsx
+++ b/apps/frontend/src/components/arrange/ArrangeCardDetailPanel.tsx
@@ -186,18 +186,18 @@ const ArrangeCardDetailBody = ({
           </div>
         )}
 
-        {isResolvable ? (
-          // 자연어 재파싱(notes)으로 해결: 장소명·주소 보완 입력 → "확인하기"로 저장+재처리.
-          <ResolveByNotesField
-            value={notes}
-            onChange={setNotes}
-            disabled={resolving}
-            error={resolveError}
-          />
-        ) : (
-          // 그 외 카드(배치 가능/고정/해결 불가)는 기존 메모 UI 유지.
-          <UserMemoField value={memo} onChange={setMemo} />
+        {isResolvable && (
+          <>
+            <ResolveByNotesField
+              value={notes}
+              onChange={setNotes}
+              disabled={resolving}
+              error={resolveError}
+            />
+            <Separator />
+          </>
         )}
+        <UserMemoField value={memo} onChange={setMemo} />
       </div>
 
       {/* 푸터 */}
@@ -210,7 +210,7 @@ const ArrangeCardDetailBody = ({
         >
           닫기
         </Button>
-        {isResolvable ? (
+        {isResolvable && (
           <Button
             type="button"
             className="h-11 flex-1 text-sm font-semibold"
@@ -219,16 +219,16 @@ const ArrangeCardDetailBody = ({
           >
             {resolving ? '재처리 중…' : '확인하기'}
           </Button>
-        ) : (
-          <Button
-            type="button"
-            className="h-11 flex-1 text-sm font-semibold"
-            disabled={!memoDirty}
-            onClick={() => onSaveMemo?.(memo)}
-          >
-            메모 저장
-          </Button>
         )}
+        <Button
+          type="button"
+          variant={isResolvable ? 'outline' : 'default'}
+          className="h-11 flex-1 text-sm font-semibold"
+          disabled={!memoDirty}
+          onClick={() => onSaveMemo?.(memo)}
+        >
+          메모 저장
+        </Button>
       </PanelActions>
     </>
   );

--- a/apps/frontend/src/components/grouping/SelectCardDetailPanel.tsx
+++ b/apps/frontend/src/components/grouping/SelectCardDetailPanel.tsx
@@ -27,6 +27,8 @@ type SelectCardDetailPanelProps = {
   card: PlaceCardViewModel | null;
   /** 확인/메모/제외 요청이 진행 중이면 true — 버튼 비활성 + 스피너 표시. */
   pending?: boolean;
+  /** 확인/메모/제외 요청 실패 시 패널 내부에 보여줄 에러 메시지. */
+  error?: string | null;
   onConfirm?: (payload: { choices: string[]; answer: string }) => void;
   onExclude?: () => void;
   onSaveMemo?: (memo: string) => void;
@@ -37,6 +39,7 @@ const SelectCardDetailPanel = ({
   onOpenChange,
   card,
   pending = false,
+  error = null,
   onConfirm,
   onExclude,
   onSaveMemo,
@@ -52,6 +55,7 @@ const SelectCardDetailPanel = ({
           onConfirm={onConfirm}
           onExclude={onExclude}
           onSaveMemo={onSaveMemo}
+          error={error}
         />
       ) : null}
     </SidePanel>
@@ -68,9 +72,11 @@ const SelectCardDetailBody = ({
   onConfirm,
   onExclude,
   onSaveMemo,
+  error,
 }: {
   card: PlaceCardViewModel;
   pending: boolean;
+  error: string | null;
   onClose: () => void;
   onConfirm?: (payload: { choices: string[]; answer: string }) => void;
   onExclude?: () => void;
@@ -224,6 +230,15 @@ const SelectCardDetailBody = ({
           </>
         )}
       </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mx-6 mb-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3.5 py-2.5 text-xs leading-relaxed text-destructive"
+        >
+          {error}
+        </div>
+      )}
 
       {/*푸터*/}
       <PanelActions>

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -801,7 +801,13 @@ const ArrangePage = () => {
 
       {/* 하단 푸터 */}
       <footer className="flex shrink-0 items-center justify-between gap-4 border-t border-border bg-background px-6 py-3">
-        <Button variant="outline" disabled>
+        <Button
+          variant="outline"
+          onClick={() =>
+            navigate(`/grouping${tripId ? `?tripId=${tripId}` : ''}`)
+          }
+          disabled={busy}
+        >
           <ArrowLeft className="size-4" aria-hidden="true" />
           이전 단계
         </Button>

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -575,6 +575,7 @@ const GroupingPage = () => {
         onOpenChange={setSelectOpen}
         card={selectCard}
         pending={busy}
+        error={state.phase === 'ready' ? state.errorMessage : null}
         onConfirm={async (payload) => {
           const cardId = selectCard?.id;
           if (await handleConfirmSelect(selectCard, payload)) {

--- a/apps/frontend/src/utils/arrange-mapper.ts
+++ b/apps/frontend/src/utils/arrange-mapper.ts
@@ -235,14 +235,20 @@ const cardToDetail = (card: Card): ArrangeCardDetailViewModel => ({
 export const cardToStockCard = (card: Card): ArrangeCardViewModel => {
   const badges = buildBadges(card);
   // 좌표가 없으면(직접 추가 카드 등) 동선 검증·자동 묶기에서 빠지므로 미리 표식을 단다.
-  if (card.coordinates == null) badges.push(NEEDS_LOCATION_BADGE);
+  const missingLocation = card.coordinates == null;
+  if (missingLocation) badges.push(NEEDS_LOCATION_BADGE);
   return {
     id: card.instance_id,
     name: card.name,
     accent: accentForCard(card),
     badges,
     draggable: true,
-    detail: cardToDetail(card),
+    // SCR-03 장소확인과 동일 규칙: BE가 notes 재파싱 가능한 카드에만 보완 입력을 연다.
+    // (undecided+needs_input/ready_partial, 또는 failed. confirmed manual 카드는 제외)
+    detail: {
+      ...cardToDetail(card),
+      canResolveByNotes: canResolveByNotes(card),
+    },
   };
 };
 


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- SCR-04(배치) 장소확인 입력 노출 규칙을 SCR-03과 일치시키고(메모 입력도 함께 노출), 이전 단계 버튼을 활성화했으며, SCR-03 장소선택 실패 에러를 패널 내부에 표시하도록 했습니다.

## 🔗 관련 이슈

closes #265

## 🗂️ 변경 범위

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? (커밋 단위로 분리)

## 👀 리뷰어에게

- **SCR-04 장소확인 노출 규칙**: `coordinates == null` 무조건이 아니라 `canResolveByNotes`(= 백엔드 `canStartNaturalLanguageParsingFromNotes` 미러: `undecided`+needs_input/ready_partial 또는 failed)로 노출하도록 변경했습니다. SCR-03 select 패널과 동일 규칙입니다.

- **장소 보완 + 메모 동시 노출**: 기존 SCR-04 패널은 장소 보완(notes)과 메모가 배타적이었으나, SCR-03처럼 둘 다 노출하도록 변경했습니다. 푸터는 `닫기 / 확인하기 / 메모 저장` 구성.

- **범위 밖(후속 백엔드 이슈)**: 메뉴얼(사용자 카드추가/`confirmed`) 카드의 위치 확인은 백엔드 미지원이라 이 PR로는 불가합니다. notes 재파싱은 `undecided`만, 구조화 위치 재처리는 accommodation/transport만 지원 → place/food/activity 메뉴얼 카드는 경로가 없습니다. (addCard enrichment 추가 / place 위치편집 재처리 / 메뉴얼 카드 undecided 생성 중 택1 필요)

- **검증 참고**: 효과를 화면에서 보려면 `undecided`+좌표없음 카드가 필요합니다. 현재 테스트 데이터는 대부분 `confirmed`라 시각적 변화가 안 보일 수 있음.

## 📸 스크린샷
<img width="978" height="766" alt="image" src="https://github.com/user-attachments/assets/4fa4834c-2368-432e-9e37-520ce84cf811" />
