### PR TITLE
Feat: #270 SCR-04 동선 최적화 1차 — Day 내 순서 최적화(제안형)

### DIFF
--- a/apps/ai-engine/app/api/route.py
+++ b/apps/ai-engine/app/api/route.py
@@ -1,7 +1,13 @@
 from fastapi import APIRouter
 
-from app.schemas.route import RouteRequest, RouteResponse
+from app.schemas.route import (
+    OptimizeOrderRequest,
+    OptimizeOrderResponse,
+    RouteRequest,
+    RouteResponse,
+)
 from app.services.route_optimizer import optimize_routes
+from app.services.route_order_service import optimize_order
 
 router = APIRouter(prefix="/internal/ai", tags=["route"])
 
@@ -10,3 +16,9 @@ router = APIRouter(prefix="/internal/ai", tags=["route"])
 async def compute_route(req: RouteRequest) -> RouteResponse:
     # leg 단위로 폴백이 적용되므로 전체 502 없이 항상 200 + 결과 반환
     return await optimize_routes(req)
+
+
+@router.post("/route/optimize-order", response_model=OptimizeOrderResponse)
+async def optimize_route_order(req: OptimizeOrderRequest) -> OptimizeOrderResponse:
+    # 행렬 산출 실패 시 추정 폴백이 적용되므로 항상 200 + 순서 반환
+    return await optimize_order(req)

--- a/apps/ai-engine/app/schemas/route.py
+++ b/apps/ai-engine/app/schemas/route.py
@@ -40,3 +40,27 @@ class RouteResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     legs: list[RouteLegResult]
+
+
+class OptimizeStop(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    instance_id: str = Field(..., min_length=1)
+    coordinates: Coordinates
+
+
+class OptimizeOrderRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # 한 Day 안에서 순서를 최적화할 카드들 (좌표 있는 카드만 전달)
+    stops: list[OptimizeStop]
+    # 시작 고정 앵커(예: 숙소) instance_id. None 이면 시작 자유.
+    start_instance_id: str | None = None
+
+
+class OptimizeOrderResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ordered_instance_ids: list[str]
+    total_duration_seconds: int
+    source: RouteSource

--- a/apps/ai-engine/app/services/route_matrix_cache.py
+++ b/apps/ai-engine/app/services/route_matrix_cache.py
@@ -1,0 +1,94 @@
+"""SCR-04 동선 최적화 이동시간 행렬 캐시 (#274).
+
+route_legs_cache(verify, best-mode)와 분리된 DRIVE 전용 캐시.
+Supabase PostgREST(L2)로 pair 단위 duration 을 저장/조회한다(places_cache 와 동일 패턴).
+캐시 실패는 절대 최적화를 깨지 않는다(에러 무해화 → Route Matrix 폴백).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# 테스트에서 monkeypatch 할 수 있도록 모듈 전역으로 둔다.
+ROUTE_MATRIX_CACHE_ENABLED = os.getenv("ROUTE_MATRIX_CACHE_ENABLED", "true").lower() == "true"
+ROUTE_MATRIX_CACHE_TTL_DAYS = int(os.getenv("ROUTE_MATRIX_CACHE_TTL_DAYS", "30"))
+CACHE_READ_TIMEOUT = float(os.getenv("ROUTE_MATRIX_CACHE_READ_TIMEOUT", "1.5"))
+CACHE_WRITE_TIMEOUT = float(os.getenv("ROUTE_MATRIX_CACHE_WRITE_TIMEOUT", "2.0"))
+
+SUPABASE_URL = os.getenv("SUPABASE_URL", "")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
+
+_TABLE_PATH = "/rest/v1/route_matrix_cache"
+_COORD_PRECISION = 100_000.0  # 좌표 5자리(약 1m) — 백엔드 COORD_PRECISION 과 일치
+MODE = "driving"
+
+
+def cache_enabled() -> bool:
+    return bool(ROUTE_MATRIX_CACHE_ENABLED and SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY)
+
+
+def round_coord(value: float) -> float:
+    return round(value * _COORD_PRECISION) / _COORD_PRECISION
+
+
+def pair_key(o_lat: float, o_lng: float, d_lat: float, d_lng: float, mode: str = MODE) -> str:
+    raw = f"{round_coord(o_lat)},{round_coord(o_lng)},{round_coord(d_lat)},{round_coord(d_lng)},{mode}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()
+
+
+def _headers() -> dict:
+    return {
+        "apikey": SUPABASE_SERVICE_ROLE_KEY,
+        "Authorization": f"Bearer {SUPABASE_SERVICE_ROLE_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
+async def get_durations(keys: list[str]) -> dict[str, int]:
+    """비만료 행의 {pair_key: duration_seconds}. 비활성/실패 시 빈 dict(폴백)."""
+    if not keys or not cache_enabled():
+        return {}
+    now_iso = datetime.now(timezone.utc).isoformat()
+    params = {
+        "pair_key": f"in.({','.join(keys)})",
+        "expires_at": f"gt.{now_iso}",
+        "select": "pair_key,duration_seconds",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=CACHE_READ_TIMEOUT) as client:
+            resp = await client.get(f"{SUPABASE_URL}{_TABLE_PATH}", params=params, headers=_headers())
+            resp.raise_for_status()
+            rows = resp.json()
+        return {
+            r["pair_key"]: int(r["duration_seconds"])
+            for r in rows
+            if r.get("duration_seconds") is not None
+        }
+    except Exception as exc:  # noqa: BLE001 - 캐시 실패가 최적화를 깨면 안 됨
+        logger.warning("route_matrix_cache read failed | error=%s", exc)
+        return {}
+
+
+async def put_durations(rows: list[dict]) -> None:
+    """rows: [{pair_key, origin_lat, origin_lng, dest_lat, dest_lng, mode, duration_seconds, distance_meters}].
+
+    PostgREST upsert(Prefer: merge-duplicates). 비활성/실패 시 무시(에러 무해화).
+    """
+    if not rows or not cache_enabled():
+        return
+    expires = (datetime.now(timezone.utc) + timedelta(days=ROUTE_MATRIX_CACHE_TTL_DAYS)).isoformat()
+    body = [{**row, "expires_at": expires} for row in rows]
+    headers = {**_headers(), "Prefer": "resolution=merge-duplicates,return=minimal"}
+    try:
+        async with httpx.AsyncClient(timeout=CACHE_WRITE_TIMEOUT) as client:
+            resp = await client.post(f"{SUPABASE_URL}{_TABLE_PATH}", json=body, headers=headers)
+            resp.raise_for_status()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("route_matrix_cache write failed | error=%s", exc)

--- a/apps/ai-engine/app/services/route_order_optimizer.py
+++ b/apps/ai-engine/app/services/route_order_optimizer.py
@@ -1,0 +1,121 @@
+"""SCR-04 동선 최적화 1차 — Day 내 방문 순서 최적화기 (#270).
+
+이동시간 행렬(matrix[i][j] = i→j 이동 초)을 받아 총 이동시간이 최소가 되는
+**개방 경로**(open path: 출발지로 되돌아오지 않음) 방문 순서를 반환한다.
+
+- n <= HELD_KARP_MAX: Held-Karp DP 로 정확해(asymmetric 행렬도 정확).
+- 그 이상: nearest-neighbor + 2-opt 휴리스틱(full-recompute 라 asymmetric 안전).
+
+순수 함수 — 외부 I/O 없음. 행렬 산출(Routes API)은 호출 측 책임.
+"""
+
+from __future__ import annotations
+
+# Held-Karp 는 O(n^2 * 2^n). n=13 이면 약 13^2 * 8192 ≈ 1.4M 연산으로 충분히 빠르다.
+# 하루 방문 카드가 13개를 넘는 경우는 드물어, 정확해 범위가 사실상 대부분을 커버한다.
+HELD_KARP_MAX = 13
+
+
+def path_duration(order: list[int], matrix: list[list[int]]) -> int:
+    """개방 경로의 총 이동시간(연속 구간 합)."""
+    return sum(matrix[order[i]][order[i + 1]] for i in range(len(order) - 1))
+
+
+def optimize_visit_order(
+    instance_ids: list[str],
+    matrix: list[list[int]],
+    start_index: int | None = None,
+) -> list[str]:
+    """instance_id 리스트를 총 이동시간 최소 순서로 재배열해 반환."""
+    if len(instance_ids) <= 1:
+        return list(instance_ids)
+    order = solve_open_path(matrix, start_index)
+    return [instance_ids[i] for i in order]
+
+
+def solve_open_path(matrix: list[list[int]], start: int | None = None) -> list[int]:
+    """최소 비용 개방 경로의 인덱스 순서. start 지정 시 그 인덱스에서 시작 고정."""
+    n = len(matrix)
+    if n <= 1:
+        return list(range(n))
+    if n <= HELD_KARP_MAX:
+        return _held_karp_open_path(matrix, start)
+    return _nearest_neighbor_2opt(matrix, start)
+
+
+def _held_karp_open_path(matrix: list[list[int]], start: int | None) -> list[int]:
+    n = len(matrix)
+    inf = float("inf")
+    full = (1 << n) - 1
+
+    # dp[mask][i] = mask 의 정점을 정확히 한 번씩 방문하고 i 에서 끝나는 최소 비용
+    dp = [[inf] * n for _ in range(1 << n)]
+    parent = [[-1] * n for _ in range(1 << n)]
+
+    bases = [start] if start is not None else range(n)
+    for s in bases:
+        dp[1 << s][s] = 0
+
+    for mask in range(1 << n):
+        for i in range(n):
+            cost_i = dp[mask][i]
+            if cost_i == inf or not (mask & (1 << i)):
+                continue
+            for j in range(n):
+                if mask & (1 << j):
+                    continue
+                nmask = mask | (1 << j)
+                cost = cost_i + matrix[i][j]
+                if cost < dp[nmask][j]:
+                    dp[nmask][j] = cost
+                    parent[nmask][j] = i
+
+    best_end, best_cost = 0, inf
+    for i in range(n):
+        if dp[full][i] < best_cost:
+            best_cost, best_end = dp[full][i], i
+
+    order: list[int] = []
+    mask, cur = full, best_end
+    while cur != -1:
+        order.append(cur)
+        prev = parent[mask][cur]
+        mask ^= 1 << cur
+        cur = prev
+    order.reverse()
+    return order
+
+
+def _nearest_neighbor_2opt(matrix: list[list[int]], start: int | None) -> list[int]:
+    n = len(matrix)
+    s = 0 if start is None else start
+
+    # 1) nearest-neighbor 초기 경로
+    visited = [False] * n
+    order = [s]
+    visited[s] = True
+    cur = s
+    for _ in range(n - 1):
+        nxt = min(
+            (j for j in range(n) if not visited[j]),
+            key=lambda j: matrix[cur][j],
+        )
+        order.append(nxt)
+        visited[nxt] = True
+        cur = nxt
+
+    # 2) 2-opt 개선 (full-recompute → asymmetric 행렬에서도 안전)
+    fix_start = start is not None
+    lo = 1 if fix_start else 0
+    best = path_duration(order, matrix)
+    improved = True
+    while improved:
+        improved = False
+        for i in range(lo, n - 1):
+            for k in range(i + 1, n):
+                cand = order[:i] + order[i : k + 1][::-1] + order[k + 1 :]
+                d = path_duration(cand, matrix)
+                if d + 1e-9 < best:
+                    order, best = cand, d
+                    improved = True
+    return order

--- a/apps/ai-engine/app/services/route_order_service.py
+++ b/apps/ai-engine/app/services/route_order_service.py
@@ -1,0 +1,117 @@
+"""SCR-04 동선 최적화 1차 — 이동시간 행렬 산출 + 순서 최적화 오케스트레이션 (#270).
+
+Google Route Matrix(computeRouteMatrix) 1회 호출로 N×N 이동시간 행렬을 만들고,
+키 부재/호출 실패/구간 누락 시 haversine 추정으로 보강한 뒤
+route_order_optimizer 로 Day 내 방문 순서를 푼다. I/O 경계 모듈.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from app.fallback.estimated_route import estimate_leg
+from app.schemas.parse import Coordinates
+from app.schemas.route import (
+    OptimizeOrderRequest,
+    OptimizeOrderResponse,
+    OptimizeStop,
+    RouteLeg,
+)
+from app.services.route_optimizer import _parse_duration_seconds, _places_api_key
+from app.services.route_order_optimizer import optimize_visit_order, path_duration
+
+logger = logging.getLogger(__name__)
+
+COMPUTE_ROUTE_MATRIX_URL = (
+    "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix"
+)
+
+
+def _estimate_seconds(origin: Coordinates, destination: Coordinates) -> int:
+    leg = RouteLeg(
+        from_instance_id="o", to_instance_id="d", origin=origin, destination=destination
+    )
+    return estimate_leg(leg).duration_seconds
+
+
+def _waypoint(coord: Coordinates) -> dict:
+    return {"waypoint": {"location": {"latLng": {"latitude": coord.lat, "longitude": coord.lng}}}}
+
+
+async def _call_route_matrix(stops: list[OptimizeStop], api_key: str) -> list[dict] | None:
+    waypoints = [_waypoint(s.coordinates) for s in stops]
+    headers = {
+        "X-Goog-Api-Key": api_key,
+        "X-Goog-FieldMask": "originIndex,destinationIndex,duration,condition",
+        "Content-Type": "application/json",
+    }
+    payload = {"origins": waypoints, "destinations": waypoints, "travelMode": "DRIVE"}
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.post(COMPUTE_ROUTE_MATRIX_URL, json=payload, headers=headers)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("Route Matrix lookup failed | error=%s", exc)
+        return None
+    data = response.json()
+    return data if isinstance(data, list) else None
+
+
+async def _build_matrix(
+    stops: list[OptimizeStop], api_key: str | None
+) -> tuple[list[list[int]], str]:
+    """N×N 이동시간(초) 행렬과 source('google'|'estimated') 반환.
+
+    먼저 haversine 추정으로 채워(=폴백 기본값) 둔 뒤, Google 결과가 있으면 덮어쓴다.
+    """
+    n = len(stops)
+    matrix = [[0] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            if i != j:
+                matrix[i][j] = _estimate_seconds(stops[i].coordinates, stops[j].coordinates)
+
+    if not api_key:
+        return matrix, "estimated"
+
+    elements = await _call_route_matrix(stops, api_key)
+    if not elements:
+        return matrix, "estimated"
+
+    for elem in elements:
+        i = elem.get("originIndex")
+        j = elem.get("destinationIndex")
+        if i is None or j is None or i == j:
+            continue
+        if elem.get("condition") != "ROUTE_EXISTS":
+            continue
+        duration = _parse_duration_seconds(elem.get("duration"))
+        if duration is not None:
+            matrix[i][j] = duration
+    return matrix, "google"
+
+
+async def optimize_order(request: OptimizeOrderRequest) -> OptimizeOrderResponse:
+    ids = [s.instance_id for s in request.stops]
+    if len(ids) <= 1:
+        return OptimizeOrderResponse(
+            ordered_instance_ids=list(ids), total_duration_seconds=0, source="estimated"
+        )
+
+    matrix, source = await _build_matrix(request.stops, _places_api_key())
+
+    start_index = None
+    if request.start_instance_id is not None and request.start_instance_id in ids:
+        start_index = ids.index(request.start_instance_id)
+
+    ordered_ids = optimize_visit_order(ids, matrix, start_index)
+    order_idx = [ids.index(x) for x in ordered_ids]
+    total = path_duration(order_idx, matrix)
+
+    return OptimizeOrderResponse(
+        ordered_instance_ids=ordered_ids,
+        total_duration_seconds=total,
+        source=source,
+    )

--- a/apps/ai-engine/app/services/route_order_service.py
+++ b/apps/ai-engine/app/services/route_order_service.py
@@ -19,6 +19,7 @@ from app.schemas.route import (
     OptimizeStop,
     RouteLeg,
 )
+from app.services import route_matrix_cache
 from app.services.route_optimizer import _parse_duration_seconds, _places_api_key
 from app.services.route_order_optimizer import optimize_visit_order, path_duration
 
@@ -44,7 +45,7 @@ async def _call_route_matrix(stops: list[OptimizeStop], api_key: str) -> list[di
     waypoints = [_waypoint(s.coordinates) for s in stops]
     headers = {
         "X-Goog-Api-Key": api_key,
-        "X-Goog-FieldMask": "originIndex,destinationIndex,duration,condition",
+        "X-Goog-FieldMask": "originIndex,destinationIndex,duration,distanceMeters,condition",
         "Content-Type": "application/json",
     }
     payload = {"origins": waypoints, "destinations": waypoints, "travelMode": "DRIVE"}
@@ -73,6 +74,23 @@ async def _build_matrix(
             if i != j:
                 matrix[i][j] = _estimate_seconds(stops[i].coordinates, stops[j].coordinates)
 
+    # pair_key 사전(캐시 조회/적재 공용)
+    pair_keys: dict[tuple[int, int], str] = {}
+    for i in range(n):
+        for j in range(n):
+            if i != j:
+                a, b = stops[i].coordinates, stops[j].coordinates
+                pair_keys[(i, j)] = route_matrix_cache.pair_key(a.lat, a.lng, b.lat, b.lng)
+
+    # 1) L2 캐시 전체 히트면 Google 호출 생략 (Route Matrix 는 부분 캐시가 불가 → 전부 있어야 의미)
+    if route_matrix_cache.cache_enabled():
+        cached = await route_matrix_cache.get_durations(list(set(pair_keys.values())))
+        if cached and all(k in cached for k in pair_keys.values()):
+            for (i, j), k in pair_keys.items():
+                matrix[i][j] = cached[k]
+            return matrix, "google"
+
+    # 2) 미스 또는 키 없음 → Route Matrix 1회 호출
     if not api_key:
         return matrix, "estimated"
 
@@ -80,6 +98,7 @@ async def _build_matrix(
     if not elements:
         return matrix, "estimated"
 
+    rows: list[dict] = []
     for elem in elements:
         i = elem.get("originIndex")
         j = elem.get("destinationIndex")
@@ -88,8 +107,25 @@ async def _build_matrix(
         if elem.get("condition") != "ROUTE_EXISTS":
             continue
         duration = _parse_duration_seconds(elem.get("duration"))
-        if duration is not None:
-            matrix[i][j] = duration
+        if duration is None:
+            continue
+        matrix[i][j] = duration
+        a, b = stops[i].coordinates, stops[j].coordinates
+        rows.append({
+            "pair_key": pair_keys[(i, j)],
+            "origin_lat": route_matrix_cache.round_coord(a.lat),
+            "origin_lng": route_matrix_cache.round_coord(a.lng),
+            "dest_lat": route_matrix_cache.round_coord(b.lat),
+            "dest_lng": route_matrix_cache.round_coord(b.lng),
+            "mode": route_matrix_cache.MODE,
+            "duration_seconds": duration,
+            "distance_meters": elem.get("distanceMeters"),
+        })
+
+    # 3) 캐시 적재 (best-effort)
+    if route_matrix_cache.cache_enabled():
+        await route_matrix_cache.put_durations(rows)
+
     return matrix, "google"
 
 

--- a/apps/ai-engine/tests/test_route_matrix_cache.py
+++ b/apps/ai-engine/tests/test_route_matrix_cache.py
@@ -1,0 +1,77 @@
+"""SCR-04 동선 최적화 행렬 캐시 단위 테스트 (#274)."""
+
+import httpx
+import pytest
+
+from app.services import route_matrix_cache as rmc
+
+
+def test_pair_key_rounds_and_is_directional() -> None:
+    # 좌표 5자리 반올림 → 미세차이는 같은 키
+    assert rmc.pair_key(34.700001, 135.500001, 34.71, 135.51) == rmc.pair_key(
+        34.700002, 135.500002, 34.71, 135.51
+    )
+    # 방향이 다르면 키가 다르다(비대칭)
+    assert rmc.pair_key(34.70, 135.50, 34.71, 135.51) != rmc.pair_key(
+        34.71, 135.51, 34.70, 135.50
+    )
+
+
+def test_cache_enabled_requires_url_and_key(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", True)
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "")
+    assert rmc.cache_enabled() is False
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "https://x.supabase.co")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "k")
+    assert rmc.cache_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_get_durations_disabled_returns_empty(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", False)
+    assert await rmc.get_durations(["k1"]) == {}
+
+
+@pytest.mark.asyncio
+async def test_get_durations_parses_rows(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", True)
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "https://x.supabase.co")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "k")
+
+    async def fake_get(self, url, *args, **kwargs):
+        return httpx.Response(
+            200,
+            json=[{"pair_key": "k1", "duration_seconds": 642}],
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    assert await rmc.get_durations(["k1"]) == {"k1": 642}
+
+
+@pytest.mark.asyncio
+async def test_get_durations_swallows_errors(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", True)
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "https://x.supabase.co")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "k")
+
+    async def boom(self, url, *args, **kwargs):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", boom)
+    assert await rmc.get_durations(["k1"]) == {}  # 폴백(빈 dict)
+
+
+@pytest.mark.asyncio
+async def test_put_durations_swallows_errors(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", True)
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "https://x.supabase.co")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "k")
+
+    async def boom(self, url, *args, **kwargs):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", boom)
+    # 예외가 새어나오지 않아야 한다
+    await rmc.put_durations([{"pair_key": "k1", "duration_seconds": 1}])

--- a/apps/ai-engine/tests/test_route_order_optimizer.py
+++ b/apps/ai-engine/tests/test_route_order_optimizer.py
@@ -1,0 +1,94 @@
+"""SCR-04 동선 최적화 1차 — Day 내 방문 순서 최적화기 단위 테스트 (#270)."""
+
+import itertools
+import random
+
+from app.services.route_order_optimizer import (
+    optimize_visit_order,
+    path_duration,
+)
+
+
+def _line_matrix(positions: list[int]) -> list[list[int]]:
+    """1차원 좌표 리스트로부터 |거리| 대칭 행렬 생성."""
+    return [[abs(a - b) for b in positions] for a in positions]
+
+
+def test_empty_returns_empty() -> None:
+    assert optimize_visit_order([], []) == []
+
+
+def test_single_returns_same() -> None:
+    assert optimize_visit_order(["a"], [[0]]) == ["a"]
+
+
+def test_free_start_orders_collinear_points() -> None:
+    # 위치 A=0 B=10 C=20 D=30 을 뒤섞어 입력
+    ids = ["C", "A", "D", "B"]
+    pos = [20, 0, 30, 10]
+    m = _line_matrix(pos)
+    order = optimize_visit_order(ids, m)
+    # 시작 자유면 최적 개방 경로는 A,B,C,D 또는 그 역순
+    assert order in (["A", "B", "C", "D"], ["D", "C", "B", "A"])
+    idx = [ids.index(x) for x in order]
+    assert path_duration(idx, m) == 30
+
+
+def test_fixed_start_respected_and_optimal() -> None:
+    ids = ["C", "A", "D", "B"]
+    pos = [20, 0, 30, 10]
+    m = _line_matrix(pos)
+    order = optimize_visit_order(ids, m, start_index=0)  # C 에서 시작 고정
+    assert order[0] == "C"
+    assert order == ["C", "D", "B", "A"]  # C 시작 최소 개방 경로 = 40
+    idx = [ids.index(x) for x in order]
+    assert path_duration(idx, m) == 40
+
+
+def test_matches_brute_force_for_small_n() -> None:
+    # 비대칭 행렬에서도 정확해(Held-Karp)가 완전탐색과 일치해야 함
+    m = [
+        [0, 5, 9, 8, 7],
+        [6, 0, 4, 11, 3],
+        [10, 4, 0, 2, 6],
+        [8, 12, 2, 0, 5],
+        [7, 3, 6, 5, 0],
+    ]
+    n = len(m)
+    order = optimize_visit_order([str(i) for i in range(n)], m)
+    got = path_duration([int(x) for x in order], m)
+    best = min(path_duration(list(p), m) for p in itertools.permutations(range(n)))
+    assert got == best
+
+
+def test_fixed_start_matches_brute_force() -> None:
+    m = [
+        [0, 5, 9, 8, 7],
+        [6, 0, 4, 11, 3],
+        [10, 4, 0, 2, 6],
+        [8, 12, 2, 0, 5],
+        [7, 3, 6, 5, 0],
+    ]
+    n = len(m)
+    order = optimize_visit_order([str(i) for i in range(n)], m, start_index=2)
+    assert order[0] == "2"
+    got = path_duration([int(x) for x in order], m)
+    best = min(
+        path_duration([2, *p], m)
+        for p in itertools.permutations([i for i in range(n) if i != 2])
+    )
+    assert got == best
+
+
+def test_large_n_returns_valid_permutation_and_not_worse_than_identity() -> None:
+    random.seed(42)
+    n = 30  # Held-Karp 한계 초과 → 휴리스틱(NN + 2-opt) 경로
+    pos = list(range(n))
+    random.shuffle(pos)
+    m = _line_matrix(pos)
+    ids = [str(i) for i in range(n)]
+    order = optimize_visit_order(ids, m)
+    assert sorted(order) == sorted(ids)  # 모든 정점 1회씩 = 유효 순열
+    got = path_duration([int(x) for x in order], m)
+    identity = path_duration(list(range(n)), m)
+    assert got <= identity  # 최소한 입력 순서보다 나빠지지 않음

--- a/apps/ai-engine/tests/test_route_order_service.py
+++ b/apps/ai-engine/tests/test_route_order_service.py
@@ -1,0 +1,146 @@
+"""SCR-04 동선 최적화 1차 — 행렬 산출 + 오케스트레이션 테스트 (#270)."""
+
+import httpx
+import pytest
+
+from app.schemas.parse import Coordinates
+from app.schemas.route import OptimizeOrderRequest, OptimizeStop
+from app.services import route_order_service as svc
+
+
+def _stops() -> list[OptimizeStop]:
+    # 위도 고정, 경도만 증가하는 일직선 점: A < B < C < D
+    return [
+        OptimizeStop(instance_id="C", coordinates=Coordinates(lat=34.70, lng=135.520)),
+        OptimizeStop(instance_id="A", coordinates=Coordinates(lat=34.70, lng=135.500)),
+        OptimizeStop(instance_id="D", coordinates=Coordinates(lat=34.70, lng=135.530)),
+        OptimizeStop(instance_id="B", coordinates=Coordinates(lat=34.70, lng=135.510)),
+    ]
+
+
+def _line_matrix_elements() -> list[dict]:
+    # 입력 index 기준 위치(초): C=20, A=0, D=30, B=10
+    pos = {0: 20, 1: 0, 2: 30, 3: 10}
+    elements = []
+    for i in range(4):
+        for j in range(4):
+            if i == j:
+                continue
+            elements.append(
+                {
+                    "originIndex": i,
+                    "destinationIndex": j,
+                    "duration": f"{abs(pos[i] - pos[j])}s",
+                    "condition": "ROUTE_EXISTS",
+                }
+            )
+    return elements
+
+
+@pytest.mark.asyncio
+async def test_no_api_key_uses_estimate(monkeypatch) -> None:
+    monkeypatch.setattr(svc, "_places_api_key", lambda: None)
+    res = await svc.optimize_order(OptimizeOrderRequest(stops=_stops()))
+    assert res.source == "estimated"
+    assert sorted(res.ordered_instance_ids) == ["A", "B", "C", "D"]
+    # 일직선이라 최적 개방 경로는 정렬 순서 또는 그 역순
+    assert res.ordered_instance_ids in (["A", "B", "C", "D"], ["D", "C", "B", "A"])
+    assert res.total_duration_seconds > 0
+
+
+@pytest.mark.asyncio
+async def test_respects_start_with_google_matrix(monkeypatch) -> None:
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    elements = _line_matrix_elements()
+
+    async def fake_post(self, url, json, headers):
+        return httpx.Response(200, json=elements, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=_stops(), start_instance_id="C")
+    )
+    assert res.source == "google"
+    assert res.ordered_instance_ids[0] == "C"
+    assert res.ordered_instance_ids == ["C", "D", "B", "A"]  # C 시작 최소 = 40
+    assert res.total_duration_seconds == 40
+
+
+@pytest.mark.asyncio
+async def test_http_failure_falls_back_to_estimate(monkeypatch) -> None:
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+
+    async def fake_post(self, url, json, headers):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    res = await svc.optimize_order(OptimizeOrderRequest(stops=_stops()))
+    assert res.source == "estimated"
+    assert sorted(res.ordered_instance_ids) == ["A", "B", "C", "D"]
+
+
+@pytest.mark.asyncio
+async def test_single_stop_is_trivial(monkeypatch) -> None:
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(
+            stops=[OptimizeStop(instance_id="solo", coordinates=Coordinates(lat=1.0, lng=2.0))]
+        )
+    )
+    assert res.ordered_instance_ids == ["solo"]
+    assert res.total_duration_seconds == 0
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_optimized_order(monkeypatch) -> None:
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    elements = _line_matrix_elements()
+
+    async def fake_post(self, url, json, headers):
+        return httpx.Response(200, json=elements, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    payload = {
+        "stops": [
+            {"instance_id": "C", "coordinates": {"lat": 34.70, "lng": 135.520}},
+            {"instance_id": "A", "coordinates": {"lat": 34.70, "lng": 135.500}},
+            {"instance_id": "D", "coordinates": {"lat": 34.70, "lng": 135.530}},
+            {"instance_id": "B", "coordinates": {"lat": 34.70, "lng": 135.510}},
+        ],
+        "start_instance_id": "C",
+    }
+    client = TestClient(app)
+    resp = client.post("/internal/ai/route/optimize-order", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ordered_instance_ids"] == ["C", "D", "B", "A"]
+    assert body["total_duration_seconds"] == 40
+    assert body["source"] == "google"
+
+
+@pytest.mark.asyncio
+async def test_handles_unordered_matrix_elements(monkeypatch) -> None:
+    # 실 computeRouteMatrix 는 요소를 인덱스 순서대로 주지 않는다.
+    # 파서가 originIndex/destinationIndex 로 배치하므로 셔플돼도 결과가 같아야 한다.
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    elements = _line_matrix_elements()
+    shuffled = list(reversed(elements))  # 순서를 일부러 뒤집음
+
+    async def fake_post(self, url, json, headers):
+        return httpx.Response(200, json=shuffled, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=_stops(), start_instance_id="C")
+    )
+    assert res.source == "google"
+    assert res.ordered_instance_ids == ["C", "D", "B", "A"]
+    assert res.total_duration_seconds == 40

--- a/apps/ai-engine/tests/test_route_order_service.py
+++ b/apps/ai-engine/tests/test_route_order_service.py
@@ -5,6 +5,7 @@ import pytest
 
 from app.schemas.parse import Coordinates
 from app.schemas.route import OptimizeOrderRequest, OptimizeStop
+from app.services import route_matrix_cache
 from app.services import route_order_service as svc
 
 
@@ -144,3 +145,70 @@ async def test_handles_unordered_matrix_elements(monkeypatch) -> None:
     assert res.source == "google"
     assert res.ordered_instance_ids == ["C", "D", "B", "A"]
     assert res.total_duration_seconds == 40
+
+
+@pytest.mark.asyncio
+async def test_full_cache_hit_skips_route_matrix(monkeypatch) -> None:
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    stops = _stops()
+    pos = {0: 20, 1: 0, 2: 30, 3: 10}  # 입력 index 기준 위치(초)
+    cached = {}
+    for i in range(4):
+        for j in range(4):
+            if i != j:
+                a, b = stops[i].coordinates, stops[j].coordinates
+                cached[route_matrix_cache.pair_key(a.lat, a.lng, b.lat, b.lng)] = abs(pos[i] - pos[j])
+
+    async def fake_get_durations(keys):
+        return cached
+
+    monkeypatch.setattr(route_matrix_cache, "get_durations", fake_get_durations)
+
+    async def must_not_call(self, *args, **kwargs):
+        raise AssertionError("전체 캐시 히트 시 Route Matrix 를 호출하면 안 됨")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", must_not_call)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=stops, start_instance_id="C")
+    )
+    assert res.source == "google"
+    assert res.ordered_instance_ids == ["C", "D", "B", "A"]
+    assert res.total_duration_seconds == 40
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_calls_matrix_and_writes(monkeypatch) -> None:
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    async def empty_cache(keys):
+        return {}
+
+    monkeypatch.setattr(route_matrix_cache, "get_durations", empty_cache)
+
+    written = {}
+
+    async def capture_put(rows):
+        written["rows"] = rows
+
+    monkeypatch.setattr(route_matrix_cache, "put_durations", capture_put)
+
+    elements = _line_matrix_elements()
+
+    async def fake_post(self, url, *args, **kwargs):
+        return httpx.Response(200, json=elements, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=_stops(), start_instance_id="C")
+    )
+    assert res.source == "google"
+    assert res.ordered_instance_ids == ["C", "D", "B", "A"]
+    assert res.total_duration_seconds == 40
+    # 4x4 - 대각 4 = 12 pair 가 캐시에 적재돼야 한다
+    assert "rows" in written and len(written["rows"]) == 12
+    assert all("pair_key" in r and "duration_seconds" in r for r in written["rows"])

--- a/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeController.java
@@ -1,0 +1,24 @@
+package com.tripkey.domain.optimize;
+
+import com.tripkey.dto.optimize.OptimizeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/trips/{tripId}/optimize")
+@RequiredArgsConstructor
+public class OptimizeController {
+
+    private final OptimizeService optimizeService;
+
+    @PostMapping
+    public ResponseEntity<OptimizeResponse> optimize(@PathVariable UUID tripId) {
+        return ResponseEntity.ok(optimizeService.optimize(tripId));
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
@@ -1,0 +1,101 @@
+package com.tripkey.domain.optimize;
+
+import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.optimize.OptimizeResponse;
+import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiOptimizeOrderRequest;
+import com.tripkey.infra.aiengine.dto.AiOptimizeOrderResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+/**
+ * SCR-04 동선 최적화 1차
+ * Day 내 방문 순서를 총 이동시간 최소가 되도록 AI 엔진으로 최적화한 "제안"을 반환한다
+ * 저장하지 않는다 — 사용자가 수락하면 verify/save 로 day_order 에 반영
+ */
+@Service
+@RequiredArgsConstructor
+public class OptimizeService {
+
+    private static final double COORD_PRECISION = 100_000.0; // 좌표 5자리(약 1m) 반올림
+
+    private final TripRepository tripRepository;
+    private final PlaceCardRepository placeCardRepository;
+    private final AiEngineClient aiEngineClient;
+
+    @Transactional(readOnly = true)
+    public OptimizeResponse optimize(UUID tripId) {
+        if (!tripRepository.existsById(tripId)) {
+            throw new TripNotFoundException(tripId);
+        }
+
+        Map<Integer, List<PlaceCard>> byDay = groupByDay(tripId);
+        List<OptimizeResponse.DayOrder> days = new ArrayList<>();
+
+        for (Map.Entry<Integer, List<PlaceCard>> entry : byDay.entrySet()) {
+            List<PlaceCard> cards = entry.getValue();
+            if (cards.size() < 2) {
+                continue; // 최적화할 게 없음 (0~1개)
+            }
+
+            List<AiOptimizeOrderRequest.Stop> stops = new ArrayList<>();
+            for (PlaceCard card : cards) {
+                stops.add(new AiOptimizeOrderRequest.Stop(
+                        card.getInstanceId().toString(),
+                        new AiOptimizeOrderRequest.Coord(round(card.getLat()), round(card.getLng()))));
+            }
+
+            AiOptimizeOrderResponse response = aiEngineClient.optimizeOrder(
+                    new AiOptimizeOrderRequest(stops, accommodationAnchor(cards)));
+
+            List<UUID> orderedIds = response.orderedInstanceIds().stream()
+                    .map(UUID::fromString)
+                    .toList();
+
+            days.add(new OptimizeResponse.DayOrder(
+                    entry.getKey(), orderedIds, response.totalDurationSeconds(), response.source()));
+        }
+
+        return OptimizeResponse.of(tripId, days);
+    }
+
+    /** Day 시작 앵커 — 숙소 카드가 있으면 그 instance_id, 없으면 null(시작 자유). */
+    private static String accommodationAnchor(List<PlaceCard> cards) {
+        for (PlaceCard card : cards) {
+            if ("accommodation".equals(card.getCategory())) {
+                return card.getInstanceId().toString();
+            }
+        }
+        return null;
+    }
+
+    /** RouteService.groupByDay 와 동일 기준: 제외 X, day 있음, 좌표 있음, day_order 정렬. */
+    private Map<Integer, List<PlaceCard>> groupByDay(UUID tripId) {
+        Map<Integer, List<PlaceCard>> byDay = new TreeMap<>();
+        for (PlaceCard card : placeCardRepository.findAllByTripId(tripId)) {
+            if (Boolean.TRUE.equals(card.getIsExcluded())) continue;
+            if (card.getDay() == null) continue;
+            if (card.getLat() == null || card.getLng() == null) continue;
+            byDay.computeIfAbsent(card.getDay(), k -> new ArrayList<>()).add(card);
+        }
+        for (List<PlaceCard> cards : byDay.values()) {
+            cards.sort(Comparator.comparing(c -> c.getDayOrder() == null ? Short.MAX_VALUE : c.getDayOrder()));
+        }
+        return byDay;
+    }
+
+    private static double round(double value) {
+        return Math.round(value * COORD_PRECISION) / COORD_PRECISION;
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/optimize/OptimizeResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/optimize/OptimizeResponse.java
@@ -1,0 +1,22 @@
+package com.tripkey.dto.optimize;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * SCR-04 동선 최적화 1차 — Day별 "제안" 방문 순서 (#270).
+ * 저장하지 않는 제안 결과. 사용자가 수락하면 verify/save 로 day_order 에 반영한다.
+ */
+public record OptimizeResponse(UUID tripId, List<DayOrder> days) {
+
+    public record DayOrder(
+            int day,
+            List<UUID> orderedInstanceIds,
+            int totalDurationSeconds,
+            String source
+    ) {}
+
+    public static OptimizeResponse of(UUID tripId, List<DayOrder> days) {
+        return new OptimizeResponse(tripId, days);
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/AiEngineClient.java
@@ -7,6 +7,8 @@ import com.tripkey.infra.aiengine.dto.AiParseRequest;
 import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentRequest;
 import com.tripkey.infra.aiengine.dto.AiNonBlockingEnrichmentResponse;
+import com.tripkey.infra.aiengine.dto.AiOptimizeOrderRequest;
+import com.tripkey.infra.aiengine.dto.AiOptimizeOrderResponse;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
 import com.tripkey.infra.aiengine.dto.AiRouteRequest;
 import com.tripkey.infra.aiengine.dto.AiRouteResponse;
@@ -55,6 +57,23 @@ public class AiEngineClient {
             return response;
         } catch (WebClientResponseException | WebClientRequestException e) {
             throw new IllegalStateException("Failed to call ai-engine route endpoint", e);
+        }
+    }
+
+    public AiOptimizeOrderResponse optimizeOrder(AiOptimizeOrderRequest request) {
+        try {
+            AiOptimizeOrderResponse response = aiEngineWebClient.post()
+                    .uri("/internal/ai/route/optimize-order")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(AiOptimizeOrderResponse.class)
+                    .block();
+            if (response == null) {
+                throw new IllegalStateException("ai-engine returned an empty optimize-order response body");
+            }
+            return response;
+        } catch (WebClientResponseException | WebClientRequestException e) {
+            throw new IllegalStateException("Failed to call ai-engine optimize-order endpoint", e);
         }
     }
 

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderRequest.java
@@ -1,0 +1,18 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record AiOptimizeOrderRequest(
+        List<Stop> stops,
+        @JsonProperty("start_instance_id") String startInstanceId
+) {
+
+    public record Coord(double lat, double lng) {}
+
+    public record Stop(
+            @JsonProperty("instance_id") String instanceId,
+            Coord coordinates
+    ) {}
+}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderResponse.java
@@ -1,0 +1,11 @@
+package com.tripkey.infra.aiengine.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record AiOptimizeOrderResponse(
+        @JsonProperty("ordered_instance_ids") List<String> orderedInstanceIds,
+        @JsonProperty("total_duration_seconds") int totalDurationSeconds,
+        String source
+) {}

--- a/apps/backend/src/test/java/com/tripkey/domain/optimize/OptimizeServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/optimize/OptimizeServiceTest.java
@@ -1,0 +1,124 @@
+package com.tripkey.domain.optimize;
+
+import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.optimize.OptimizeResponse;
+import com.tripkey.infra.aiengine.AiEngineClient;
+import com.tripkey.infra.aiengine.dto.AiOptimizeOrderRequest;
+import com.tripkey.infra.aiengine.dto.AiOptimizeOrderResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OptimizeServiceTest {
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @Mock
+    private PlaceCardRepository placeCardRepository;
+
+    @Mock
+    private AiEngineClient aiEngineClient;
+
+    @InjectMocks
+    private OptimizeService optimizeService;
+
+    private PlaceCard card(UUID id, Integer day, short order, Double lat, Double lng,
+                           String category, boolean excluded) {
+        PlaceCard c = org.mockito.Mockito.mock(PlaceCard.class);
+        lenient().when(c.getInstanceId()).thenReturn(id);
+        lenient().when(c.getDay()).thenReturn(day);
+        lenient().when(c.getDayOrder()).thenReturn(order);
+        lenient().when(c.getLat()).thenReturn(lat);
+        lenient().when(c.getLng()).thenReturn(lng);
+        lenient().when(c.getCategory()).thenReturn(category);
+        lenient().when(c.getIsExcluded()).thenReturn(excluded);
+        return c;
+    }
+
+    @Test
+    void optimizeReturnsPerDaySuggestionWithAccommodationAnchor() {
+        UUID tripId = UUID.randomUUID();
+        UUID acc = UUID.randomUUID();
+        UUID p1 = UUID.randomUUID();
+        UUID p2 = UUID.randomUUID();
+
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard accCard = card(acc, 1, (short) 0, 34.70, 135.50, "accommodation", false);
+        PlaceCard place1 = card(p1, 1, (short) 1, 34.71, 135.51, "place", false);
+        PlaceCard place2 = card(p2, 1, (short) 2, 34.72, 135.52, "food", false);
+        PlaceCard day2 = card(UUID.randomUUID(), 2, (short) 0, 35.0, 135.0, "place", false);
+        PlaceCard noCoord = card(UUID.randomUUID(), 1, (short) 3, null, null, "place", false);
+        PlaceCard excluded = card(UUID.randomUUID(), 1, (short) 4, 34.7, 135.5, "place", true);
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(accCard, place1, place2, day2, noCoord, excluded));
+
+        // Day1: 3 stops → AI 호출, 재정렬 결과 반환. Day2: 1 stop → 스킵(AI 미호출).
+        when(aiEngineClient.optimizeOrder(any())).thenReturn(
+                new AiOptimizeOrderResponse(
+                        List.of(acc.toString(), p2.toString(), p1.toString()), 1800, "google"));
+
+        OptimizeResponse res = optimizeService.optimize(tripId);
+
+        assertThat(res.tripId()).isEqualTo(tripId);
+        assertThat(res.days()).hasSize(1);
+        OptimizeResponse.DayOrder d = res.days().get(0);
+        assertThat(d.day()).isEqualTo(1);
+        assertThat(d.orderedInstanceIds()).containsExactly(acc, p2, p1);
+        assertThat(d.totalDurationSeconds()).isEqualTo(1800);
+        assertThat(d.source()).isEqualTo("google");
+
+        ArgumentCaptor<AiOptimizeOrderRequest> captor =
+                ArgumentCaptor.forClass(AiOptimizeOrderRequest.class);
+        verify(aiEngineClient, times(1)).optimizeOrder(captor.capture());
+        AiOptimizeOrderRequest req = captor.getValue();
+        assertThat(req.startInstanceId()).isEqualTo(acc.toString());
+        assertThat(req.stops()).hasSize(3);
+        // day_order 정렬: acc(0) → place1(1) → place2(2)
+        assertThat(req.stops().get(0).instanceId()).isEqualTo(acc.toString());
+        assertThat(req.stops().get(1).instanceId()).isEqualTo(p1.toString());
+        assertThat(req.stops().get(2).instanceId()).isEqualTo(p2.toString());
+    }
+
+    @Test
+    void skipsDaysWithFewerThanTwoStopsAndDoesNotCallAi() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        PlaceCard single = card(UUID.randomUUID(), 1, (short) 0, 34.70, 135.50, "place", false);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(single));
+
+        OptimizeResponse res = optimizeService.optimize(tripId);
+
+        assertThat(res.days()).isEmpty();
+        verify(aiEngineClient, never()).optimizeOrder(any());
+    }
+
+    @Test
+    void throwsWhenTripNotFound() {
+        UUID tripId = UUID.randomUUID();
+        when(tripRepository.existsById(tripId)).thenReturn(false);
+        assertThatThrownBy(() -> optimizeService.optimize(tripId))
+                .isInstanceOf(TripNotFoundException.class);
+    }
+}

--- a/shared/docs/migrations/V014__route_matrix_cache.sql
+++ b/shared/docs/migrations/V014__route_matrix_cache.sql
@@ -1,0 +1,34 @@
+-- TripKey migration: route_matrix_cache (#274)
+-- Date: 2026-06-26
+-- Scope: SCR-04 동선 최적화(#270)의 이동시간 행렬 캐시.
+--        verify 의 route_legs_cache(best-mode) 와 메트릭이 달라(여기는 DRIVE) 분리한다.
+--
+-- 적용 대상: Supabase (dev / staging / production)
+-- 적용 방법: Supabase SQL Editor 에서 본 파일 전체 실행
+-- 동기 산출물: shared/docs/schema.sql 에 본 테이블 반영
+--
+-- 키: pair_key = sha1("round(o_lat),round(o_lng),round(d_lat),round(d_lng),mode") (좌표 5자리 반올림)
+--     PostgREST upsert(Prefer: resolution=merge-duplicates) 충돌 대상이 되도록 PK 로 둔다.
+
+create table if not exists public.route_matrix_cache (
+  pair_key         text        primary key,
+  origin_lat       double precision not null,
+  origin_lng       double precision not null,
+  dest_lat         double precision not null,
+  dest_lng         double precision not null,
+  mode             text        not null default 'driving',
+  duration_seconds integer     not null,
+  distance_meters  integer,
+  created_at       timestamptz not null default now(),
+  expires_at       timestamptz not null
+);
+
+-- 만료 정리/조회용
+create index if not exists idx_route_matrix_cache_expires
+  on public.route_matrix_cache (expires_at);
+
+-- ─────────────────────────────────────────────
+-- 검증 (적용 후 Supabase SQL Editor)
+-- ─────────────────────────────────────────────
+-- select column_name, data_type from information_schema.columns
+-- where table_name = 'route_matrix_cache' order by ordinal_position;


### PR DESCRIPTION
Closes #270

## 개요

SCR-04 동선 최적화 1차(MVP): Day 내 방문 순서를 총 이동시간 최소가 되도록 최적화한 **제안**을 반환합니다. 저장은 하지 않으며(suggestion-only), 수락 시 기존 `verify`로 `day_order`에 반영합니다.

## 변경

### AI 엔진
- `route_order_optimizer.py` — Held-Karp 정확해(n≤13) + nearest-neighbor/2-opt 폴백(비대칭 안전), 시작 앵커 고정 지원. 순수 로직.
- `route_order_service.py` — Google **computeRouteMatrix** 1회 호출로 N×N 이동시간 행렬 + 키부재/실패/누락 시 haversine 추정 폴백.
- `POST /internal/ai/route/optimize-order` 엔드포인트.

### 백엔드
- `AiEngineClient.optimizeOrder()` + `AiOptimizeOrderRequest/Response` DTO.
- `OptimizeService` — Day 그룹핑(제외X·day있음·좌표있음·day_order 정렬), 숙소 앵커 탐지, AI 호출 → Day별 제안 순서.
- `POST /v1/trips/{tripId}/optimize` (`OptimizeController`) + `OptimizeResponse` DTO.

## 검증

- AI 엔진: pytest **91 passed** (신규 13건 — 완전탐색 대조, 비대칭 행렬, **실 API 무순서 응답 회귀** 포함).
- 백엔드: `OptimizeServiceTest` 통과 + 모듈 전체 컴파일 성공.
- **실 API 검증 완료**: computeRouteMatrix 응답 형식(`originIndex/destinationIndex/duration:"Ns"/condition:"ROUTE_EXISTS"`, 요소 무순서) 확인 — 파서가 인덱스 기준 배치라 순서 무관하게 정확.

## 비범위 / 후속

- 제안 수락 → 저장: 기존 `verify` 재사용(= FE 작업, 별도 PR).
- `route_legs_cache` 재활용(행렬 캐싱, 모드 통일 필요) — 비용 최적화 후속.
- Phase 2(제약: 항공/숙소 종료앵커·고정카드·영업시간, OR-tools), Phase 3(Day 배정 재조정).
- 백엔드 컨트롤러/통합 테스트 보강.
