### PR TITLE
feat(ai): #274 동선 최적화 캐시 Phase B — per-leg granular 미스 처리

### DIFF
--- a/apps/ai-engine/app/services/route_order_service.py
+++ b/apps/ai-engine/app/services/route_order_service.py
@@ -1,13 +1,15 @@
-"""SCR-04 동선 최적화 1차 — 이동시간 행렬 산출 + 순서 최적화 오케스트레이션 (#270).
+"""SCR-04 동선 최적화 — 이동시간 행렬 산출 + 순서 최적화 오케스트레이션 (#270, #274).
 
-Google Route Matrix(computeRouteMatrix) 1회 호출로 N×N 이동시간 행렬을 만들고,
-키 부재/호출 실패/구간 누락 시 haversine 추정으로 보강한 뒤
-route_order_optimizer 로 Day 내 방문 순서를 푼다. I/O 경계 모듈.
+L2 캐시(route_matrix_cache)의 pair 는 그대로 쓰고(부분 히트 포함), 빠진 pair 는 개수에 따라
+per-leg computeRoutes(소수) 또는 Route Matrix 1회(다수)로 채운다. 키 부재/호출 실패/구간 누락 시
+haversine 추정으로 보강한 뒤 route_order_optimizer 로 Day 내 방문 순서를 푼다. I/O 경계 모듈.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 
 import httpx
 
@@ -20,7 +22,11 @@ from app.schemas.route import (
     RouteLeg,
 )
 from app.services import route_matrix_cache
-from app.services.route_optimizer import _parse_duration_seconds, _places_api_key
+from app.services.route_optimizer import (
+    _call_routes_api,
+    _parse_duration_seconds,
+    _places_api_key,
+)
 from app.services.route_order_optimizer import optimize_visit_order, path_duration
 
 logger = logging.getLogger(__name__)
@@ -28,6 +34,10 @@ logger = logging.getLogger(__name__)
 COMPUTE_ROUTE_MATRIX_URL = (
     "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix"
 )
+
+# 빠진 pair 가 이 수 이하면 per-leg computeRoutes 로 그 pair만 호출(부분변경 granular 절감),
+# 초과하면 Route Matrix 1회로 전체 재계산(cold 시 호출 수 폭증 방지). #274 Phase B.
+PER_LEG_MAX_PAIRS = int(os.getenv("ROUTE_MATRIX_PER_LEG_MAX_PAIRS", "8"))
 
 
 def _estimate_seconds(origin: Coordinates, destination: Coordinates) -> int:
@@ -60,12 +70,82 @@ async def _call_route_matrix(stops: list[OptimizeStop], api_key: str) -> list[di
     return data if isinstance(data, list) else None
 
 
+def _cache_row(a: Coordinates, b: Coordinates, key: str, duration: int, distance) -> dict:
+    return {
+        "pair_key": key,
+        "origin_lat": route_matrix_cache.round_coord(a.lat),
+        "origin_lng": route_matrix_cache.round_coord(a.lng),
+        "dest_lat": route_matrix_cache.round_coord(b.lat),
+        "dest_lng": route_matrix_cache.round_coord(b.lng),
+        "mode": route_matrix_cache.MODE,
+        "duration_seconds": duration,
+        "distance_meters": distance,
+    }
+
+
+async def _fill_via_route_matrix(
+    stops: list[OptimizeStop],
+    api_key: str,
+    matrix: list[list[int]],
+    pair_keys: dict[tuple[int, int], str],
+) -> bool:
+    """Route Matrix 1회로 전체 pair 를 채우고 캐시에 적재. 성공 시 True."""
+    elements = await _call_route_matrix(stops, api_key)
+    if not elements:
+        return False
+    rows: list[dict] = []
+    for elem in elements:
+        i = elem.get("originIndex")
+        j = elem.get("destinationIndex")
+        if i is None or j is None or i == j:
+            continue
+        if elem.get("condition") != "ROUTE_EXISTS":
+            continue
+        duration = _parse_duration_seconds(elem.get("duration"))
+        if duration is None:
+            continue
+        matrix[i][j] = duration
+        a, b = stops[i].coordinates, stops[j].coordinates
+        rows.append(_cache_row(a, b, pair_keys[(i, j)], duration, elem.get("distanceMeters")))
+    if route_matrix_cache.cache_enabled():
+        await route_matrix_cache.put_durations(rows)
+    return True
+
+
+async def _fill_via_per_leg(
+    stops: list[OptimizeStop],
+    api_key: str,
+    matrix: list[list[int]],
+    pair_keys: dict[tuple[int, int], str],
+    missing: list[tuple[int, int]],
+) -> bool:
+    """빠진 pair 만 per-leg computeRoutes(DRIVE)로 병렬 호출하고 캐시에 적재. 1건이라도 성공 시 True."""
+    results = await asyncio.gather(
+        *[
+            _call_routes_api(stops[i].coordinates, stops[j].coordinates, "DRIVE", api_key)
+            for (i, j) in missing
+        ]
+    )
+    rows: list[dict] = []
+    for (i, j), result in zip(missing, results):
+        if result is None:
+            continue
+        duration = result["duration_seconds"]
+        matrix[i][j] = duration
+        a, b = stops[i].coordinates, stops[j].coordinates
+        rows.append(_cache_row(a, b, pair_keys[(i, j)], duration, result.get("distance_meters")))
+    if rows and route_matrix_cache.cache_enabled():
+        await route_matrix_cache.put_durations(rows)
+    return bool(rows)
+
+
 async def _build_matrix(
     stops: list[OptimizeStop], api_key: str | None
 ) -> tuple[list[list[int]], str]:
     """N×N 이동시간(초) 행렬과 source('google'|'estimated') 반환.
 
-    먼저 haversine 추정으로 채워(=폴백 기본값) 둔 뒤, Google 결과가 있으면 덮어쓴다.
+    haversine 추정으로 채운 뒤, L2 캐시의 pair 는 그대로 사용(부분 히트 포함)하고,
+    빠진 pair 는 개수에 따라 per-leg computeRoutes(소수) 또는 Route Matrix 1회(다수)로 채운다(#274 Phase B).
     """
     n = len(stops)
     matrix = [[0] * n for _ in range(n)]
@@ -82,51 +162,33 @@ async def _build_matrix(
                 a, b = stops[i].coordinates, stops[j].coordinates
                 pair_keys[(i, j)] = route_matrix_cache.pair_key(a.lat, a.lng, b.lat, b.lng)
 
-    # 1) L2 캐시 전체 히트면 Google 호출 생략 (Route Matrix 는 부분 캐시가 불가 → 전부 있어야 의미)
+    # 1) L2 캐시 조회 — 부분 히트도 채운다(Phase A 는 전체 히트만 사용했음)
+    used_google = False
     if route_matrix_cache.cache_enabled():
         cached = await route_matrix_cache.get_durations(list(set(pair_keys.values())))
-        if cached and all(k in cached for k in pair_keys.values()):
-            for (i, j), k in pair_keys.items():
+        for (i, j), k in pair_keys.items():
+            if k in cached:
                 matrix[i][j] = cached[k]
-            return matrix, "google"
+                used_google = True
+        missing = [(i, j) for (i, j), k in pair_keys.items() if k not in cached]
+    else:
+        missing = list(pair_keys.keys())
 
-    # 2) 미스 또는 키 없음 → Route Matrix 1회 호출
+    # 2) 전부 캐시 히트 → Google 호출 없음
+    if not missing:
+        return matrix, "google"
+
+    # 3) 키 없음 → 남은 pair 는 추정 유지
     if not api_key:
-        return matrix, "estimated"
+        return matrix, "google" if used_google else "estimated"
 
-    elements = await _call_route_matrix(stops, api_key)
-    if not elements:
-        return matrix, "estimated"
+    # 4) 하이브리드: 빠진 pair 가 적으면 per-leg, 많으면 Route Matrix 1회
+    if len(missing) > PER_LEG_MAX_PAIRS:
+        filled = await _fill_via_route_matrix(stops, api_key, matrix, pair_keys)
+    else:
+        filled = await _fill_via_per_leg(stops, api_key, matrix, pair_keys, missing)
 
-    rows: list[dict] = []
-    for elem in elements:
-        i = elem.get("originIndex")
-        j = elem.get("destinationIndex")
-        if i is None or j is None or i == j:
-            continue
-        if elem.get("condition") != "ROUTE_EXISTS":
-            continue
-        duration = _parse_duration_seconds(elem.get("duration"))
-        if duration is None:
-            continue
-        matrix[i][j] = duration
-        a, b = stops[i].coordinates, stops[j].coordinates
-        rows.append({
-            "pair_key": pair_keys[(i, j)],
-            "origin_lat": route_matrix_cache.round_coord(a.lat),
-            "origin_lng": route_matrix_cache.round_coord(a.lng),
-            "dest_lat": route_matrix_cache.round_coord(b.lat),
-            "dest_lng": route_matrix_cache.round_coord(b.lng),
-            "mode": route_matrix_cache.MODE,
-            "duration_seconds": duration,
-            "distance_meters": elem.get("distanceMeters"),
-        })
-
-    # 3) 캐시 적재 (best-effort)
-    if route_matrix_cache.cache_enabled():
-        await route_matrix_cache.put_durations(rows)
-
-    return matrix, "google"
+    return matrix, "google" if (used_google or filled) else "estimated"
 
 
 async def optimize_order(request: OptimizeOrderRequest) -> OptimizeOrderResponse:

--- a/apps/ai-engine/tests/test_route_order_service.py
+++ b/apps/ai-engine/tests/test_route_order_service.py
@@ -212,3 +212,78 @@ async def test_cache_miss_calls_matrix_and_writes(monkeypatch) -> None:
     # 4x4 - 대각 4 = 12 pair 가 캐시에 적재돼야 한다
     assert "rows" in written and len(written["rows"]) == 12
     assert all("pair_key" in r and "duration_seconds" in r for r in written["rows"])
+
+
+@pytest.mark.asyncio
+async def test_partial_cache_miss_uses_per_leg(monkeypatch) -> None:
+    # 12 pair 중 소수만 미스 → Route Matrix 전체 재계산이 아니라 per-leg 로 빠진 pair 만 호출 (#274 Phase B)
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    async def partial_get(keys):
+        ks = list(keys)
+        return {k: 600 for k in ks[:-2]}  # 마지막 2개만 미스
+
+    monkeypatch.setattr(route_matrix_cache, "get_durations", partial_get)
+
+    put_rows: list[dict] = []
+
+    async def capture_put(rows):
+        put_rows.extend(rows)
+
+    monkeypatch.setattr(route_matrix_cache, "put_durations", capture_put)
+
+    calls = {"n": 0}
+
+    async def fake_routes(origin, destination, travel_mode, api_key):
+        calls["n"] += 1
+        assert travel_mode == "DRIVE"
+        return {"duration_seconds": 300, "distance_meters": 1000}
+
+    monkeypatch.setattr(svc, "_call_routes_api", fake_routes)
+
+    async def must_not_call_matrix(self, *args, **kwargs):
+        raise AssertionError("부분 미스 시 computeRouteMatrix 를 호출하면 안 됨")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", must_not_call_matrix)
+
+    res = await svc.optimize_order(OptimizeOrderRequest(stops=_stops()))
+    assert calls["n"] == 2            # 빠진 pair 만 per-leg 호출
+    assert len(put_rows) == 2         # 빠진 pair 만 캐시 적재
+    assert res.source == "google"
+
+
+@pytest.mark.asyncio
+async def test_many_misses_use_route_matrix_not_per_leg(monkeypatch) -> None:
+    # 미스가 임계(PER_LEG_MAX_PAIRS=8)보다 많으면 per-leg 대신 Route Matrix 1회 (cold 폭증 방지)
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    async def empty_cache(keys):
+        return {}
+
+    monkeypatch.setattr(route_matrix_cache, "get_durations", empty_cache)
+
+    async def noop_put(rows):
+        return None
+
+    monkeypatch.setattr(route_matrix_cache, "put_durations", noop_put)
+
+    async def must_not_per_leg(*args, **kwargs):
+        raise AssertionError("미스가 많으면 per-leg 가 아니라 Route Matrix 를 써야 함")
+
+    monkeypatch.setattr(svc, "_call_routes_api", must_not_per_leg)
+
+    elements = _line_matrix_elements()
+
+    async def fake_post(self, url, *args, **kwargs):
+        return httpx.Response(200, json=elements, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=_stops(), start_instance_id="C")
+    )
+    assert res.source == "google"
+    assert res.ordered_instance_ids == ["C", "D", "B", "A"]
+    assert res.total_duration_seconds == 40


### PR DESCRIPTION
## 📝 작업 내용

- #274 Phase B 핵심: 동선 최적화 이동시간 행렬 캐시에서 **빠진 pair만 per-leg `computeRoutes`(DRIVE)로 호출**하도록 변경 → 부분 변경 시 Google Route Matrix 과금 절감
- Phase A는 미스 시 Route Matrix로 **전체 재계산**이라 부분 변경 이득이 없었음(같은 Day 재최적화에만 이득). Phase B는 캐시 부분 히트 + 빠진 pair만 granular 호출.

## 🔗 관련 이슈

Part of #274 (Phase B 핵심). ※ 아래 "비범위" 항목이 남아 #274는 이 PR로 닫지 않습니다.
관련: #270/#272(동선 최적화), #278(Phase A)

## 🗂️ 변경 범위

- [ ] Frontend
- [ ] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [ ] 공통/설정/문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (ai-engine 전체 **102 passed**)
- [x] 기존 기능이 깨지지 않았나요? (전체 히트/전체 미스 회귀 테스트 유지)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 🔧 핵심 변경 (`route_order_service._build_matrix`)

- L2 캐시 **부분 히트도 사용**(기존엔 전체 히트만 채택).
- 하이브리드 미스 처리:
  - 빠진 pair ≤ `PER_LEG_MAX_PAIRS`(env, 기본 8) → **per-leg `computeRoutes`(DRIVE) 병렬 호출**, 빠진 pair만 적재
  - 초과 → 기존 **Route Matrix 1회**(cold 호출 폭증 방지)
- per-leg는 `route_optimizer._call_routes_api`를 **DRIVE 모드로 재사용**(매트릭스와 메트릭 일치).
- 신규 env: `ROUTE_MATRIX_PER_LEG_MAX_PAIRS` (기본 8).

## 🧩 결정 사항 (확정)

- **하이브리드**(per-leg + 임계 초과 시 Route Matrix) 채택 — cold 호출 폭증 방지.
- **route_legs_cache pair 공유는 이번 PR 제외** — best-mode(verify) vs DRIVE(optimize) 메트릭 통일 결정이 선행돼야 해서 별도 후속.

## ⛔ 비범위 / 후속 (#274에 남음)

- [ ] `route_legs_cache` pair 공유 (메트릭 통일 결정 선행)
- [ ] 캐시 적중률/과금 모니터링

## 👀 리뷰어에게

- BE/DTO/DB 영향 없음: `OptimizeOrderResponse`(ordered_instance_ids/total_duration_seconds/source) 계약 동일, V014 그대로 사용.
- 트레이드오프: 임계 이하 부분 미스는 per-leg(빠진 pair 수만큼 호출, 병렬), 임계 초과(cold 등)는 Route Matrix 1회. 임계는 env로 조정 가능.