### PR TITLE
SCR-04 구조화 편집으로 처리필요 카드 해결 (Phase 2)

### DIFF
--- a/apps/frontend/src/components/arrange/ArrangeCardDetailPanel.tsx
+++ b/apps/frontend/src/components/arrange/ArrangeCardDetailPanel.tsx
@@ -2,8 +2,15 @@
 // 정리 화면(SCR-03)의 CardDetailPanel 과 동일한 조립 부품
 // (SidePanel / StatusInfoBox / DetailRow / UserMemoField / PanelActions / PlaceCardBadge)을 재사용한다.
 //
-// 처리필요(unavailable) 카드 중 자연어 재파싱으로 해결 가능한 카드(detail.canResolveByNotes)는
-// "장소 정보 보완"(notes) 입력 + "확인하기"(저장+재처리) 푸터를 보여준다. 그 외 카드는 기존 메모 UI.
+// 처리필요(unavailable) 카드 중:
+//  - 숙소/교통 카드(canResolveByStructuredEdit): 구조화 편집 폼 + 선택처리 버튼
+//  - 자연어 재파싱 가능 카드(canResolveByNotes): 장소 정보 보완 입력
+//  - 그 외: 사용자 메모 UI
+//
+// 확인하기 PATCH 라우팅:
+//  ① structuredDirty → 구조화 PATCH (location 변경 시 폴링, 아닐 시 즉시 반영)
+//  ② notes 입력만  → notes PATCH (항상 폴링)
+//  선택처리 버튼   → notes PATCH(기존 텍스트 자동 전송) (항상 폴링)
 
 import { Clock, Info, MapPin, Plane, User, X } from 'lucide-react';
 import { Dialog } from 'radix-ui';
@@ -14,12 +21,14 @@ import SidePanel from '@/components/common/SidePanel';
 import {
   DetailRow,
   StatusInfoBox,
+  StructuredEditSection,
   UserMemoField,
 } from '@/components/grouping/CardDetailParts';
 import PlaceCardBadge from '@/components/grouping/PlaceCardBadge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import type { ArrangeCardViewModel } from '@/types/arrange';
+import type { CardPatchRequest } from '@/types/grouping-api';
 
 type ArrangeCardDetailPanelProps = {
   open: boolean;
@@ -28,6 +37,13 @@ type ArrangeCardDetailPanelProps = {
   onSaveMemo?: (memo: string) => void;
   /** 처리필요 카드의 notes 보완 입력 → 저장+재처리(self-heal) 트리거 */
   onResolveByNotes?: (notes: string) => void;
+  /** 처리필요 숙소/교통 카드의 구조화 필드 편집 → 저장(+위치 변경 시 재처리) */
+  onResolveByStructuredEdit?: (args: {
+    payload: CardPatchRequest;
+    locationChanged: boolean;
+  }) => void;
+  /** 기존 location/name 을 notes 로 자동 전송해 AI 재처리 트리거 */
+  onSelectProcess?: () => void;
   /** 재처리 요청~폴링이 진행 중이면 true (확인하기 버튼 로딩/잠금) */
   resolving?: boolean;
   /** 재처리가 실패했거나 시간 내에 끝나지 않은 경우의 안내(재시도 가능) */
@@ -40,6 +56,8 @@ const ArrangeCardDetailPanel = ({
   card,
   onSaveMemo,
   onResolveByNotes,
+  onResolveByStructuredEdit,
+  onSelectProcess,
   resolving = false,
   resolveError = null,
 }: ArrangeCardDetailPanelProps) => {
@@ -53,6 +71,8 @@ const ArrangeCardDetailPanel = ({
           onClose={() => onOpenChange(false)}
           onSaveMemo={onSaveMemo}
           onResolveByNotes={onResolveByNotes}
+          onResolveByStructuredEdit={onResolveByStructuredEdit}
+          onSelectProcess={onSelectProcess}
           resolving={resolving}
           resolveError={resolveError}
         />
@@ -69,6 +89,8 @@ const ArrangeCardDetailBody = ({
   onClose,
   onSaveMemo,
   onResolveByNotes,
+  onResolveByStructuredEdit,
+  onSelectProcess,
   resolving,
   resolveError,
 }: {
@@ -76,24 +98,68 @@ const ArrangeCardDetailBody = ({
   onClose: () => void;
   onSaveMemo?: (memo: string) => void;
   onResolveByNotes?: (notes: string) => void;
+  onResolveByStructuredEdit?: (args: {
+    payload: CardPatchRequest;
+    locationChanged: boolean;
+  }) => void;
+  onSelectProcess?: () => void;
   resolving: boolean;
   resolveError: string | null;
 }) => {
   const detail = card.detail!;
-  // 고정 카드(항공권 등)는 상단 상태 pill 을 파란색(info), 일반 카드는 초록색(done)으로.
   const isFixed = card.draggable === false;
-  // 처리필요 카드(클릭 시 안내가 있는 카드)인지 / 그중 notes 재파싱으로 해결 가능한지.
   const isAttention = card.actionGuide != null;
   const isResolvable = detail.canResolveByNotes === true;
+  const canStructuredEdit = detail.canResolveByStructuredEdit === true;
+  const showConfirmButton = isResolvable || canStructuredEdit;
 
   const initialMemo = detail.memo ?? '';
   const [memo, setMemo] = useState(initialMemo);
   const memoDirty = memo.trim() !== initialMemo.trim();
 
   const [notes, setNotes] = useState(detail.notes ?? '');
-  const canConfirm = notes.trim().length > 0 && !resolving;
+
+  // 구조화 편집 필드 상태 — 숙소/교통 처리필요 카드에서만 의미 있음
+  const sf = detail.structuredFields;
+  const [location, setLocation] = useState(sf?.location ?? '');
+  const [checkIn, setCheckIn] = useState(sf?.checkIn ?? '');
+  const [checkOut, setCheckOut] = useState(sf?.checkOut ?? '');
+  const [timeConstraint, setTimeConstraint] = useState(
+    sf?.timeConstraint ?? ''
+  );
+  const [flightNumber, setFlightNumber] = useState(sf?.flightNumber ?? '');
+
+  const locationChanged = location.trim() !== (sf?.location ?? '').trim();
+  const structuredDirty =
+    locationChanged ||
+    checkIn.trim() !== (sf?.checkIn ?? '').trim() ||
+    checkOut.trim() !== (sf?.checkOut ?? '').trim() ||
+    timeConstraint.trim() !== (sf?.timeConstraint ?? '').trim() ||
+    flightNumber.trim() !== (sf?.flightNumber ?? '').trim();
+
+  const canConfirm =
+    (structuredDirty || (isResolvable && notes.trim().length > 0)) &&
+    !resolving;
 
   const categoryBadge = card.badges?.find((badge) => badge.kind === 'category');
+
+  const handleConfirm = () => {
+    if (structuredDirty) {
+      const payload: CardPatchRequest = {};
+      if (location.trim()) payload.location = location.trim();
+      if (detail.structuredEditCategory === 'accommodation') {
+        if (checkIn.trim()) payload.check_in = checkIn.trim();
+        if (checkOut.trim()) payload.check_out = checkOut.trim();
+      } else if (detail.structuredEditCategory === 'transport') {
+        if (timeConstraint.trim())
+          payload.time_constraint = timeConstraint.trim();
+        if (flightNumber.trim()) payload.flight_number = flightNumber.trim();
+      }
+      onResolveByStructuredEdit?.({ payload, locationChanged });
+    } else if (notes.trim().length > 0) {
+      onResolveByNotes?.(notes.trim());
+    }
+  };
 
   return (
     <>
@@ -176,7 +242,7 @@ const ArrangeCardDetailBody = ({
 
         <Separator />
 
-        {/* 처리필요 카드 안내(인플레이스). 해결 가능/불가 모두 사유를 보여준다. */}
+        {/* 처리필요 카드 안내(인플레이스) */}
         {isAttention && card.actionGuide && (
           <div className="rounded-xl border border-amber-200 bg-amber-50/70 p-4 dark:border-amber-900/50 dark:bg-amber-950/30">
             <p className="flex gap-2 text-sm leading-relaxed whitespace-pre-line text-amber-800 dark:text-amber-200">
@@ -186,21 +252,55 @@ const ArrangeCardDetailBody = ({
           </div>
         )}
 
-        {isResolvable && (
+        {/* 구조화 편집 섹션 (숙소/교통 처리필요 카드) */}
+        {canStructuredEdit && detail.structuredEditCategory && (
           <>
-            <ResolveByNotesField
-              value={notes}
-              onChange={setNotes}
+            <StructuredEditSection
+              category={detail.structuredEditCategory}
+              location={location}
+              onLocationChange={setLocation}
+              checkIn={checkIn}
+              onCheckInChange={setCheckIn}
+              checkOut={checkOut}
+              onCheckOutChange={setCheckOut}
+              timeConstraint={timeConstraint}
+              onTimeConstraintChange={setTimeConstraint}
+              flightNumber={flightNumber}
+              onFlightNumberChange={setFlightNumber}
               disabled={resolving}
-              error={resolveError}
+              canSelectProcess={detail.canSelectProcess}
+              onSelectProcess={onSelectProcess}
             />
             <Separator />
           </>
         )}
+
+        {/* 장소 정보 보완 섹션 (notes 재파싱 가능 카드) */}
+        {isResolvable && (
+          <ResolveByNotesField
+            value={notes}
+            onChange={setNotes}
+            disabled={resolving}
+            conflictWarning={structuredDirty && notes.trim().length > 0}
+          />
+        )}
+
+        {/* 재처리 에러 안내 */}
+        {resolveError && (
+          <div
+            role="alert"
+            className="rounded-xl border border-destructive/30 bg-destructive/10 p-3 text-sm leading-relaxed text-destructive"
+          >
+            {resolveError}
+          </div>
+        )}
+
+        {/* 사용자 메모 — resolvable/구조화 편집 카드에서도 항상 노출(#267) */}
+        {isResolvable && <Separator />}
         <UserMemoField value={memo} onChange={setMemo} />
       </div>
 
-      {/* 푸터 */}
+      {/* 푸터 — 메모 저장은 항상 노출, 확인하기는 해결 가능 카드에만 추가(#267) */}
       <PanelActions>
         <Button
           type="button"
@@ -210,19 +310,19 @@ const ArrangeCardDetailBody = ({
         >
           닫기
         </Button>
-        {isResolvable && (
+        {showConfirmButton && (
           <Button
             type="button"
             className="h-11 flex-1 text-sm font-semibold"
             disabled={!canConfirm}
-            onClick={() => onResolveByNotes?.(notes.trim())}
+            onClick={handleConfirm}
           >
             {resolving ? '재처리 중…' : '확인하기'}
           </Button>
         )}
         <Button
           type="button"
-          variant={isResolvable ? 'outline' : 'default'}
+          variant={showConfirmButton ? 'outline' : 'default'}
           className="h-11 flex-1 text-sm font-semibold"
           disabled={!memoDirty}
           onClick={() => onSaveMemo?.(memo)}
@@ -239,12 +339,12 @@ const ResolveByNotesField = ({
   value,
   onChange,
   disabled,
-  error,
+  conflictWarning,
 }: {
   value: string;
   onChange: (value: string) => void;
   disabled: boolean;
-  error: string | null;
+  conflictWarning?: boolean;
 }) => (
   <section>
     <h3 className="text-sm font-semibold text-foreground">장소 정보 보완</h3>
@@ -260,8 +360,11 @@ const ResolveByNotesField = ({
       rows={3}
       className="mt-3 w-full resize-none rounded-xl border border-input bg-background px-3.5 py-3 text-sm text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none disabled:opacity-60"
     />
-    {error && (
-      <p className="mt-2 text-xs leading-relaxed text-destructive">{error}</p>
+    {conflictWarning && (
+      <p className="mt-2 text-xs leading-relaxed text-amber-700 dark:text-amber-300">
+        구조화 편집 중에는 장소 정보 보완을 함께 전송하지 않아요. 먼저
+        확인하기를 눌러 저장하세요.
+      </p>
     )}
   </section>
 );

--- a/apps/frontend/src/components/grouping/CardDetailParts.tsx
+++ b/apps/frontend/src/components/grouping/CardDetailParts.tsx
@@ -5,6 +5,142 @@ import { type LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
+type StructuredEditSectionProps = {
+  category: 'accommodation' | 'transport';
+  location: string;
+  onLocationChange: (v: string) => void;
+  checkIn: string;
+  onCheckInChange: (v: string) => void;
+  checkOut: string;
+  onCheckOutChange: (v: string) => void;
+  timeConstraint: string;
+  onTimeConstraintChange: (v: string) => void;
+  flightNumber: string;
+  onFlightNumberChange: (v: string) => void;
+  disabled: boolean;
+  canSelectProcess?: boolean;
+  onSelectProcess?: () => void;
+};
+
+const inputCn =
+  'mt-2 w-full resize-none rounded-xl border border-input bg-background px-3.5 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none disabled:opacity-60';
+
+const StructuredField = ({
+  label,
+  value,
+  onChange,
+  placeholder,
+  helper,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+  helper?: string;
+  disabled: boolean;
+}) => (
+  <div>
+    <label className="block text-xs font-medium text-foreground">{label}</label>
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={inputCn}
+    />
+    {helper && (
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+        {helper}
+      </p>
+    )}
+  </div>
+);
+
+export const StructuredEditSection = ({
+  category,
+  location,
+  onLocationChange,
+  checkIn,
+  onCheckInChange,
+  checkOut,
+  onCheckOutChange,
+  timeConstraint,
+  onTimeConstraintChange,
+  flightNumber,
+  onFlightNumberChange,
+  disabled,
+  canSelectProcess,
+  onSelectProcess,
+}: StructuredEditSectionProps) => (
+  <section>
+    <h3 className="text-sm font-semibold text-foreground">구조화 편집</h3>
+    <div className="mt-3 space-y-4">
+      <StructuredField
+        label={category === 'transport' ? '위치/공항' : '위치'}
+        value={location}
+        onChange={onLocationChange}
+        placeholder={
+          category === 'transport'
+            ? '예) 인천국제공항 / 간사이 국제공항'
+            : '예) 오사카 난바 / 난바역 부근'
+        }
+        helper="위치를 바꾸면 AI가 지도 위치를 다시 찾아요"
+        disabled={disabled}
+      />
+      {category === 'accommodation' && (
+        <>
+          <StructuredField
+            label="체크인"
+            value={checkIn}
+            onChange={onCheckInChange}
+            placeholder="예) 2025-08-02 15:00"
+            disabled={disabled}
+          />
+          <StructuredField
+            label="체크아웃"
+            value={checkOut}
+            onChange={onCheckOutChange}
+            placeholder="예) 2025-08-05 11:00"
+            disabled={disabled}
+          />
+        </>
+      )}
+      {category === 'transport' && (
+        <>
+          <StructuredField
+            label="시간"
+            value={timeConstraint}
+            onChange={onTimeConstraintChange}
+            placeholder="예) 오전 10:30 출발"
+            disabled={disabled}
+          />
+          <StructuredField
+            label="편명"
+            value={flightNumber}
+            onChange={onFlightNumberChange}
+            placeholder="예) KE723"
+            disabled={disabled}
+          />
+        </>
+      )}
+    </div>
+    {canSelectProcess && (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-4 w-full text-xs"
+        disabled={disabled}
+        onClick={onSelectProcess}
+      >
+        현재 정보로 처리
+      </Button>
+    )}
+  </section>
+);
+
 const MEMO_HINT =
   '메모는 04 추천 흐름에 조용히 반영되고, 처리 후에는 AI 맥락 내용만 업데이트돼요.';
 

--- a/apps/frontend/src/components/grouping/EditCardDetailPanel.tsx
+++ b/apps/frontend/src/components/grouping/EditCardDetailPanel.tsx
@@ -1,4 +1,7 @@
-// EditCardDetailPanel — "수정이 필요한 카드들"상세보기 사이드 패널
+// EditCardDetailPanel — "수정이 필요한 카드들" 상세보기 사이드 패널
+//
+// 숙소/교통 카드(canResolveByStructuredEdit): 구조화 편집 폼 + 선택처리 버튼 레이아웃
+// 그 외 카드: 기존 질문/입력(QuestionBox + AnswerField) 레이아웃
 
 import { Clock, Info, MapPin, User, X } from 'lucide-react';
 import { Dialog } from 'radix-ui';
@@ -10,12 +13,14 @@ import SidePanel from '@/components/common/SidePanel';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import type { PlaceCardViewModel } from '@/types/grouping';
+import type { CardPatchRequest } from '@/types/grouping-api';
 
 import {
   AnswerField,
   DetailRow,
   QuestionBox,
   StatusInfoBox,
+  StructuredEditSection,
   UserMemoField,
 } from './CardDetailParts';
 import PlaceCardBadge from './PlaceCardBadge';
@@ -23,10 +28,20 @@ import PlaceCardBadge from './PlaceCardBadge';
 type EditCardDetailPanelProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-
   card: PlaceCardViewModel | null;
   onConfirm?: (payload: { answer: string }) => void;
   onSaveMemo?: (memo: string) => void;
+  /** 처리필요 숙소/교통 카드의 구조화 필드 편집 → 저장(+위치 변경 시 재처리) */
+  onResolveByStructuredEdit?: (args: {
+    payload: CardPatchRequest;
+    locationChanged: boolean;
+  }) => void;
+  /** notes 보완 입력 → 저장+재처리 */
+  onResolveByNotes?: (notes: string) => void;
+  /** 기존 location/name 을 notes 로 자동 전송해 AI 재처리 트리거 */
+  onSelectProcess?: () => void;
+  resolving?: boolean;
+  resolveError?: string | null;
 };
 
 const EditCardDetailPanel = ({
@@ -35,6 +50,11 @@ const EditCardDetailPanel = ({
   card,
   onConfirm,
   onSaveMemo,
+  onResolveByStructuredEdit,
+  onResolveByNotes,
+  onSelectProcess,
+  resolving = false,
+  resolveError = null,
 }: EditCardDetailPanelProps) => {
   return (
     <SidePanel open={open} onOpenChange={onOpenChange}>
@@ -46,6 +66,11 @@ const EditCardDetailPanel = ({
           onClose={() => onOpenChange(false)}
           onConfirm={onConfirm}
           onSaveMemo={onSaveMemo}
+          onResolveByStructuredEdit={onResolveByStructuredEdit}
+          onResolveByNotes={onResolveByNotes}
+          onSelectProcess={onSelectProcess}
+          resolving={resolving}
+          resolveError={resolveError}
         />
       ) : null}
     </SidePanel>
@@ -60,17 +85,30 @@ const EditCardDetailBody = ({
   onClose,
   onConfirm,
   onSaveMemo,
+  onResolveByStructuredEdit,
+  onResolveByNotes,
+  onSelectProcess,
+  resolving,
+  resolveError,
 }: {
   card: PlaceCardViewModel;
   onClose: () => void;
   onConfirm?: (payload: { answer: string }) => void;
   onSaveMemo?: (memo: string) => void;
+  onResolveByStructuredEdit?: (args: {
+    payload: CardPatchRequest;
+    locationChanged: boolean;
+  }) => void;
+  onResolveByNotes?: (notes: string) => void;
+  onSelectProcess?: () => void;
+  resolving: boolean;
+  resolveError: string | null;
 }) => {
   const detail = card.editDetail!;
+  const canStructuredEdit = detail.canResolveByStructuredEdit === true;
+  const isResolvable = detail.canResolveByNotes === true;
 
-  //입력 state(패널 로컬)
-
-  // "질문에 대한 답변"(보정 내용)
+  // 질문/답변 패스 (비구조화 카드)
   const [answer, setAnswer] = useState(detail.answer ?? '');
 
   // 사용자 메모
@@ -78,15 +116,62 @@ const EditCardDetailBody = ({
   const [memo, setMemo] = useState(initialMemo);
   const memoDirty = memo.trim() !== initialMemo.trim();
 
-  // "확인하기"
-  const canConfirm = answer.trim().length > 0;
+  // 구조화 편집 필드 상태
+  const sf = detail.structuredFields;
+  const [location, setLocation] = useState(sf?.location ?? '');
+  const [checkIn, setCheckIn] = useState(sf?.checkIn ?? '');
+  const [checkOut, setCheckOut] = useState(sf?.checkOut ?? '');
+  const [timeConstraint, setTimeConstraint] = useState(
+    sf?.timeConstraint ?? ''
+  );
+  const [flightNumber, setFlightNumber] = useState(sf?.flightNumber ?? '');
+
+  const locationChanged = location.trim() !== (sf?.location ?? '').trim();
+  const structuredDirty =
+    locationChanged ||
+    checkIn.trim() !== (sf?.checkIn ?? '').trim() ||
+    checkOut.trim() !== (sf?.checkOut ?? '').trim() ||
+    timeConstraint.trim() !== (sf?.timeConstraint ?? '').trim() ||
+    flightNumber.trim() !== (sf?.flightNumber ?? '').trim();
+
+  // notes 보완 섹션
+  const [notes, setNotes] = useState(detail.notes ?? '');
+
+  // 확인하기 활성 조건
+  const canConfirmStructured =
+    canStructuredEdit &&
+    (structuredDirty || (isResolvable && notes.trim().length > 0)) &&
+    !resolving;
+  const canConfirmAnswer = !canStructuredEdit && answer.trim().length > 0;
+  const canConfirm = canConfirmStructured || canConfirmAnswer;
 
   const moreBadge = card.badges?.find((badge) => badge.kind === 'more');
   const hint = detail.aiHint ?? card.reminder;
-  // "상세 정보"
   const hasDetailRows = Boolean(
     card.region || card.durationLabel || detail.userIntent || hint
   );
+
+  const handleConfirm = () => {
+    if (canStructuredEdit) {
+      if (structuredDirty) {
+        const payload: CardPatchRequest = {};
+        if (location.trim()) payload.location = location.trim();
+        if (detail.structuredEditCategory === 'accommodation') {
+          if (checkIn.trim()) payload.check_in = checkIn.trim();
+          if (checkOut.trim()) payload.check_out = checkOut.trim();
+        } else if (detail.structuredEditCategory === 'transport') {
+          if (timeConstraint.trim())
+            payload.time_constraint = timeConstraint.trim();
+          if (flightNumber.trim()) payload.flight_number = flightNumber.trim();
+        }
+        onResolveByStructuredEdit?.({ payload, locationChanged });
+      } else if (isResolvable && notes.trim().length > 0) {
+        onResolveByNotes?.(notes.trim());
+      }
+    } else {
+      onConfirm?.({ answer: answer.trim() });
+    }
+  };
 
   return (
     <>
@@ -178,51 +263,137 @@ const EditCardDetailBody = ({
 
         <Separator />
 
-        {/* 질문 / 입력 */}
-        <section>
-          <h3 className="text-sm font-semibold text-foreground">질문 / 입력</h3>
-          <QuestionBox question={detail.question} />
-          <AnswerField
-            value={answer}
-            onChange={setAnswer}
-            placeholder="필요한 내용을 자유롭게 입력해주세요..."
-          />
-        </section>
+        {canStructuredEdit && detail.structuredEditCategory ? (
+          // 숙소/교통 카드: 구조화 편집 레이아웃
+          <>
+            <StructuredEditSection
+              category={detail.structuredEditCategory}
+              location={location}
+              onLocationChange={setLocation}
+              checkIn={checkIn}
+              onCheckInChange={setCheckIn}
+              checkOut={checkOut}
+              onCheckOutChange={setCheckOut}
+              timeConstraint={timeConstraint}
+              onTimeConstraintChange={setTimeConstraint}
+              flightNumber={flightNumber}
+              onFlightNumberChange={setFlightNumber}
+              disabled={resolving}
+              canSelectProcess={detail.canSelectProcess}
+              onSelectProcess={onSelectProcess}
+            />
 
-        <Separator />
+            {/* 장소 정보 보완 섹션 */}
+            {isResolvable && (
+              <>
+                <Separator />
+                <section>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    장소 정보 보완
+                  </h3>
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                    장소명이나 주소를 더 정확히 입력하면 AI 가 다시 분석해 지도
+                    위치를 찾아드려요.
+                  </p>
+                  <textarea
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    disabled={resolving}
+                    placeholder="예) 도톤보리 글리코 사인 앞 / 오사카시 추오구 도톤보리 1-10-2"
+                    rows={3}
+                    className="mt-3 w-full resize-none rounded-xl border border-input bg-background px-3.5 py-3 text-sm text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none disabled:opacity-60"
+                  />
+                  {structuredDirty && notes.trim().length > 0 && (
+                    <p className="mt-2 text-xs leading-relaxed text-amber-700 dark:text-amber-300">
+                      구조화 편집 중에는 장소 정보 보완을 함께 전송하지 않아요.
+                      먼저 확인하기를 눌러 저장하세요.
+                    </p>
+                  )}
+                </section>
+              </>
+            )}
 
-        {/* 사용자 메모  */}
-        <UserMemoField value={memo} onChange={setMemo} />
+            {/* 재처리 에러 안내 */}
+            {resolveError && (
+              <div
+                role="alert"
+                className="rounded-xl border border-destructive/30 bg-destructive/10 p-3 text-sm leading-relaxed text-destructive"
+              >
+                {resolveError}
+              </div>
+            )}
+          </>
+        ) : (
+          // 그 외 카드: 기존 질문/입력 레이아웃
+          <>
+            <section>
+              <h3 className="text-sm font-semibold text-foreground">
+                질문 / 입력
+              </h3>
+              <QuestionBox question={detail.question} />
+              <AnswerField
+                value={answer}
+                onChange={setAnswer}
+                placeholder="필요한 내용을 자유롭게 입력해주세요..."
+              />
+            </section>
+
+            <Separator />
+
+            <UserMemoField value={memo} onChange={setMemo} />
+          </>
+        )}
       </div>
 
       {/* 푸터(고정) */}
-      <PanelActions>
-        <Button
-          type="button"
-          variant="outline"
-          className="h-11 flex-1 text-sm"
-          onClick={onClose}
-        >
-          닫기
-        </Button>
-        <Button
-          type="button"
-          className="h-11 flex-1 text-sm font-semibold"
-          disabled={!canConfirm}
-          onClick={() => onConfirm?.({ answer: answer.trim() })}
-        >
-          확인하기
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          className="h-11 flex-1 text-sm font-semibold"
-          disabled={!memoDirty}
-          onClick={() => onSaveMemo?.(memo)}
-        >
-          메모 저장
-        </Button>
-      </PanelActions>
+      {canStructuredEdit ? (
+        <PanelActions>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-11 flex-1 text-sm"
+            onClick={onClose}
+          >
+            닫기
+          </Button>
+          <Button
+            type="button"
+            className="h-11 flex-1 text-sm font-semibold"
+            disabled={!canConfirm}
+            onClick={handleConfirm}
+          >
+            {resolving ? '재처리 중…' : '확인하기'}
+          </Button>
+        </PanelActions>
+      ) : (
+        <PanelActions>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-11 flex-1 text-sm"
+            onClick={onClose}
+          >
+            닫기
+          </Button>
+          <Button
+            type="button"
+            className="h-11 flex-1 text-sm font-semibold"
+            disabled={!canConfirm}
+            onClick={handleConfirm}
+          >
+            확인하기
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-11 flex-1 text-sm font-semibold"
+            disabled={!memoDirty}
+            onClick={() => onSaveMemo?.(memo)}
+          >
+            메모 저장
+          </Button>
+        </PanelActions>
+      )}
     </>
   );
 };

--- a/apps/frontend/src/components/grouping/SelectCardDetailPanel.tsx
+++ b/apps/frontend/src/components/grouping/SelectCardDetailPanel.tsx
@@ -93,7 +93,7 @@ const SelectCardDetailBody = ({
   const [memo, setMemo] = useState(initialMemo);
   const memoDirty = memo.trim() !== initialMemo.trim();
 
-  const canConfirm = selectedChoices.length > 0 || answer.trim().length > 0;
+  const canConfirm = true;
 
   // 단일 선택 — 카드 1장 = 장소 1개이므로 하나만 유지. 같은 칩을 다시 누르면 해제.
   const toggleChoice = (choice: string) =>

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -37,6 +37,7 @@ import type {
   ScheduledCardViewModel,
 } from '@/types/arrange';
 import type { RouteWarning } from '@/types/arrange-api';
+import type { CardPatchRequest } from '@/types/grouping-api';
 import type { ArrangeDragPayload } from '@/utils/arrange-dnd';
 
 import { fetchGroups04 } from '../utils/arrange-api';
@@ -464,27 +465,9 @@ const ArrangePage = () => {
     };
   };
 
-  // 처리필요 카드 해결 — 자연어(notes) 보완 입력으로 카드 레벨 AI 재파싱을 트리거하고,
-  // 재처리(processing)가 끝날 때까지 폴링한 뒤 결과를 좌측 목록에 반영한다.
-  // 성공(배치 가능 승격) → 패널 닫기 / 미해결·타임아웃 → 패널 유지(재시도 가능).
-  const handleResolveByNotes = async (notes: string) => {
-    if (!tripId || !detailCard) return;
-    const instanceId = detailCard.id;
-    setResolveError(null);
-    setResolving(true);
-    resolvePollRef.current?.();
-
-    try {
-      await patchCardMutation.mutateAsync({
-        instanceId,
-        payload: { notes },
-      });
-    } catch (error) {
-      setResolving(false);
-      setResolveError(errorMessageOf(error, '재처리 요청에 실패했습니다.'));
-      return;
-    }
-
+  // 재처리 폴링 공통 로직: patchCard 완료 후 instanceId 카드가 processing 을 벗어날 때까지
+  // 2 초 간격으로 /cards 를 조회하고, 승격(unavailable 이탈) 여부에 따라 패널을 닫거나 재시도 안내를 띄운다.
+  const startResolvePoll = (instanceId: string) => {
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     resolvePollRef.current = () => {
@@ -493,7 +476,6 @@ const ArrangePage = () => {
     };
     const startedAt = Date.now();
 
-    // 폴링 종료 처리: 좌측 목록을 갱신하고, 승격 여부에 따라 패널을 닫거나 재시도 안내를 띄운다.
     const settle = async (timedOut: boolean) => {
       const result = await refreshLeftGroupsPreservingBoard().catch(() => null);
       if (cancelled) return;
@@ -501,11 +483,9 @@ const ArrangePage = () => {
       const promoted = result != null && !result.unavailableIds.has(instanceId);
       if (promoted) {
         setNotice('카드가 배치 가능 목록으로 이동했어요.');
-        // 패널이 아직 이 카드를 보여주는 중일 때만 닫는다.
         if (detailCardIdRef.current === instanceId) setDetailOpen(false);
         return;
       }
-      // 아직 해결 안 됨 — 패널을 열어둔 채 최신 카드 상태로 갱신해 다시 시도할 수 있게 한다.
       if (detailCardIdRef.current === instanceId) {
         const refreshed = result?.groups
           .flatMap((group) => group.cards)
@@ -514,7 +494,7 @@ const ArrangePage = () => {
         setResolveError(
           timedOut
             ? '재처리가 시간 내에 끝나지 않았어요. 잠시 후 다시 시도해 주세요.'
-            : '아직 배치할 수 없어요. 장소명·주소를 더 정확히 입력해 다시 시도해 주세요.'
+            : '현재 정보로는 위치를 찾지 못했어요. 장소명이나 주소를 더 정확히 입력해 주세요.'
         );
       }
     };
@@ -522,7 +502,7 @@ const ArrangePage = () => {
     const tick = async () => {
       if (cancelled) return;
       try {
-        const cardsRes = await fetchCards(tripId);
+        const cardsRes = await fetchCards(tripId!);
         if (cancelled) return;
         const card = cardsRes.cards.find((c) => c.instance_id === instanceId);
         const done = !card || card.processing_status !== 'processing';
@@ -534,6 +514,76 @@ const ArrangePage = () => {
       if (!cancelled) timer = setTimeout(tick, POLL_INTERVAL_MS);
     };
     timer = setTimeout(tick, POLL_INTERVAL_MS);
+  };
+
+  // 처리필요 카드 해결 — 자연어(notes) 보완 입력으로 AI 재파싱 트리거.
+  const handleResolveByNotes = async (notes: string) => {
+    if (!tripId || !detailCard) return;
+    const instanceId = detailCard.id;
+    setResolveError(null);
+    setResolving(true);
+    resolvePollRef.current?.();
+    try {
+      await patchCardMutation.mutateAsync({ instanceId, payload: { notes } });
+    } catch (error) {
+      setResolving(false);
+      setResolveError(errorMessageOf(error, '재처리 요청에 실패했습니다.'));
+      return;
+    }
+    startResolvePoll(instanceId);
+  };
+
+  // 처리필요 숙소/교통 카드의 구조화 필드 편집.
+  // 위치 변경 시 → 재처리 트리거 + 폴링. 비위치 필드만 → 즉시 저장 후 갱신.
+  const handleResolveByStructuredEdit = async ({
+    payload,
+    locationChanged,
+  }: {
+    payload: CardPatchRequest;
+    locationChanged: boolean;
+  }) => {
+    if (!tripId || !detailCard) return;
+    const instanceId = detailCard.id;
+    setResolveError(null);
+    setResolving(true);
+    resolvePollRef.current?.();
+    try {
+      await patchCardMutation.mutateAsync({ instanceId, payload });
+    } catch (error) {
+      setResolving(false);
+      setResolveError(errorMessageOf(error, '저장에 실패했습니다.'));
+      return;
+    }
+    if (!locationChanged) {
+      // 비위치 필드만 변경 → 폴링 없이 즉시 갱신
+      setResolving(false);
+      await refreshLeftGroupsPreservingBoard();
+      if (detailCardIdRef.current === instanceId) setDetailOpen(false);
+      return;
+    }
+    startResolvePoll(instanceId);
+  };
+
+  // 선택처리 — 기존 location 또는 name 을 notes 로 자동 전송해 AI 재파싱 트리거.
+  const handleSelectProcess = async () => {
+    if (!tripId || !detailCard) return;
+    const autoNotes = detailCard.detail?.selectProcessNotes;
+    if (!autoNotes) return;
+    const instanceId = detailCard.id;
+    setResolveError(null);
+    setResolving(true);
+    resolvePollRef.current?.();
+    try {
+      await patchCardMutation.mutateAsync({
+        instanceId,
+        payload: { notes: autoNotes },
+      });
+    } catch (error) {
+      setResolving(false);
+      setResolveError(errorMessageOf(error, '재처리 요청에 실패했습니다.'));
+      return;
+    }
+    startResolvePoll(instanceId);
   };
 
   // 정리 반영 — POST /groups/reorder. "재정렬이 필요한 카드"를 클러스터로 재편입한 뒤
@@ -835,6 +885,8 @@ const ArrangePage = () => {
         card={detailCard}
         onSaveMemo={handleSaveMemo}
         onResolveByNotes={handleResolveByNotes}
+        onResolveByStructuredEdit={handleResolveByStructuredEdit}
+        onSelectProcess={handleSelectProcess}
         resolving={resolving}
         resolveError={resolveError}
       />

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -104,6 +104,7 @@ const ArrangePage = () => {
   const storeTripId = useOnboardingStore((s) => s.tripId);
   const setStoreTripId = useOnboardingStore((s) => s.actions.setTripId);
   const form = useOnboardingStore((s) => s.form);
+  const navigate = useNavigate();
   const { type: calendarType, exactDate, flexDate } = useCalendarStore();
   const tripId: string | null = urlTripId ?? storeTripId;
 
@@ -675,9 +676,9 @@ const ArrangePage = () => {
         ...buildMissingLocationWarnings(),
       ]);
       setConfirmed(true);
-      setNotice('일정이 확정되었습니다.');
-      // 확정 성공 → SCR-05(확정 전 최종 점검) 화면으로 이동.
-      navigate(`/confirm${tripId ? `?tripId=${tripId}` : ''}`);
+      navigate(`/confirm${tripId ? `?tripId=${tripId}` : ''}`, {
+        state: { notice: '일정이 확정되었습니다.' },
+      });
     } catch (error) {
       setActionError(errorMessageOf(error, '일정 확정에 실패했습니다.'));
     }

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -104,7 +104,6 @@ const ArrangePage = () => {
   const storeTripId = useOnboardingStore((s) => s.tripId);
   const setStoreTripId = useOnboardingStore((s) => s.actions.setTripId);
   const form = useOnboardingStore((s) => s.form);
-  const navigate = useNavigate();
   const { type: calendarType, exactDate, flexDate } = useCalendarStore();
   const tripId: string | null = urlTripId ?? storeTripId;
 

--- a/apps/frontend/src/pages/ConfirmPage.tsx
+++ b/apps/frontend/src/pages/ConfirmPage.tsx
@@ -3,7 +3,7 @@
 // tripId 는 URL(?tripId=) → 온보딩 스토어 순으로 취득(진입 가드는 RequireTrip 위임).
 
 import { useMemo, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import AlertCardList from '@/components/confirm/AlertCardList';
 import ContextCardList from '@/components/confirm/ContextCardList';
@@ -25,7 +25,11 @@ import { useOnboardingStore } from '@/utils/onboarding-store';
 
 const ConfirmPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
+  const [notice, setNotice] = useState<string | null>(
+    (location.state as { notice?: string } | null)?.notice ?? null
+  );
   const urlTripId = searchParams.get('tripId');
   const storeTripId = useOnboardingStore((s) => s.tripId);
   const form = useOnboardingStore((s) => s.form);
@@ -140,6 +144,20 @@ const ConfirmPage = () => {
           </div>
         }
       />
+
+      {notice && (
+        <div className="flex items-center justify-between border-b border-primary/20 bg-primary/5 px-8 py-3 text-sm text-primary">
+          <span>{notice}</span>
+          <button
+            type="button"
+            aria-label="닫기"
+            className="ml-4 text-primary/60 hover:text-primary"
+            onClick={() => setNotice(null)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       <main className="grid flex-1 grid-cols-[300px_minmax(0,1fr)]">
         <aside className="flex flex-col gap-6 border-r border-border bg-card px-8 py-10">

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -562,11 +562,12 @@ const GroupingPage = () => {
     if (!card || !tripId) return Promise.resolve(false);
     // 선택 칩 + 답변을 한 덩어리 자연어(notes)로 합쳐 보낸다.
     // 백엔드는 undecided 카드의 notes 입력을 카드 레벨 AI 재파싱으로 처리한다.
-    const notes = [...payload.choices, payload.answer]
-      .map((value) => value.trim())
-      .filter(Boolean)
-      .join(', ');
-    if (!notes) return Promise.resolve(false);
+    // 입력이 없으면 카드명을 fallback으로 전송해 AI가 최소 컨텍스트로 재파싱할 수 있게 한다.
+    const notes =
+      [...payload.choices, payload.answer]
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .join(', ') || card.name;
     return runCardMutation(
       () => patchCard(tripId, card.id, { notes }),
       '확인 처리에 실패했습니다.'

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -28,6 +28,7 @@ import type {
 } from '@/types/grouping';
 import type { Card, Groups03Response } from '@/types/grouping-api';
 
+import type { CardPatchRequest } from '../types/grouping-api';
 import {
   useCalendarStore,
   formatDateRangeLabel,
@@ -193,6 +194,18 @@ const GroupingPage = () => {
   const [editOpen, setEditOpen] = useState(false);
   const [addCardOpen, setAddCardOpen] = useState(false);
 
+  // EditCardDetailPanel 구조화 편집/선택처리 전용 상태
+  const [editResolving, setEditResolving] = useState(false);
+  const [editResolveError, setEditResolveError] = useState<string | null>(null);
+  const editPollRef = useRef<(() => void) | null>(null);
+
+  // editCard 가 바뀔 때 이전 폴링 취소 + 에러 초기화
+  useEffect(() => {
+    editPollRef.current?.();
+    setEditResolving(false);
+    setEditResolveError(null);
+  }, [editCard?.id]);
+
   const refresh = useCallback(
     async (signal?: AbortSignal): Promise<void> => {
       if (!tripId) return;
@@ -256,6 +269,167 @@ const GroupingPage = () => {
 
   // tripId 변경/언마운트 시 진행 중 폴링 정리
   useEffect(() => () => pollCancelRef.current?.(), [tripId]);
+  useEffect(() => () => editPollRef.current?.(), [tripId]);
+
+  // EditCardDetailPanel 구조화 편집용 폴링: 처리 완료 시 결과 피드백
+  const startEditResolvePoll = useCallback(
+    (instanceId: string) => {
+      if (!tripId) return;
+      editPollRef.current?.();
+
+      let cancelled = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      editPollRef.current = () => {
+        cancelled = true;
+        if (timer) clearTimeout(timer);
+      };
+      const startedAt = Date.now();
+
+      const settle = async (timedOut: boolean) => {
+        try {
+          const [groupsRes, cardsRes] = await Promise.all([
+            fetchGroups03(tripId),
+            fetchCards(tripId),
+          ]);
+          if (cancelled) return;
+          dispatch({
+            type: 'REFRESH_SUCCESS',
+            groups: groupsRes,
+            contextSummary: cardsRes.context_summary,
+          });
+          const stillProblem = groupsRes.fix_required.some(
+            (c) => c.instance_id === instanceId
+          );
+          setEditResolving(false);
+          if (!stillProblem) {
+            setEditOpen(false);
+          } else {
+            setEditResolveError(
+              timedOut
+                ? '재처리가 시간 내에 끝나지 않았어요. 잠시 후 다시 시도해 주세요.'
+                : '현재 정보로는 위치를 찾지 못했어요. 장소명이나 주소를 더 정확히 입력해 주세요.'
+            );
+          }
+        } catch {
+          if (!cancelled) {
+            setEditResolving(false);
+            setEditResolveError(
+              '재처리 결과를 확인하지 못했어요. 새로고침을 시도해 주세요.'
+            );
+          }
+        }
+      };
+
+      const tick = async () => {
+        if (cancelled) return;
+        try {
+          const [groupsRes, cardsRes] = await Promise.all([
+            fetchGroups03(tripId),
+            fetchCards(tripId),
+          ]);
+          if (cancelled) return;
+          dispatch({
+            type: 'REFRESH_SUCCESS',
+            groups: groupsRes,
+            contextSummary: cardsRes.context_summary,
+          });
+          const card = cardsRes.cards.find((c) => c.instance_id === instanceId);
+          if (!card || card.processing_status !== 'processing')
+            return settle(false);
+        } catch {
+          // 일시적 실패는 다음 tick 에서 재시도
+        }
+        if (Date.now() - startedAt > POLL_TIMEOUT_MS) return settle(true);
+        if (!cancelled) timer = setTimeout(tick, POLL_INTERVAL_MS);
+      };
+
+      timer = setTimeout(tick, POLL_INTERVAL_MS);
+    },
+    [tripId]
+  );
+
+  // 처리필요 숙소/교통 카드의 구조화 필드 편집 저장
+  const handleResolveByStructuredEdit = useCallback(
+    async ({
+      payload,
+      locationChanged,
+    }: {
+      payload: CardPatchRequest;
+      locationChanged: boolean;
+    }) => {
+      if (!tripId || !editCard || editResolving) return;
+      const instanceId = editCard.id;
+      setEditResolveError(null);
+      setEditResolving(true);
+      try {
+        await patchCard(tripId, instanceId, payload);
+      } catch (error) {
+        setEditResolving(false);
+        setEditResolveError(errorMessageOf(error, '저장에 실패했습니다.'));
+        return;
+      }
+      if (!locationChanged) {
+        // 비위치 필드만 → 즉시 갱신, 폴링 없음
+        try {
+          const [groupsRes, cardsRes] = await Promise.all([
+            fetchGroups03(tripId),
+            fetchCards(tripId),
+          ]);
+          dispatch({
+            type: 'REFRESH_SUCCESS',
+            groups: groupsRes,
+            contextSummary: cardsRes.context_summary,
+          });
+        } catch {
+          /* 실패 시 무시 */
+        }
+        setEditResolving(false);
+        setEditOpen(false);
+        return;
+      }
+      startEditResolvePoll(instanceId);
+    },
+    [tripId, editCard, editResolving, startEditResolvePoll]
+  );
+
+  // notes 보완 입력 → AI 재파싱 트리거 (EditCardDetailPanel 에서 직접 notes 입력 시)
+  const handleResolveByNotesEdit = useCallback(
+    async (notes: string) => {
+      if (!tripId || !editCard || editResolving) return;
+      const instanceId = editCard.id;
+      setEditResolveError(null);
+      setEditResolving(true);
+      try {
+        await patchCard(tripId, instanceId, { notes });
+      } catch (error) {
+        setEditResolving(false);
+        setEditResolveError(
+          errorMessageOf(error, '재처리 요청에 실패했습니다.')
+        );
+        return;
+      }
+      startEditResolvePoll(instanceId);
+    },
+    [tripId, editCard, editResolving, startEditResolvePoll]
+  );
+
+  // 선택처리 — 기존 location/name 을 notes 로 자동 전송
+  const handleSelectProcessEdit = useCallback(async () => {
+    if (!tripId || !editCard || editResolving) return;
+    const autoNotes = editCard.editDetail?.selectProcessNotes;
+    if (!autoNotes) return;
+    const instanceId = editCard.id;
+    setEditResolveError(null);
+    setEditResolving(true);
+    try {
+      await patchCard(tripId, instanceId, { notes: autoNotes });
+    } catch (error) {
+      setEditResolving(false);
+      setEditResolveError(errorMessageOf(error, '재처리 요청에 실패했습니다.'));
+      return;
+    }
+    startEditResolvePoll(instanceId);
+  }, [tripId, editCard, editResolving, startEditResolvePoll]);
 
   // 초기 로딩 / tripId 변경 시 재로딩
   useEffect(() => {
@@ -597,16 +771,22 @@ const GroupingPage = () => {
         onOpenChange={setEditOpen}
         card={editCard}
         onConfirm={(payload) => {
-          // 수정 재처리 전용 API는 아직 미구현. 연결되면 별도 mutation으로 교체 예정.
-          console.log('[GroupingPage] edit payload (미구현)', payload);
-          dispatch({
-            type: 'BUSY_FAIL',
-            message: '수정 재처리 API는 아직 연결되지 않았습니다.',
-          });
+          // 비구조화(질문/입력) 카드 경로 — notes로 전송
+          const notes = payload.answer.trim();
+          if (!notes || !tripId || !editCard) return;
+          runCardMutation(
+            () => patchCard(tripId, editCard.id, { notes }),
+            '확인 처리에 실패했습니다.'
+          );
         }}
         onSaveMemo={async (memo) => {
           await handleSaveMemo(editCard, memo);
         }}
+        onResolveByStructuredEdit={handleResolveByStructuredEdit}
+        onResolveByNotes={handleResolveByNotesEdit}
+        onSelectProcess={handleSelectProcessEdit}
+        resolving={editResolving}
+        resolveError={editResolveError}
       />
 
       <AddCardModal

--- a/apps/frontend/src/types/arrange.ts
+++ b/apps/frontend/src/types/arrange.ts
@@ -66,6 +66,25 @@ export type ArrangeCardDetailViewModel = {
    * 처리 필요(unavailable) 카드에만 true 일 수 있고, 그 외에는 undefined/false.
    */
   canResolveByNotes?: boolean;
+  /** 구조화 필드 편집으로 해결 가능한 처리필요 카드 여부. 숙소/교통 unavailable 카드에만 true. */
+  canResolveByStructuredEdit?: boolean;
+  /** 카테고리별 구조화 편집 폼 렌더링 결정용. canResolveByStructuredEdit === true 인 카드에만 채워진다. */
+  structuredEditCategory?: 'accommodation' | 'transport';
+  /** 구조화 편집 초기값. 숙소/교통 카드의 현재 저장된 필드값. */
+  structuredFields?: {
+    location?: string;
+    checkIn?: string;
+    checkOut?: string;
+    timeConstraint?: string;
+    flightNumber?: string;
+  };
+  /**
+   * 텍스트 입력 없이 선택처리 가능 여부.
+   * canResolveByNotes === true && (location != null || name != null).
+   */
+  canSelectProcess?: boolean;
+  /** 선택처리 시 notes 로 자동 전송할 텍스트. card.location ?? card.name 우선순위. */
+  selectProcessNotes?: string;
 };
 
 /** 좌측 카드 그룹 한 덩어리(항공권 / 숙소 / 지역 그룹 등). */

--- a/apps/frontend/src/types/grouping.ts
+++ b/apps/frontend/src/types/grouping.ts
@@ -229,6 +229,29 @@ export type EditCardDetailViewModel = {
   answer?: string;
   /** "사용자 메모" textarea 초기값. 보통 ''. 입력값이 이 값과 달라지면 "메모 저장"이 활성화된다 */
   memo?: string;
+  /** notes 보완 입력 초기값(장소 정보 보완 섹션). 구조화 편집과 분리된 notes 경로에 쓰인다. */
+  notes?: string;
+  /** 구조화 편집 초기값. 숙소/교통 edit 카드의 현재 저장된 필드값. */
+  structuredFields?: {
+    location?: string;
+    checkIn?: string;
+    checkOut?: string;
+    timeConstraint?: string;
+    flightNumber?: string;
+  };
+  /** 카테고리별 구조화 편집 폼 렌더링 결정용. */
+  structuredEditCategory?: 'accommodation' | 'transport';
+  /** 구조화 필드 편집으로 해결 가능한 처리필요 카드 여부. 숙소/교통 fix_required 카드에만 true. */
+  canResolveByStructuredEdit?: boolean;
+  /** notes 보완 입력으로 AI 재파싱 가능 여부(BE canStartNaturalLanguageParsingFromNotes 미러링). */
+  canResolveByNotes?: boolean;
+  /**
+   * 텍스트 입력 없이 선택처리 가능 여부.
+   * canResolveByNotes === true && (location != null || name != null).
+   */
+  canSelectProcess?: boolean;
+  /** 선택처리 시 notes 로 자동 전송할 텍스트. */
+  selectProcessNotes?: string;
 };
 
 /** "해야 할 액션" 버킷 1개(헤더 + 그 안의 카드들). */

--- a/apps/frontend/src/utils/arrange-mapper.ts
+++ b/apps/frontend/src/utils/arrange-mapper.ts
@@ -229,6 +229,24 @@ const cardToDetail = (card: Card): ArrangeCardDetailViewModel => ({
   aiHint: card.tips ?? card.blocked_reason ?? undefined,
   memo: card.memo ?? '',
   notes: card.notes ?? '',
+  structuredFields:
+    card.category === 'accommodation' || card.category === 'transport'
+      ? {
+          location: card.location ?? undefined,
+          checkIn: card.check_in ?? undefined,
+          checkOut: card.check_out ?? undefined,
+          timeConstraint: card.time_constraint ?? undefined,
+          flightNumber: card.flight_number ?? undefined,
+        }
+      : undefined,
+  structuredEditCategory:
+    card.category === 'accommodation'
+      ? 'accommodation'
+      : card.category === 'transport'
+        ? 'transport'
+        : undefined,
+  canSelectProcess: canResolveByNotes(card) && !!(card.location ?? card.name),
+  selectProcessNotes: card.location ?? card.name ?? undefined,
 });
 
 /** 좌측 목록의 배치 가능 카드(드래그 가능). add 응답 등에서도 재사용한다. */
@@ -270,7 +288,13 @@ const cardToAttentionCard = (
     // 처리필요 카드만 notes 재파싱(self-heal) 가능 플래그를 채운다. 제외 카드는 해결 대상이 아니다.
     detail:
       kind === 'unavailable'
-        ? { ...cardToDetail(card), canResolveByNotes: canResolveByNotes(card) }
+        ? {
+            ...cardToDetail(card),
+            canResolveByNotes: canResolveByNotes(card),
+            canResolveByStructuredEdit:
+              card.category === 'accommodation' ||
+              card.category === 'transport',
+          }
         : cardToDetail(card),
     // 제외 카드는 의도적으로 뺀 항목이므로 안내하지 않는다.
     actionGuide: kind === 'unavailable' ? attentionGuide(card) : undefined,

--- a/apps/frontend/src/utils/grouping-mapper.ts
+++ b/apps/frontend/src/utils/grouping-mapper.ts
@@ -127,28 +127,57 @@ const toSelectCard = (card: Card): PlaceCardViewModel => ({
   },
 });
 
-const toEditCard = (card: Card): PlaceCardViewModel => ({
-  id: card.instance_id,
-  name: card.name,
-  region: card.location ?? undefined,
-  durationLabel: formatDuration(card.estimated_duration_min),
-  processing: card.processing_status === 'processing',
-  accent: accentFor('edit'),
-  badges: buildBadges(card, 'edit'),
-  reminder: reminderFor(card),
-  editDetail: {
-    classification:
-      CLASSIFICATION_LABEL[card.classification] ?? card.classification,
-    placementStatus: card.placement_status,
-    userIntent: card.user_context ?? undefined,
-    aiHint: card.tips ?? undefined,
-    reason: card.blocked_reason ?? '처리에 실패했어요',
-    retryNotice: '아래에 올바른 정보를 입력해주시면 다시 처리를 시도합니다',
-    question: card.question_text ?? '정확한 정보를 입력해주세요',
-    answer: '',
-    memo: card.memo ?? '',
-  },
-});
+const canResolveByNotesCheck = (card: Card): boolean =>
+  (card.classification === 'undecided' &&
+    (card.placement_status === 'needs_input' ||
+      card.placement_status === 'ready_partial')) ||
+  (card.processing_status === 'failed' &&
+    card.classification !== 'open_question');
+
+const toEditCard = (card: Card): PlaceCardViewModel => {
+  const resolvable = canResolveByNotesCheck(card);
+  const isStructuredCategory =
+    card.category === 'accommodation' || card.category === 'transport';
+  return {
+    id: card.instance_id,
+    name: card.name,
+    region: card.location ?? undefined,
+    durationLabel: formatDuration(card.estimated_duration_min),
+    processing: card.processing_status === 'processing',
+    accent: accentFor('edit'),
+    badges: buildBadges(card, 'edit'),
+    reminder: reminderFor(card),
+    editDetail: {
+      classification:
+        CLASSIFICATION_LABEL[card.classification] ?? card.classification,
+      placementStatus: card.placement_status,
+      userIntent: card.user_context ?? undefined,
+      aiHint: card.tips ?? undefined,
+      reason: card.blocked_reason ?? '처리에 실패했어요',
+      retryNotice: '아래에 올바른 정보를 입력해주시면 다시 처리를 시도합니다',
+      question: card.question_text ?? '정확한 정보를 입력해주세요',
+      answer: '',
+      memo: card.memo ?? '',
+      notes: card.notes ?? '',
+      structuredFields: isStructuredCategory
+        ? {
+            location: card.location ?? undefined,
+            checkIn: card.check_in ?? undefined,
+            checkOut: card.check_out ?? undefined,
+            timeConstraint: card.time_constraint ?? undefined,
+            flightNumber: card.flight_number ?? undefined,
+          }
+        : undefined,
+      structuredEditCategory: isStructuredCategory
+        ? (card.category as 'accommodation' | 'transport')
+        : undefined,
+      canResolveByStructuredEdit: isStructuredCategory,
+      canResolveByNotes: resolvable,
+      canSelectProcess: resolvable && !!(card.location ?? card.name),
+      selectProcessNotes: card.location ?? card.name ?? undefined,
+    },
+  };
+};
 
 const toUnassignedCard = (card: Card): PlaceCardViewModel => ({
   id: card.instance_id,


### PR DESCRIPTION

## 🎯 작업 내용 (FE)

배치(SCR-04)/정리(SCR-03)에서 숙소·항공·교통 처리필요 카드를 구조화 필드 편집으로 인플레이스 해결한다.  
위치를 보완·수정하면 재처리되어 배치 가능으로 승격되고, 위치 외 필드만 손보면 값만 저장됨.

- 숙소: `location` / `check_in` / `check_out`
- 항공·교통: `location`(공항) / `time_constraint`(시간) / `flight_number`(편명)

Phase 1과 달리 구조화 편집 UI는 정리·배치 양쪽 모두 미존재. FE 신규 구축 필요.

---

## 🔁 재현/배경

- 처리필요(좌표없음/needs_input/failed) 숙소·항공·교통 카드가 있는 trip
- Phase 1은 notes 자연어 경로만 연동 → 구조화 필드(위치/체크인/시간 등)로는 해결 불가
- 정리 화면 EditCardDetailPanel은 저장 시 alert만 띄우는 스텁 → 구조화 편집이 어디에서도 동작하지 않음

---

## 🤔 예상 동작

1. 처리필요 숙소·교통 카드 클릭 → 구조화 편집 폼(카테고리별 필드)이 열린다.
2. 위치(공항) 변경 후 저장 → processing → 폴링(2초/30초) → 좌표 생기면 배치 가능 승격. 실패 시 재시도 가능.
3. 위치 외 필드만(체크인/시간/편명) 변경 후 저장 → 값만 저장, 재처리/폴링 없이 즉시 반영.
4. **[신규] 선택처리**: 필드를 아무것도 입력하지 않아도, 카드에 이미 기존 location 또는 name 텍스트가 있으면 "현재 정보로 처리" 버튼으로 재처리 트리거 가능. 사용자 텍스트 입력 없이 AI 재처리 발동.
5. 구조화 편집과 notes 보완은 분리된 액션으로 제공(한 PATCH에 섞지 않음).

---

## ✨ 신규: 선택처리 (텍스트 입력 없이 카드 처리)

### 개요

카드에 이미 `location` 또는 카드명(`name`)이 존재하는 경우, 사용자가 텍스트를 새로 입력하지 않아도 FE가 기존 값을 `notes`로 자동 전송하여 AI 재처리를 트리거한다.

### 동작 원리 (BE API 분석 기반)

```
card.location = "오사카 도톤보리 호텔"  (BE에 저장된 값)
card.coordinates = null  (좌표 없음 → 처리필요 상태)

[선택처리 클릭]
FE → PATCH { notes: "오사카 도톤보리 호텔" }

BE: notesInput = "오사카 도톤보리 호텔"  (null 아님)
    canStartNaturalLanguageParsingFromNotes() = true  (undecided + needs_input)
    → AI 재파싱 트리거 → 폴링 → 좌표 확보 시 배치 가능 승격
```

> **핵심**: `location` 필드와 `notes` 필드는 BE에서 독립적으로 처리된다.
> `applyAccommodationEdit`는 location 변경 여부로 재처리 여부를 판단하므로 동일 location 재전송은 재처리를 트리거하지 않는다.
> 반면 `notes` 필드는 값이 있으면 (`trimToNull != null`) `canStartNaturalLanguageParsingFromNotes()` 조건에 따라 독립적으로 재처리를 트리거한다.

### 선택처리 활성 조건 (FE)

```typescript
// canResolveByNotes 조건과 동일 + 기존 텍스트 원천 필요
const canSelectProcess = (card: Card): boolean =>
  canResolveByNotes(card) &&          // BE notes 재파싱 가능 상태
  (card.location != null || card.name != null);  // notes로 보낼 원천 텍스트 존재
```

notes 원천 우선순위: `card.location` → `card.name`

### UX 규칙

- "현재 정보로 처리" 버튼은 구조화 편집 폼과 함께 노출 (별도 섹션 또는 보조 버튼).
- 클릭 시 BE에 `{ notes: card.location ?? card.name }` 전송 → Phase 1과 동일한 재처리 로딩/폴링/승격 흐름.
- 실패 시 안내: "현재 정보로는 위치를 찾지 못했어요. 장소명이나 주소를 더 정확히 입력해 주세요." → 구조화 편집으로 유도.
- 성공 시: 패널 닫기 + "카드가 배치 가능 목록으로 이동했어요." 노티스.

### 제한 사항

- 선택처리는 AI 재처리를 트리거하는 것으로 성공 보장 없음. 이미 동일 텍스트로 실패한 경우 재시도도 실패할 수 있음.
- 카드에 `location`도 `name`도 없는 경우(드문 케이스) 버튼 비활성.
- 선택처리와 구조화 편집 저장은 동시 실행 불가(진행 중 상태 잠금 동일하게 적용).

---

## 🗂️ 예상 변경 범위 (FE)

### 1. 공통 입력 폼 컴포넌트 신규

`components/grouping/CardDetailParts.tsx`에 `StructuredEditField`(가칭) 추가.  
기존 `UserMemoField`/`AnswerField`와 같은 레이어. label + 자유 텍스트 input/textarea 조합의 재사용 부품.

**카테고리별 필드 구성:**

| 카테고리 | 필드 | placeholder 예시 |
|---|---|---|
| 숙소(accommodation) | 위치(location) | 예) 오사카 난바 / 난바역 부근 |
| 숙소(accommodation) | 체크인(check_in) | 예) 2025-08-02 15:00 |
| 숙소(accommodation) | 체크아웃(check_out) | 예) 2025-08-05 11:00 |
| 항공·교통(transport) | 위치/공항(location) | 예) 인천국제공항 / 간사이 국제공항 |
| 항공·교통(transport) | 시간(time_constraint) | 예) 오전 10:30 출발 |
| 항공·교통(transport) | 편명(flight_number) | 예) KE723 |

- 위치 필드 아래 helper text: "위치를 바꾸면 AI가 지도 위치를 다시 찾아요"
- 입력은 자유 텍스트(검증·picker 불필요)

### 2. 패널 통합 — ArrangeCardDetailPanel(SCR-04)

현재 `isResolvable`일 때 `ResolveByNotesField`, 아닌 경우 `UserMemoField` 2분기.  
여기에 구조화 편집 섹션과 선택처리 버튼을 추가한다.

**처리필요 숙소·교통 카드 패널 구조:**

```
[처리필요 안내 callout]
─────────────────────
[구조화 편집 섹션]   ← Phase 2 신규
  - 카테고리별 필드 (StructuredEditField)
  - [현재 정보로 처리] 버튼  ← 선택처리 신규
─────────────────────
[장소 정보 보완 섹션]  ← Phase 1 notes 경로 (canResolveByNotes 시)
─────────────────────
[확인하기] 버튼 / 재처리 로딩 / 에러 callout
```

**푸터 "확인하기" 분기:**
- 구조화 편집 변경 시 → 구조화 PATCH
- notes만 변경 시 → notes PATCH
- 동시 변경 시 → 구조화 편집 우선(한 번에 하나)
- 선택처리 → notes PATCH (기존 location/name 자동 전송)

재처리 로딩(`resolving`)·실패 callout(`resolveError`)·재시도는 Phase 1과 공유.

### 3. 패널 통합 — EditCardDetailPanel(SCR-03, 스텁 해소)

현재 "질문/입력"(AnswerField) + 저장 시 alert 스텁(`GroupingPage.tsx:573-577`)을 **구조화 편집 폼 + 실제 patchCard**로 교체.  
배치 화면과 동일한 `StructuredEditField` 폼 재사용.

`onConfirm`/`onSaveMemo` 외에 `onResolveByStructuredEdit`(가칭) 콜백 추가.  
`GroupingPage`에서 `patchCard` + (위치 변경 시) 폴링으로 연결.

선택처리 버튼도 동일하게 추가. `onSelectProcess` 콜백 → `GroupingPage`에서 `patchCard({ notes: ... })` + 폴링.

### 4. 핸들러 — pages/ArrangePage.tsx

`handleResolveByStructuredEdit`(가칭) 추가:

```typescript
// 변경 필드 diff 계산
const locationChanged = newLocation !== originalLocation;

// patchCard (구조화 필드 PATCH)
await patchCardMutation.mutateAsync({ instanceId, payload: structuredPayload });

if (locationChanged) {
  // 폴링 시작 (Phase 1 refreshLeftGroupsPreservingBoard 재사용)
  startPolling(instanceId);
} else {
  // 폴링 없이 즉시 갱신
  await refreshLeftGroupsPreservingBoard();
  setDetailOpen(false);
}
```

`handleSelectProcess` 추가:

```typescript
// 기존 card.location ?? card.name 을 notes로 자동 전송
const autoNotes = detailCard.detail.region ?? detailCard.name;
await patchCardMutation.mutateAsync({ instanceId, payload: { notes: autoNotes } });
// Phase 1과 동일한 폴링 시작
startPolling(instanceId);
```

### 5. 핸들러 — pages/GroupingPage.tsx

- EditCardDetailPanel 저장 핸들러: 실제 `patchCard` + (위치 변경 시) 폴링으로 교체
- `handleSelectProcess`: ArrangePage와 동일한 로직

### 6. ViewModel·매퍼

**`types/arrange.ts` — ArrangeCardDetailViewModel 추가 필드:**

```typescript
type ArrangeCardDetailViewModel = {
  // ... 기존 필드 ...

  /** 구조화 편집 초기값 — 숙소/교통 카드의 현재 저장값 */
  structuredFields?: {
    location?: string;
    checkIn?: string;
    checkOut?: string;
    timeConstraint?: string;
    flightNumber?: string;
  };

  /**
   * 구조화 편집으로 해결 가능한 처리필요 카드 여부.
   * category = accommodation | transport && 처리필요(unavailable) 상태.
   */
  canResolveByStructuredEdit?: boolean;

  /**
   * 텍스트 입력 없이 선택처리 가능 여부.
   * canResolveByNotes === true && (location != null || name != null).
   */
  canSelectProcess?: boolean;

  /** 선택처리 시 자동 전송할 notes 원천 텍스트. */
  selectProcessNotes?: string;
};
```

**`utils/arrange-mapper.ts` — cardToDetail 확장:**

```typescript
const cardToDetail = (card: Card): ArrangeCardDetailViewModel => ({
  // ... 기존 매핑 ...
  structuredFields: (card.category === 'accommodation' || card.category === 'transport')
    ? {
        location: card.location ?? undefined,
        checkIn: card.check_in ?? undefined,
        checkOut: card.check_out ?? undefined,
        timeConstraint: card.time_constraint ?? undefined,
        flightNumber: card.flight_number ?? undefined,
      }
    : undefined,
  canResolveByStructuredEdit:
    (card.category === 'accommodation' || card.category === 'transport') &&
    /* 처리필요 상태 판정은 cardToAttentionCard 맥락에서만 true */
    undefined,  // cardToAttentionCard 에서 덮어씀
  canSelectProcess: canResolveByNotes(card) && !!(card.location ?? card.name),
  selectProcessNotes: card.location ?? card.name ?? undefined,
});
```

`cardToAttentionCard`에서 unavailable 카드에만 `canResolveByStructuredEdit: true` 세팅.

**정리 화면 `types/grouping.ts` — editDetail ViewModel 동일 필드 추가.**

---

## 구현 키 포인트

### 위치 변경 감지 = 폴링 분기 기준

BE가 동일 위치일 때 재처리하지 않으므로, FE도 `location`이 기존값과 달라졌을 때만 폴링을 건다.  
(불필요한 로딩/타임아웃 방지)

```typescript
const locationChanged = (newVal: string | undefined, original: string | undefined) =>
  (newVal ?? '').trim() !== (original ?? '').trim();
```

### 선택처리 vs 구조화 편집 vs notes 보완 — 3분기 PATCH 전략

| 액션 | 발동 조건 | 전송 payload | 폴링 여부 |
|---|---|---|---|
| 선택처리 | `canSelectProcess && !resolving` (버튼 클릭) | `{ notes: existingLocation ?? name }` | 항상 O |
| 구조화 편집 (위치 변경 포함) | `structuredDirty` (확인하기) | `{ location, check_in?, check_out?, time_constraint?, flight_number? }` | O |
| 구조화 편집 (위치 외만) | `structuredDirty && !locationChanged` (확인하기) | `{ check_in?, check_out?, time_constraint?, flight_number? }` | X |
| notes 보완 | `!structuredDirty && notes.trim().length > 0` (확인하기) | `{ notes: userInput }` | 항상 O |

**한 PATCH에 구조화 편집 + notes를 함께 담지 않는다.**  
- `structuredDirty`가 true이면 notes 입력값이 있어도 이번 요청에서 notes는 전송하지 않음  
- notes를 함께 저장하려면 구조화 편집 저장 완료 후 메모·notes 보완 섹션에서 별도 전송

### 폴링·승격 감지·보드 보존

Phase 1 패턴(`pollUntil`/`refreshLeftGroupsPreservingBoard`) 그대로 재사용.  
`POLL_INTERVAL_MS = 2000` / `POLL_TIMEOUT_MS = 30000` 동일.

---

## UI 동작 규칙

### "확인하기" 활성 조건 (canConfirm)

```typescript
// 구조화 필드 dirty OR notes 입력 있음 — 둘 중 하나라도 바뀌면 활성
const canConfirm =
  (structuredDirty || notes.trim().length > 0) && !resolving;
```

- **구조화 필드 dirty**: 초기값 대비 변경된 필드가 하나 이상 있음.
- **notes 입력**: 사용자가 notes 텍스트를 한 글자 이상 입력함.
- **`resolving`**: 재처리 진행 중이면 비활성.

### "확인하기" PATCH 라우팅 (단일 경로 원칙)

한 번의 "확인하기"에서 구조화 편집과 notes를 **동시에 한 PATCH에 담지 않는다.**  
(BE 주석: "FE는 구조화 편집과 notes를 분리 전송"—동시 전송 시 notes 경로가 우선되어 구조화 필드 변경이 AI에 반영되지 않을 수 있음)

```
[확인하기 클릭] →

  ① structuredDirty === true (location 변경 포함/불포함 무관)
       → 구조화 PATCH: { location?, check_in?, check_out?, time_constraint?, flight_number? }
       → notes 필드에 텍스트가 있어도 이번 PATCH에는 포함하지 않음
       → location 변경 감지:
            변경됨 → 재처리 → 폴링
            변경 없음(비위치 필드만) → 저장 후 즉시 갱신, 패널 유지 or 닫기
       → (notes를 함께 저장하고 싶으면 별도 메모 저장 버튼으로 안내)

  ② structuredDirty === false && notes.trim().length > 0
       → notes PATCH: { notes: userInput }
       → 항상 재처리 폴링 시작 (canStartNaturalLanguageParsingFromNotes 조건 BE가 판정)

  ③ structuredDirty === false && notes.trim().length === 0
       → canConfirm === false → 버튼 비활성 (선택처리 버튼 사용 안내)
```

> **동시 입력 충돌 방지**: 구조화 필드를 편집하면 notes 입력 영역에 "구조화 편집 중에는 장소 정보 보완을 함께 전송하지 않아요. 먼저 확인하기를 눌러 저장하세요." 라는 인라인 안내를 표시. notes를 먼저 입력한 경우에도 동일한 안내.  
> 이를 통해 어느 순서로 입력해도 사용자가 예상 동작을 이해할 수 있게 한다.

### 선택처리 버튼 규칙

- **활성 조건**: `canSelectProcess === true` (기존 텍스트 원천 존재)
- **structuredDirty 또는 notes 입력 여부와 무관하게 항상 표시** (진행 중 시에는 비활성)
- 클릭 시 현재 폼 입력 상태와 무관하게 `{ notes: autoText }` 단독 전송

### 기타 규칙

- **location 변경 감지 = 폴링 분기 기준**: `(newVal ?? '').trim() !== (original ?? '').trim()`
- **다른 카드로 패널 전환 시 입력 state 초기화** (`key={card.id}` 패턴 유지)
- **재처리 진행 중**: 구조화 편집 / 선택처리 / notes / 메모 저장 모든 버튼 비활성

---

## ✅ Phase 2 완료 기준

- [ ] 구조화 편집 폼 UI 신규 — 카테고리별 필드(숙소: 위치/체크인/체크아웃, 항공·교통: 위치/시간/편명) 입력 폼이 배치·정리 패널에 렌더된다.
- [ ] 처리필요 숙소 카드: 위치 보완 → 재처리 → 배치 가능 승격 / 체크인·체크아웃만 수정 시 폴링 없이 저장.
- [ ] 처리필요 항공·교통 카드: 공항(location) 보완 → 재처리 → 승격 / 시간·편명만 수정 시 폴링 없이 저장.
- [ ] **[신규] 선택처리**: 처리필요 숙소·교통 카드에 기존 location/name이 있으면 "현재 정보로 처리" 버튼이 활성되고, 클릭 시 텍스트 입력 없이 AI 재처리가 트리거된다.
- [ ] 재처리 실패(needs_input 강등/failed) 시 패널 잠기지 않고 재시도 가능.
- [ ] 구조화 편집·선택처리·notes 보완이 분리 동작(한 요청에 혼합 전송하지 않음).
- [ ] 정리 화면(SCR-03) EditCardDetailPanel 스텁 해소 — 배치/정리 동일 폼·동작.
- [ ] 구조화 필드 미변경 + notes 미입력 시 "확인하기" 비활성 / 구조화 필드 또는 notes 중 하나만 바꿔도 "확인하기" 활성.
- [ ] 구조화 편집과 notes를 동시에 입력해도 에러 없이 처리됨 — 구조화 dirty 시 구조화 PATCH 단독 전송, notes-only 시 notes PATCH 단독 전송.
- [ ] 패널 카드 전환 시 입력 state 초기화.
- [ ] `tsc` 통과 / `eslint` 0 errors.

---

## 🔍 선택처리 가능 여부 판별 근거 (BE 코드 분석)

- `notes` 필드와 `location` 필드는 BE에서 독립 처리.
- `applyAccommodationEdit`는 `location` 변경 여부로 구조화 재처리 분기. 동일 location 재전송 시 재처리 없음.
- `notes`에 기존 location 문자열을 보내는 것은 notes-기반 AI 파싱 경로를 타며, BE는 이를 별개로 처리한다.
- 선택처리는 이 notes-기반 경로를 활용. FE-단 독립 변경 사항으로 BE 신규 API 불필요.
