### PR TITLE
Fix: SCR-04 배치된 카드 클릭 시 상세 패널 노출

### DIFF
--- a/apps/frontend/src/components/arrange/DayColumn.tsx
+++ b/apps/frontend/src/components/arrange/DayColumn.tsx
@@ -27,6 +27,8 @@ type DayColumnProps = DayColumnViewModel & {
   draggingCardId?: string | null;
   /** 드래그가 진행 중이면 모든 컬럼을 드롭 가능 상태로 강조 */
   dragActive?: boolean;
+  /** 배치된 카드 클릭 시 상세 패널 열기 */
+  onCardClick?: (cardId: string) => void;
 };
 
 // 카드 사이/끝의 삽입 위치 표시 선.
@@ -44,6 +46,7 @@ const DayColumn = ({
   onCardDragEnd,
   draggingCardId,
   dragActive = false,
+  onCardClick,
 }: DayColumnProps) => {
   const isEmpty = cards.length === 0;
   const [isOver, setIsOver] = useState(false);
@@ -163,7 +166,12 @@ const DayColumn = ({
                     draggingCardId === card.id && 'opacity-40'
                   )}
                 >
-                  <ScheduleCard {...card} />
+                  <ScheduleCard
+                    {...card}
+                    onClick={
+                      !card.fixedTime ? () => onCardClick?.(card.id) : undefined
+                    }
+                  />
                 </div>
               </Fragment>
             );

--- a/apps/frontend/src/components/arrange/ScheduleCard.tsx
+++ b/apps/frontend/src/components/arrange/ScheduleCard.tsx
@@ -16,17 +16,23 @@ const ACCENT_BAR: Record<PlaceCardAccent, string> = {
   muted: 'bg-muted-foreground/30',
 };
 
+type ScheduleCardProps = ScheduledCardViewModel & { onClick?: () => void };
+
 const ScheduleCard = ({
   name,
   accent = 'green',
   badges = [],
   fixedTime,
   timeLabel,
-}: ScheduledCardViewModel) => {
+  onClick,
+}: ScheduleCardProps) => {
   // 고정 시작 시간 카드 — 옅은 primary 톤 박스
   if (fixedTime) {
     return (
-      <div className="rounded-xl border border-primary/30 bg-primary/5 px-3.5 py-3">
+      <div
+        className="rounded-xl border border-primary/30 bg-primary/5 px-3.5 py-3"
+        onClick={onClick}
+      >
         <p className="text-[11px] font-medium text-primary/80">
           고정 시작 시간
         </p>
@@ -43,7 +49,10 @@ const ScheduleCard = ({
   }
 
   return (
-    <div className="flex overflow-hidden rounded-xl bg-card ring-1 ring-foreground/10">
+    <div
+      className="flex overflow-hidden rounded-xl bg-card ring-1 ring-foreground/10"
+      onClick={onClick}
+    >
       <span
         aria-hidden="true"
         className={cn('w-1 shrink-0', ACCENT_BAR[accent])}

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -611,6 +611,16 @@ const ArrangePage = () => {
     }
   };
 
+  // 우측 보드 카드 클릭 → 상세 패널 열기.
+  // 원본(좌측에서 드래그해 배치한 카드)이 보존되어 있으면 우선 사용하고,
+  // 없으면(초기 로드 시 이미 보드에 있던 카드) toArrangeCard 로 변환해 폴백한다.
+  const handleCardClick = (cardId: string) => {
+    const scheduled = days.flatMap((d) => d.cards).find((c) => c.id === cardId);
+    if (!scheduled) return;
+    const saved = originalCardsRef.current.get(cardId);
+    openCardDetail(saved?.card ?? toArrangeCard(scheduled));
+  };
+
   // 일정 확정 — POST /confirm. 성공 시 확정 상태로 전환.
   const handleConfirm = async () => {
     if (!tripId) return;
@@ -791,6 +801,7 @@ const ArrangePage = () => {
                     onDropCard={(payload, index) =>
                       handleDropOnDay(payload, day.id, index)
                     }
+                    onCardClick={handleCardClick}
                   />
                 ))}
               </div>


### PR DESCRIPTION

## 📝 작업 내용

배치 화면(SCR-04)의 우측 Day 컬럼에 **배치 완료된 카드를 클릭해도 상세 패널이 열리지 않던** 문제를, `ScheduleCard → DayColumn → ArrangePage` 로 클릭 이벤트를 연결해 `ArrangeCardDetailPanel` 이 인플레이스로 열리도록 수정했습니다. 원본이 보존된 카드는 원본을, 그렇지 않으면 뷰모델을 변환해 폴백합니다.

## 🔗 관련 이슈

closes #284

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

변경 파일 (3):

- `components/arrange/ScheduleCard.tsx` 
- `components/arrange/DayColumn.tsx` 
- `pages/ArrangePage.tsx` 

## ✅ 작업 체크리스트

- [x] 정적 검증 통과 — `tsc -b`(typecheck) / `eslint`(lint) / `vite build` 모두 성공, prettier 경고 0
- [ ] 로컬에서 정상 동작 확인 — 배치 카드 클릭 → 상세 패널 노출 / 원본 보존 카드는 메모·처리상태 표시 (수동 UI 확인 예정)
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — 좌측 `CardListPanel` 클릭 경로(`onSelectCard`) 미변경, 드래그/verify/confirm 로직 미변경, 고정 시간 카드는 기존과 동일(패널 미노출)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요? — 없음
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? — 배치 카드 클릭 → 상세 패널 노출 한 가지만

## 👀 리뷰어에게

- **원본 우선 폴백 (`handleCardClick`, ArrangePage.tsx):** 좌측에서 드래그해 배치한 카드는 `originalCardsRef` 에 원본(`ArrangeCardViewModel`)이 보존되어 있어 그대로 사용함. 그래야 `detail`(메모, `canResolveByNotes` 등) 필드가 유지되어 처리필요 카드의 인플레이스 보완 흐름(#230)까지 연결됨. 
- **고정 시간 카드(`fixedTime`, 항공권 등) 의도적 제외:** `DayColumn` 에서 `!card.fixedTime` 일 때만 `onClick` 을 전달합니다. 고정 카드는 사용자가 상세 확인/편집할 필드가 없어 이번엔 패널을 열지 않도록 결정.
- **`ScheduleCard` 고정 브랜치의 `onClick`:** 현재 `DayColumn` 이 고정 카드에는 항상 `undefined` 를 넘겨 실질적으로 미사용이며, 컴포넌트 시그니처의 일관성/향후 유연성을 위해 두 변형 모두에 prop만 연결.
- **후속 개선 여지(접근성):** 클릭 가능한 `div` 에 `cursor-pointer` / `role="button"` / `tabIndex` / 키보드 핸들러가 아직 없음. 동작 자체는 이슈 범위대로 해결되며, a11y 보강은 후속으로 분리 가능.

## 📸 스크린샷

UI 변경이 있는 경우에만 첨부해주세요.

- (첨부 예정) 배치된 카드 클릭 → `ArrangeCardDetailPanel` 노출
- (첨부 예정) 원본 보존 카드 클릭 시 메모/처리 상태 표시
