### PR TITLE
Feat: #277 동선 검증 정확도 보강 (이동시간 합산·실제 이동거리)

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/verify/RouteValidator.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/verify/RouteValidator.java
@@ -2,6 +2,8 @@ package com.tripkey.domain.verify;
 
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.route.RouteService;
+import com.tripkey.dto.placement.RouteLeg;
 import com.tripkey.dto.placement.RouteWarning;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,6 +16,12 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 
+/**
+ * SCR-04V 동선 검증. (#277 정확도 보강)
+ * - 거리 conflict: 캐시된 실제 이동거리(route_legs) 우선, 없으면 직선거리(PostGIS) 폴백.
+ * - 시간 conflict: Day 체류시간 합 + 카드 간 이동시간(route_legs) 합.
+ * 이동시간/거리는 RouteService.readCachedLegs(캐시 전용, AI 미호출)로 읽는다.
+ */
 @Component
 @RequiredArgsConstructor
 public class RouteValidator {
@@ -22,31 +30,51 @@ public class RouteValidator {
     static final int DURATION_THRESHOLD_MINUTES = 600;
 
     private final PlaceCardRepository placeCardRepository;
+    private final RouteService routeService;
 
     @Transactional(readOnly = true)
     public List<RouteWarning> validate(UUID tripId) {
+        List<RouteLeg> legs = routeService.readCachedLegs(tripId);
         List<RouteWarning> warnings = new ArrayList<>();
-        warnings.addAll(distanceWarnings(tripId));
-        warnings.addAll(durationWarnings(tripId));
+        warnings.addAll(distanceWarnings(tripId, legs));
+        warnings.addAll(durationWarnings(tripId, legs));
         return warnings;
     }
 
-    private List<RouteWarning> distanceWarnings(UUID tripId) {
+    private List<RouteWarning> distanceWarnings(UUID tripId, List<RouteLeg> legs) {
+        // (from -> to) 실제 이동거리 맵 (캐시 leg 우선)
+        Map<String, Integer> realDistance = new HashMap<>();
+        for (RouteLeg leg : legs) {
+            if (leg.distanceMeters() != null) {
+                realDistance.put(legKey(leg.fromInstanceId(), leg.toInstanceId()), leg.distanceMeters());
+            }
+        }
+
         List<Object[]> rows = placeCardRepository.findAdjacentCardDistances(tripId);
         List<RouteWarning> result = new ArrayList<>();
         for (Object[] row : rows) {
             UUID idA = (UUID) row[0];
             UUID idB = (UUID) row[1];
             int day = ((Number) row[2]).intValue();
-            double distance = ((Number) row[3]).doubleValue();
+            double straight = ((Number) row[3]).doubleValue();
+            Integer real = realDistance.get(legKey(idA, idB));
+            int distance = real != null ? real : (int) Math.round(straight);
             if (distance > DISTANCE_THRESHOLD_METERS) {
-                result.add(RouteWarning.distance(day, idA, idB, (int) Math.round(distance)));
+                result.add(RouteWarning.distance(day, idA, idB, distance));
             }
         }
         return result;
     }
 
-    private List<RouteWarning> durationWarnings(UUID tripId) {
+    private List<RouteWarning> durationWarnings(UUID tripId, List<RouteLeg> legs) {
+        // Day 별 이동시간(초) 합
+        Map<Integer, Integer> travelSecByDay = new HashMap<>();
+        for (RouteLeg leg : legs) {
+            if (leg.day() != null && leg.durationSeconds() != null) {
+                travelSecByDay.merge(leg.day(), leg.durationSeconds(), Integer::sum);
+            }
+        }
+
         Map<Integer, List<PlaceCard>> byDay = new TreeMap<>();
         for (PlaceCard card : placeCardRepository.findAllByTripId(tripId)) {
             if (Boolean.TRUE.equals(card.getIsExcluded())) continue;
@@ -57,18 +85,24 @@ public class RouteValidator {
 
         List<RouteWarning> result = new ArrayList<>();
         for (Map.Entry<Integer, List<PlaceCard>> entry : byDay.entrySet()) {
-            int total = 0;
+            int stayMinutes = 0;
             List<UUID> instanceIds = new ArrayList<>();
             for (PlaceCard card : entry.getValue()) {
                 if (card.getEstimatedDurationMin() != null) {
-                    total += card.getEstimatedDurationMin();
+                    stayMinutes += card.getEstimatedDurationMin();
                 }
                 instanceIds.add(card.getInstanceId());
             }
+            int travelMinutes = travelSecByDay.getOrDefault(entry.getKey(), 0) / 60;
+            int total = stayMinutes + travelMinutes;
             if (total > DURATION_THRESHOLD_MINUTES) {
                 result.add(RouteWarning.duration(entry.getKey(), instanceIds, total));
             }
         }
         return result;
+    }
+
+    private static String legKey(UUID from, UUID to) {
+        return from + "->" + to;
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/verify/VerifyService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/verify/VerifyService.java
@@ -77,8 +77,9 @@ public class VerifyService {
         }
 
         placeCardRepository.flush();
-        List<RouteWarning> routeWarnings = routeValidator.validate(tripId);
+
         // route leg 계산은 부가정보(best-effort). ai-engine 장애/타임아웃 시에도 Day 배치 저장은 성공해야 한다.
+        // 먼저 계산해 route_legs_cache 를 채운 뒤 검증해야, 시간/거리 conflict 가 이동시간을 반영한다(#277).
         List<RouteLeg> routeLegs;
         try {
             routeLegs = routeService.computeLegs(tripId);
@@ -86,6 +87,8 @@ public class VerifyService {
             log.warn("route leg 계산 실패, 빈 결과로 대체합니다. tripId={}", tripId, e);
             routeLegs = List.of();
         }
+
+        List<RouteWarning> routeWarnings = routeValidator.validate(tripId);
 
         return PlacementSaveResponse.of(tripId, skippedInstanceIds, routeWarnings, routeLegs);
     }

--- a/apps/backend/src/main/java/com/tripkey/dto/placement/RouteWarning.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/placement/RouteWarning.java
@@ -29,7 +29,7 @@ public record RouteWarning(
                 "duration",
                 day,
                 instanceIds,
-                String.format("Day %d 활동 시간 합계 %d시간", day, hours),
+                String.format("Day %d 활동·이동 시간 합계 %d시간", day, hours),
                 null,
                 totalMinutes
         );

--- a/apps/backend/src/test/java/com/tripkey/domain/verify/RouteValidatorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/verify/RouteValidatorTest.java
@@ -2,7 +2,10 @@ package com.tripkey.domain.verify;
 
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.route.RouteService;
+import com.tripkey.dto.placement.RouteLeg;
 import com.tripkey.dto.placement.RouteWarning;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,6 +17,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,8 +27,17 @@ class RouteValidatorTest {
     @Mock
     private PlaceCardRepository placeCardRepository;
 
+    @Mock
+    private RouteService routeService;
+
     @InjectMocks
     private RouteValidator routeValidator;
+
+    @BeforeEach
+    void setUp() {
+        // 기본: 캐시된 leg 없음 → 이동시간 0, 거리 conflict 는 직선거리 폴백
+        lenient().when(routeService.readCachedLegs(any())).thenReturn(List.of());
+    }
 
     @Test
     void validateReturnsEmptyWhenNoData() {
@@ -188,6 +202,45 @@ class RouteValidatorTest {
         assertThat(warnings).hasSize(2);
         assertThat(warnings).extracting(RouteWarning::type)
                 .containsExactlyInAnyOrder("distance", "duration");
+    }
+
+    @Test
+    void durationIncludesTravelTimeFromCachedLegs() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard c1 = placeCard(tripId, "place", 1, (short) 300);
+        PlaceCard c2 = placeCard(tripId, "place", 1, (short) 300);
+        // 체류 600분(임계 600 동일 → 단독이면 미경고). 이동 60분 더해 660 > 600 → 경고.
+        when(placeCardRepository.findAdjacentCardDistances(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(c1, c2));
+        when(routeService.readCachedLegs(tripId)).thenReturn(List.of(
+                new RouteLeg(1, c1.getInstanceId(), c2.getInstanceId(), 3600, 5_000, "driving", "google")));
+
+        List<RouteWarning> warnings = routeValidator.validate(tripId);
+
+        assertThat(warnings).hasSize(1);
+        RouteWarning w = warnings.get(0);
+        assertThat(w.type()).isEqualTo("duration");
+        assertThat(w.totalMinutes()).isEqualTo(660); // 600 체류 + 60 이동
+    }
+
+    @Test
+    void distanceUsesRealLegDistanceOverStraightLine() {
+        UUID tripId = UUID.randomUUID();
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+        // 직선거리 5km(임계 이하)지만 실제 이동거리 12km(임계 초과) → 경고
+        when(placeCardRepository.findAdjacentCardDistances(tripId))
+                .thenReturn(List.<Object[]>of(new Object[]{a, b, 1, 5_000.0}));
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+        when(routeService.readCachedLegs(tripId)).thenReturn(List.of(
+                new RouteLeg(1, a, b, 1500, 12_000, "driving", "google")));
+
+        List<RouteWarning> warnings = routeValidator.validate(tripId);
+
+        assertThat(warnings).hasSize(1);
+        RouteWarning w = warnings.get(0);
+        assertThat(w.type()).isEqualTo("distance");
+        assertThat(w.distanceMeters()).isEqualTo(12_000);
     }
 
     private PlaceCard placeCard(UUID tripId, String category, Integer day, Short estimatedDurationMin) {


### PR DESCRIPTION
Closes #277

## 개요
SCR-04V 동선 **검증**의 정확도를 보강한다. (동선 최적화 #270과 별개, develop 기준 독립 작업)

## 문제 (기존)
- 시간 conflict: Day **체류시간만** 합산(카드 간 이동시간 미포함).
- 거리 conflict: **직선거리(PostGIS)** 기준(실제 이동거리 아님).

## 변경
- `RouteValidator` — `RouteService.readCachedLegs`(캐시 전용, AI 미호출)로 leg를 읽어:
  - 시간 conflict = **체류시간 + 카드 간 이동시간** 합
  - 거리 conflict = **실제 이동거리(leg) 우선**, 없으면 직선거리 폴백
- `VerifyService` — `computeLegs`(캐시 워밍)를 `validate` **앞으로** 이동 → 첫 verify에도 이동시간 반영
- `RouteWarning` duration 메시지 "활동·이동 시간"으로 정정
- `validate(tripId)` 시그니처 유지 → CardService(읽기 경로) 무변경

## 검증
- `RouteValidatorTest`(신규: 이동시간 합산 / 실제 거리 우선 + 기존 회귀), `VerifyServiceTest`, `CardServiceTest` 통과 + 컴파일 성공.
- 마이그레이션 불필요(기존 `route_legs_cache` 사용).

## 참고 / 후속
- 읽기 경로(getCards)에서 validate가 readCachedLegs를 호출해 쿼리가 소폭 증가(인덱스 조회). 필요 시 카드/캐시 조회 통합은 후속.
- 임계값(10km/600분) 외부 설정화는 후속 검토 항목.
