### PR TITLE
Feat: #274 동선 최적화 행렬 캐시 (route_matrix_cache, Phase A)

### DIFF
--- a/apps/ai-engine/app/services/route_matrix_cache.py
+++ b/apps/ai-engine/app/services/route_matrix_cache.py
@@ -1,0 +1,94 @@
+"""SCR-04 동선 최적화 이동시간 행렬 캐시 (#274).
+
+route_legs_cache(verify, best-mode)와 분리된 DRIVE 전용 캐시.
+Supabase PostgREST(L2)로 pair 단위 duration 을 저장/조회한다(places_cache 와 동일 패턴).
+캐시 실패는 절대 최적화를 깨지 않는다(에러 무해화 → Route Matrix 폴백).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# 테스트에서 monkeypatch 할 수 있도록 모듈 전역으로 둔다.
+ROUTE_MATRIX_CACHE_ENABLED = os.getenv("ROUTE_MATRIX_CACHE_ENABLED", "true").lower() == "true"
+ROUTE_MATRIX_CACHE_TTL_DAYS = int(os.getenv("ROUTE_MATRIX_CACHE_TTL_DAYS", "30"))
+CACHE_READ_TIMEOUT = float(os.getenv("ROUTE_MATRIX_CACHE_READ_TIMEOUT", "1.5"))
+CACHE_WRITE_TIMEOUT = float(os.getenv("ROUTE_MATRIX_CACHE_WRITE_TIMEOUT", "2.0"))
+
+SUPABASE_URL = os.getenv("SUPABASE_URL", "")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
+
+_TABLE_PATH = "/rest/v1/route_matrix_cache"
+_COORD_PRECISION = 100_000.0  # 좌표 5자리(약 1m) — 백엔드 COORD_PRECISION 과 일치
+MODE = "driving"
+
+
+def cache_enabled() -> bool:
+    return bool(ROUTE_MATRIX_CACHE_ENABLED and SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY)
+
+
+def round_coord(value: float) -> float:
+    return round(value * _COORD_PRECISION) / _COORD_PRECISION
+
+
+def pair_key(o_lat: float, o_lng: float, d_lat: float, d_lng: float, mode: str = MODE) -> str:
+    raw = f"{round_coord(o_lat)},{round_coord(o_lng)},{round_coord(d_lat)},{round_coord(d_lng)},{mode}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()
+
+
+def _headers() -> dict:
+    return {
+        "apikey": SUPABASE_SERVICE_ROLE_KEY,
+        "Authorization": f"Bearer {SUPABASE_SERVICE_ROLE_KEY}",
+        "Content-Type": "application/json",
+    }
+
+
+async def get_durations(keys: list[str]) -> dict[str, int]:
+    """비만료 행의 {pair_key: duration_seconds}. 비활성/실패 시 빈 dict(폴백)."""
+    if not keys or not cache_enabled():
+        return {}
+    now_iso = datetime.now(timezone.utc).isoformat()
+    params = {
+        "pair_key": f"in.({','.join(keys)})",
+        "expires_at": f"gt.{now_iso}",
+        "select": "pair_key,duration_seconds",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=CACHE_READ_TIMEOUT) as client:
+            resp = await client.get(f"{SUPABASE_URL}{_TABLE_PATH}", params=params, headers=_headers())
+            resp.raise_for_status()
+            rows = resp.json()
+        return {
+            r["pair_key"]: int(r["duration_seconds"])
+            for r in rows
+            if r.get("duration_seconds") is not None
+        }
+    except Exception as exc:  # noqa: BLE001 - 캐시 실패가 최적화를 깨면 안 됨
+        logger.warning("route_matrix_cache read failed | error=%s", exc)
+        return {}
+
+
+async def put_durations(rows: list[dict]) -> None:
+    """rows: [{pair_key, origin_lat, origin_lng, dest_lat, dest_lng, mode, duration_seconds, distance_meters}].
+
+    PostgREST upsert(Prefer: merge-duplicates). 비활성/실패 시 무시(에러 무해화).
+    """
+    if not rows or not cache_enabled():
+        return
+    expires = (datetime.now(timezone.utc) + timedelta(days=ROUTE_MATRIX_CACHE_TTL_DAYS)).isoformat()
+    body = [{**row, "expires_at": expires} for row in rows]
+    headers = {**_headers(), "Prefer": "resolution=merge-duplicates,return=minimal"}
+    try:
+        async with httpx.AsyncClient(timeout=CACHE_WRITE_TIMEOUT) as client:
+            resp = await client.post(f"{SUPABASE_URL}{_TABLE_PATH}", json=body, headers=headers)
+            resp.raise_for_status()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("route_matrix_cache write failed | error=%s", exc)

--- a/apps/ai-engine/app/services/route_order_service.py
+++ b/apps/ai-engine/app/services/route_order_service.py
@@ -19,6 +19,7 @@ from app.schemas.route import (
     OptimizeStop,
     RouteLeg,
 )
+from app.services import route_matrix_cache
 from app.services.route_optimizer import _parse_duration_seconds, _places_api_key
 from app.services.route_order_optimizer import optimize_visit_order, path_duration
 
@@ -44,7 +45,7 @@ async def _call_route_matrix(stops: list[OptimizeStop], api_key: str) -> list[di
     waypoints = [_waypoint(s.coordinates) for s in stops]
     headers = {
         "X-Goog-Api-Key": api_key,
-        "X-Goog-FieldMask": "originIndex,destinationIndex,duration,condition",
+        "X-Goog-FieldMask": "originIndex,destinationIndex,duration,distanceMeters,condition",
         "Content-Type": "application/json",
     }
     payload = {"origins": waypoints, "destinations": waypoints, "travelMode": "DRIVE"}
@@ -73,6 +74,23 @@ async def _build_matrix(
             if i != j:
                 matrix[i][j] = _estimate_seconds(stops[i].coordinates, stops[j].coordinates)
 
+    # pair_key 사전(캐시 조회/적재 공용)
+    pair_keys: dict[tuple[int, int], str] = {}
+    for i in range(n):
+        for j in range(n):
+            if i != j:
+                a, b = stops[i].coordinates, stops[j].coordinates
+                pair_keys[(i, j)] = route_matrix_cache.pair_key(a.lat, a.lng, b.lat, b.lng)
+
+    # 1) L2 캐시 전체 히트면 Google 호출 생략 (Route Matrix 는 부분 캐시가 불가 → 전부 있어야 의미)
+    if route_matrix_cache.cache_enabled():
+        cached = await route_matrix_cache.get_durations(list(set(pair_keys.values())))
+        if cached and all(k in cached for k in pair_keys.values()):
+            for (i, j), k in pair_keys.items():
+                matrix[i][j] = cached[k]
+            return matrix, "google"
+
+    # 2) 미스 또는 키 없음 → Route Matrix 1회 호출
     if not api_key:
         return matrix, "estimated"
 
@@ -80,6 +98,7 @@ async def _build_matrix(
     if not elements:
         return matrix, "estimated"
 
+    rows: list[dict] = []
     for elem in elements:
         i = elem.get("originIndex")
         j = elem.get("destinationIndex")
@@ -88,8 +107,25 @@ async def _build_matrix(
         if elem.get("condition") != "ROUTE_EXISTS":
             continue
         duration = _parse_duration_seconds(elem.get("duration"))
-        if duration is not None:
-            matrix[i][j] = duration
+        if duration is None:
+            continue
+        matrix[i][j] = duration
+        a, b = stops[i].coordinates, stops[j].coordinates
+        rows.append({
+            "pair_key": pair_keys[(i, j)],
+            "origin_lat": route_matrix_cache.round_coord(a.lat),
+            "origin_lng": route_matrix_cache.round_coord(a.lng),
+            "dest_lat": route_matrix_cache.round_coord(b.lat),
+            "dest_lng": route_matrix_cache.round_coord(b.lng),
+            "mode": route_matrix_cache.MODE,
+            "duration_seconds": duration,
+            "distance_meters": elem.get("distanceMeters"),
+        })
+
+    # 3) 캐시 적재 (best-effort)
+    if route_matrix_cache.cache_enabled():
+        await route_matrix_cache.put_durations(rows)
+
     return matrix, "google"
 
 

--- a/apps/ai-engine/tests/test_route_matrix_cache.py
+++ b/apps/ai-engine/tests/test_route_matrix_cache.py
@@ -1,0 +1,77 @@
+"""SCR-04 동선 최적화 행렬 캐시 단위 테스트 (#274)."""
+
+import httpx
+import pytest
+
+from app.services import route_matrix_cache as rmc
+
+
+def test_pair_key_rounds_and_is_directional() -> None:
+    # 좌표 5자리 반올림 → 미세차이는 같은 키
+    assert rmc.pair_key(34.700001, 135.500001, 34.71, 135.51) == rmc.pair_key(
+        34.700002, 135.500002, 34.71, 135.51
+    )
+    # 방향이 다르면 키가 다르다(비대칭)
+    assert rmc.pair_key(34.70, 135.50, 34.71, 135.51) != rmc.pair_key(
+        34.71, 135.51, 34.70, 135.50
+    )
+
+
+def test_cache_enabled_requires_url_and_key(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", True)
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "")
+    assert rmc.cache_enabled() is False
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "https://x.supabase.co")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "k")
+    assert rmc.cache_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_get_durations_disabled_returns_empty(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", False)
+    assert await rmc.get_durations(["k1"]) == {}
+
+
+@pytest.mark.asyncio
+async def test_get_durations_parses_rows(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", True)
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "https://x.supabase.co")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "k")
+
+    async def fake_get(self, url, *args, **kwargs):
+        return httpx.Response(
+            200,
+            json=[{"pair_key": "k1", "duration_seconds": 642}],
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    assert await rmc.get_durations(["k1"]) == {"k1": 642}
+
+
+@pytest.mark.asyncio
+async def test_get_durations_swallows_errors(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", True)
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "https://x.supabase.co")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "k")
+
+    async def boom(self, url, *args, **kwargs):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", boom)
+    assert await rmc.get_durations(["k1"]) == {}  # 폴백(빈 dict)
+
+
+@pytest.mark.asyncio
+async def test_put_durations_swallows_errors(monkeypatch) -> None:
+    monkeypatch.setattr(rmc, "ROUTE_MATRIX_CACHE_ENABLED", True)
+    monkeypatch.setattr(rmc, "SUPABASE_URL", "https://x.supabase.co")
+    monkeypatch.setattr(rmc, "SUPABASE_SERVICE_ROLE_KEY", "k")
+
+    async def boom(self, url, *args, **kwargs):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", boom)
+    # 예외가 새어나오지 않아야 한다
+    await rmc.put_durations([{"pair_key": "k1", "duration_seconds": 1}])

--- a/apps/ai-engine/tests/test_route_order_service.py
+++ b/apps/ai-engine/tests/test_route_order_service.py
@@ -5,6 +5,7 @@ import pytest
 
 from app.schemas.parse import Coordinates
 from app.schemas.route import OptimizeOrderRequest, OptimizeStop
+from app.services import route_matrix_cache
 from app.services import route_order_service as svc
 
 
@@ -144,3 +145,70 @@ async def test_handles_unordered_matrix_elements(monkeypatch) -> None:
     assert res.source == "google"
     assert res.ordered_instance_ids == ["C", "D", "B", "A"]
     assert res.total_duration_seconds == 40
+
+
+@pytest.mark.asyncio
+async def test_full_cache_hit_skips_route_matrix(monkeypatch) -> None:
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    stops = _stops()
+    pos = {0: 20, 1: 0, 2: 30, 3: 10}  # 입력 index 기준 위치(초)
+    cached = {}
+    for i in range(4):
+        for j in range(4):
+            if i != j:
+                a, b = stops[i].coordinates, stops[j].coordinates
+                cached[route_matrix_cache.pair_key(a.lat, a.lng, b.lat, b.lng)] = abs(pos[i] - pos[j])
+
+    async def fake_get_durations(keys):
+        return cached
+
+    monkeypatch.setattr(route_matrix_cache, "get_durations", fake_get_durations)
+
+    async def must_not_call(self, *args, **kwargs):
+        raise AssertionError("전체 캐시 히트 시 Route Matrix 를 호출하면 안 됨")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", must_not_call)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=stops, start_instance_id="C")
+    )
+    assert res.source == "google"
+    assert res.ordered_instance_ids == ["C", "D", "B", "A"]
+    assert res.total_duration_seconds == 40
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_calls_matrix_and_writes(monkeypatch) -> None:
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    async def empty_cache(keys):
+        return {}
+
+    monkeypatch.setattr(route_matrix_cache, "get_durations", empty_cache)
+
+    written = {}
+
+    async def capture_put(rows):
+        written["rows"] = rows
+
+    monkeypatch.setattr(route_matrix_cache, "put_durations", capture_put)
+
+    elements = _line_matrix_elements()
+
+    async def fake_post(self, url, *args, **kwargs):
+        return httpx.Response(200, json=elements, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=_stops(), start_instance_id="C")
+    )
+    assert res.source == "google"
+    assert res.ordered_instance_ids == ["C", "D", "B", "A"]
+    assert res.total_duration_seconds == 40
+    # 4x4 - 대각 4 = 12 pair 가 캐시에 적재돼야 한다
+    assert "rows" in written and len(written["rows"]) == 12
+    assert all("pair_key" in r and "duration_seconds" in r for r in written["rows"])

--- a/shared/docs/migrations/V014__route_matrix_cache.sql
+++ b/shared/docs/migrations/V014__route_matrix_cache.sql
@@ -1,0 +1,34 @@
+-- TripKey migration: route_matrix_cache (#274)
+-- Date: 2026-06-26
+-- Scope: SCR-04 동선 최적화(#270)의 이동시간 행렬 캐시.
+--        verify 의 route_legs_cache(best-mode) 와 메트릭이 달라(여기는 DRIVE) 분리한다.
+--
+-- 적용 대상: Supabase (dev / staging / production)
+-- 적용 방법: Supabase SQL Editor 에서 본 파일 전체 실행
+-- 동기 산출물: shared/docs/schema.sql 에 본 테이블 반영
+--
+-- 키: pair_key = sha1("round(o_lat),round(o_lng),round(d_lat),round(d_lng),mode") (좌표 5자리 반올림)
+--     PostgREST upsert(Prefer: resolution=merge-duplicates) 충돌 대상이 되도록 PK 로 둔다.
+
+create table if not exists public.route_matrix_cache (
+  pair_key         text        primary key,
+  origin_lat       double precision not null,
+  origin_lng       double precision not null,
+  dest_lat         double precision not null,
+  dest_lng         double precision not null,
+  mode             text        not null default 'driving',
+  duration_seconds integer     not null,
+  distance_meters  integer,
+  created_at       timestamptz not null default now(),
+  expires_at       timestamptz not null
+);
+
+-- 만료 정리/조회용
+create index if not exists idx_route_matrix_cache_expires
+  on public.route_matrix_cache (expires_at);
+
+-- ─────────────────────────────────────────────
+-- 검증 (적용 후 Supabase SQL Editor)
+-- ─────────────────────────────────────────────
+-- select column_name, data_type from information_schema.columns
+-- where table_name = 'route_matrix_cache' order by ordinal_position;


### PR DESCRIPTION
Part of #274 (Phase A). Phase B(per-pair granular)는 동일 이슈 #274 에 잔여 작업으로 둠 — 본 PR 머지로 #274 를 닫지 않음.

> ⚠️ #272(SCR-04 동선 최적화 1차) 위에 **스택된 PR**입니다. base 가 `feat/be-route-optimize-order` 이므로 #272 머지 후 develop 으로 재타겟/리베이스 예정.

## 개요
동선 최적화(#270)의 이동시간 행렬을 캐시해 Google Route Matrix 과금을 줄인다(Phase A — 행렬 단위 캐시).

## 핵심 제약 반영
- **Route Matrix 는 부분 캐시 불가**(전체 cross product 과금) → "Day 전체 pair 가 모두 캐시됐을 때만" Google 호출 생략.
- **메트릭 분리**: optimize 는 DRIVE 기준. verify 의 `route_legs_cache`(best-mode)와 섞이지 않도록 **별도 테이블**.

## 변경
- `V014__route_matrix_cache.sql` — DRIVE 전용 캐시 테이블(pair_key PK).
- `route_matrix_cache.py` — Supabase PostgREST L2 캐시(`places_cache` 동일 패턴), kill switch + TTL + 에러 무해화.
- `route_order_service._build_matrix` — 전체 히트 → Google 0콜, 미스 → 1회 호출 후 pair 적재(fieldmask 에 distanceMeters 추가).

## 검증
- AI 엔진 pytest **100 passed** (캐시 모듈 6 + 통합 2).

## 배포 메모
- **V014 를 dev/staging/prod Supabase 에 적용**해야 캐싱 활성화. 적용 전이라도 에러 무해화 → Route Matrix 폴백으로 정상 동작.

## 후속 (#274 Phase B)
- per-pair granular: Route Matrix 폐기 → 미스 pair 만 per-leg 호출, verify 캐시와 공유.
- 캐시 적중률/과금 모니터링.
