### PR TITLE
feat: #275 동선 최적화 Phase 2 — 제약 반영(앵커·귀가·고정·예약시각·모드, OR-tools)

### DIFF
--- a/apps/ai-engine/app/schemas/route.py
+++ b/apps/ai-engine/app/schemas/route.py
@@ -47,6 +47,12 @@ class OptimizeStop(BaseModel):
 
     instance_id: str = Field(..., min_length=1)
     coordinates: Coordinates
+    # 고정 카드(pin): time_constraint 가 있는 카드. 예약시각이 파싱되지 않으면 현재 순서(위치)를 고정한다.
+    pinned: bool = False
+    # 예약 시각 "HH:MM" (BE 가 time_constraint 에서 추출). 있으면 해당 시각 time window 로 반영.
+    reserved_time: str | None = None
+    # 체류 시간(분, estimated_duration_min). 예약시각 제약 계산의 service time 으로 사용.
+    duration_min: int | None = None
 
 
 class OptimizeOrderRequest(BaseModel):
@@ -54,10 +60,10 @@ class OptimizeOrderRequest(BaseModel):
 
     # 한 Day 안에서 순서를 최적화할 카드들 (좌표 있는 카드만 전달)
     stops: list[OptimizeStop]
-    # 시작 고정 앵커(예: 숙소) instance_id. None 이면 시작 자유.
+    # 시작 고정 앵커(예: 숙소, 첫날 도착 항공) instance_id. None 이면 시작 자유.
     start_instance_id: str | None = None
     # 종료 고정 앵커(예: 마지막날 항공 출발) instance_id. None 이면 종료 자유.
-    # 시작 앵커와 같으면 무시한다(귀가 closed-tour 는 후속 슬라이스).
+    # 시작 앵커와 같으면 귀가 closed-tour(숙소 출발 → 숙소 복귀)로 최적화한다.
     end_instance_id: str | None = None
 
 

--- a/apps/ai-engine/app/schemas/route.py
+++ b/apps/ai-engine/app/schemas/route.py
@@ -56,6 +56,9 @@ class OptimizeOrderRequest(BaseModel):
     stops: list[OptimizeStop]
     # 시작 고정 앵커(예: 숙소) instance_id. None 이면 시작 자유.
     start_instance_id: str | None = None
+    # 종료 고정 앵커(예: 마지막날 항공 출발) instance_id. None 이면 종료 자유.
+    # 시작 앵커와 같으면 무시한다(귀가 closed-tour 는 후속 슬라이스).
+    end_instance_id: str | None = None
 
 
 class OptimizeOrderResponse(BaseModel):

--- a/apps/ai-engine/app/services/route_order_constrained.py
+++ b/apps/ai-engine/app/services/route_order_constrained.py
@@ -1,0 +1,130 @@
+"""SCR-04 동선 최적화 Phase 2 — 제약 반영 OR-tools 라우팅 솔버 (#275).
+
+제약(귀가 closed-tour / 고정 카드 위치 / 예약시각 time window)이 있을 때만 사용한다.
+무제약 경로는 기존 route_order_optimizer(Held-Karp/2-opt)가 계속 담당한다.
+
+- closed_tour: start 에서 출발해 모든 정점을 돌고 start 로 복귀(숙소 귀가).
+- pinned_positions: {노드: 원래 위치} — 해당 노드를 방문 순서상 그 위치에 고정.
+- time_windows: {노드: 예약시각(일정 시작 기준 초)} — 해당 시각에 정확히 방문 시작
+  (일찍 도착하면 대기(slack), 늦으면 불능). service_times 가 체류 시간으로 누적된다.
+- 자유 시작/종료는 0 비용 dummy 노드로 모델링한다(개방 경로 표준 기법).
+
+해가 없으면(제약 충돌) None 을 반환한다 — 호출 측이 무제약 폴백을 수행한다.
+순수 함수 — 외부 I/O 없음.
+"""
+
+from __future__ import annotations
+
+from ortools.constraint_solver import pywrapcp, routing_enums_pb2
+
+# time dimension 상한(하루 일정 기준 넉넉한 지평선)
+DAY_HORIZON_SECONDS = 20 * 3600
+# n 이 작아(하루 카드 수) 최적해는 수 ms 내 도달 — GLS 는 시간제한까지 탐색하므로 짧게 둔다
+SEARCH_TIME_LIMIT_MS = 200
+
+
+def solve_constrained(
+    matrix: list[list[int]],
+    start: int | None = None,
+    end: int | None = None,
+    closed_tour: bool = False,
+    pinned_positions: dict[int, int] | None = None,
+    time_windows: dict[int, int] | None = None,
+    service_times: list[int] | None = None,
+) -> list[int] | None:
+    """제약을 만족하는 최소 이동시간 방문 순서(인덱스). 해가 없으면 None."""
+    n = len(matrix)
+    if n <= 1:
+        return list(range(n))
+    pinned_positions = pinned_positions or {}
+    time_windows = time_windows or {}
+    service_times = service_times or [0] * n
+
+    if closed_tour and start is None:
+        closed_tour = False  # 복귀 지점이 없으면 개방 경로로 강등
+
+    # 자유 시작/종료 → 0 비용 dummy 노드. 양끝 모두 자유면 dummy 순환(=개방 경로) 기법.
+    dummy: int | None = None
+    if closed_tour:
+        size = n
+        manager = pywrapcp.RoutingIndexManager(size, 1, start)
+    elif start is not None and end is not None:
+        size = n
+        manager = pywrapcp.RoutingIndexManager(size, 1, [start], [end])
+    else:
+        dummy = n
+        size = n + 1
+        if start is None and end is None:
+            manager = pywrapcp.RoutingIndexManager(size, 1, dummy)
+        else:
+            starts = [start if start is not None else dummy]
+            ends = [end if end is not None else dummy]
+            manager = pywrapcp.RoutingIndexManager(size, 1, starts, ends)
+
+    routing = pywrapcp.RoutingModel(manager)
+
+    def _travel(from_index: int, to_index: int) -> int:
+        a = manager.IndexToNode(from_index)
+        b = manager.IndexToNode(to_index)
+        if a == dummy or b == dummy:
+            return 0
+        return int(matrix[a][b])
+
+    transit_cb = routing.RegisterTransitCallback(_travel)
+    routing.SetArcCostEvaluatorOfAllVehicles(transit_cb)
+
+    # 고정 카드: 방문 순번 카운터(Order) 차원의 누적값을 원래 위치로 고정
+    if pinned_positions:
+        routing.AddConstantDimension(1, size + 1, True, "Order")
+        order_dim = routing.GetDimensionOrDie("Order")
+        # dummy 시작이면 실제 첫 정점의 순번이 1 부터 시작하므로 위치를 1 씩 민다
+        offset = 1 if (dummy is not None and start is None and not closed_tour) else 0
+        for node, pos in pinned_positions.items():
+            routing.solver().Add(
+                order_dim.CumulVar(manager.NodeToIndex(node)) == pos + offset
+            )
+
+    # 예약시각: Time 차원(이동 + 출발 정점 체류)의 누적값을 예약 시각으로 고정.
+    # slack 이 대기를 흡수하므로 "일찍 도착 후 대기" 는 허용, 지각은 불능 처리된다.
+    if time_windows:
+
+        def _time(from_index: int, to_index: int) -> int:
+            a = manager.IndexToNode(from_index)
+            b = manager.IndexToNode(to_index)
+            if a == dummy or b == dummy:
+                return 0
+            return int(matrix[a][b]) + int(service_times[a])
+
+        time_cb = routing.RegisterTransitCallback(_time)
+        routing.AddDimension(
+            time_cb, DAY_HORIZON_SECONDS, DAY_HORIZON_SECONDS, True, "Time"
+        )
+        time_dim = routing.GetDimensionOrDie("Time")
+        for node, at in time_windows.items():
+            time_dim.CumulVar(manager.NodeToIndex(node)).SetRange(at, at)
+
+    params = pywrapcp.DefaultRoutingSearchParameters()
+    params.first_solution_strategy = (
+        routing_enums_pb2.FirstSolutionStrategy.PATH_CHEAPEST_ARC
+    )
+    params.local_search_metaheuristic = (
+        routing_enums_pb2.LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH
+    )
+    params.time_limit.FromMilliseconds(SEARCH_TIME_LIMIT_MS)
+
+    solution = routing.SolveWithParameters(params)
+    if solution is None:
+        return None
+
+    order: list[int] = []
+    index = routing.Start(0)
+    while not routing.IsEnd(index):
+        node = manager.IndexToNode(index)
+        if node != dummy:
+            order.append(node)
+        index = solution.Value(routing.NextVar(index))
+    final = manager.IndexToNode(index)
+    # closed tour 의 종점은 시작 정점 재방문이므로 제외, dummy 종점도 제외
+    if not closed_tour and final != dummy:
+        order.append(final)
+    return order

--- a/apps/ai-engine/app/services/route_order_optimizer.py
+++ b/apps/ai-engine/app/services/route_order_optimizer.py
@@ -25,25 +25,35 @@ def optimize_visit_order(
     instance_ids: list[str],
     matrix: list[list[int]],
     start_index: int | None = None,
+    end_index: int | None = None,
 ) -> list[str]:
     """instance_id 리스트를 총 이동시간 최소 순서로 재배열해 반환."""
     if len(instance_ids) <= 1:
         return list(instance_ids)
-    order = solve_open_path(matrix, start_index)
+    order = solve_open_path(matrix, start_index, end_index)
     return [instance_ids[i] for i in order]
 
 
-def solve_open_path(matrix: list[list[int]], start: int | None = None) -> list[int]:
-    """최소 비용 개방 경로의 인덱스 순서. start 지정 시 그 인덱스에서 시작 고정."""
+def solve_open_path(
+    matrix: list[list[int]], start: int | None = None, end: int | None = None
+) -> list[int]:
+    """최소 비용 개방 경로의 인덱스 순서. start/end 지정 시 양 끝을 고정한다.
+
+    end 가 start 와 같거나 범위를 벗어나면 종료 자유로 처리한다(귀가 closed-tour 는 후속 슬라이스).
+    """
     n = len(matrix)
     if n <= 1:
         return list(range(n))
+    if end is not None and (end == start or not (0 <= end < n)):
+        end = None
     if n <= HELD_KARP_MAX:
-        return _held_karp_open_path(matrix, start)
-    return _nearest_neighbor_2opt(matrix, start)
+        return _held_karp_open_path(matrix, start, end)
+    return _nearest_neighbor_2opt(matrix, start, end)
 
 
-def _held_karp_open_path(matrix: list[list[int]], start: int | None) -> list[int]:
+def _held_karp_open_path(
+    matrix: list[list[int]], start: int | None, end: int | None = None
+) -> list[int]:
     n = len(matrix)
     inf = float("inf")
     full = (1 << n) - 1
@@ -70,10 +80,14 @@ def _held_karp_open_path(matrix: list[list[int]], start: int | None) -> list[int
                     dp[nmask][j] = cost
                     parent[nmask][j] = i
 
-    best_end, best_cost = 0, inf
-    for i in range(n):
-        if dp[full][i] < best_cost:
-            best_cost, best_end = dp[full][i], i
+    # end 앵커가 지정되고 도달 가능하면 그 노드에서 끝나는 경로로 고정, 아니면 최소 비용 종점 선택
+    if end is not None and dp[full][end] != inf:
+        best_end = end
+    else:
+        best_end, best_cost = 0, inf
+        for i in range(n):
+            if dp[full][i] < best_cost:
+                best_cost, best_end = dp[full][i], i
 
     order: list[int] = []
     mask, cur = full, best_end
@@ -86,7 +100,9 @@ def _held_karp_open_path(matrix: list[list[int]], start: int | None) -> list[int
     return order
 
 
-def _nearest_neighbor_2opt(matrix: list[list[int]], start: int | None) -> list[int]:
+def _nearest_neighbor_2opt(
+    matrix: list[list[int]], start: int | None, end: int | None = None
+) -> list[int]:
     n = len(matrix)
     s = 0 if start is None else start
 
@@ -104,15 +120,22 @@ def _nearest_neighbor_2opt(matrix: list[list[int]], start: int | None) -> list[i
         visited[nxt] = True
         cur = nxt
 
+    # end 앵커가 있으면 마지막 위치로 강제(2-opt 가 마지막을 건드리지 않도록 함)
+    fix_end = end is not None and end != s
+    if fix_end:
+        order.remove(end)
+        order.append(end)
+
     # 2) 2-opt 개선 (full-recompute → asymmetric 행렬에서도 안전)
     fix_start = start is not None
     lo = 1 if fix_start else 0
+    k_upper = (n - 1) if fix_end else n  # end 고정 시 마지막 인덱스는 reverse 대상 제외
     best = path_duration(order, matrix)
     improved = True
     while improved:
         improved = False
         for i in range(lo, n - 1):
-            for k in range(i + 1, n):
+            for k in range(i + 1, k_upper):
                 cand = order[:i] + order[i : k + 1][::-1] + order[k + 1 :]
                 d = path_duration(cand, matrix)
                 if d + 1e-9 < best:

--- a/apps/ai-engine/app/services/route_order_optimizer.py
+++ b/apps/ai-engine/app/services/route_order_optimizer.py
@@ -39,7 +39,8 @@ def solve_open_path(
 ) -> list[int]:
     """최소 비용 개방 경로의 인덱스 순서. start/end 지정 시 양 끝을 고정한다.
 
-    end 가 start 와 같거나 범위를 벗어나면 종료 자유로 처리한다(귀가 closed-tour 는 후속 슬라이스).
+    end 가 start 와 같거나 범위를 벗어나면 종료 자유로 처리한다
+    (귀가 closed-tour 는 route_order_constrained 의 OR-tools 솔버가 담당).
     """
     n = len(matrix)
     if n <= 1:

--- a/apps/ai-engine/app/services/route_order_service.py
+++ b/apps/ai-engine/app/services/route_order_service.py
@@ -204,7 +204,13 @@ async def optimize_order(request: OptimizeOrderRequest) -> OptimizeOrderResponse
     if request.start_instance_id is not None and request.start_instance_id in ids:
         start_index = ids.index(request.start_instance_id)
 
-    ordered_ids = optimize_visit_order(ids, matrix, start_index)
+    end_index = None
+    if request.end_instance_id is not None and request.end_instance_id in ids:
+        end_index = ids.index(request.end_instance_id)
+    if end_index == start_index:  # 같은 앵커(귀가 등)는 종료 자유로 (후속 슬라이스)
+        end_index = None
+
+    ordered_ids = optimize_visit_order(ids, matrix, start_index, end_index)
     order_idx = [ids.index(x) for x in ordered_ids]
     total = path_duration(order_idx, matrix)
 

--- a/apps/ai-engine/app/services/route_order_service.py
+++ b/apps/ai-engine/app/services/route_order_service.py
@@ -1,8 +1,9 @@
-"""SCR-04 동선 최적화 — 이동시간 행렬 산출 + 순서 최적화 오케스트레이션 (#270, #274).
+"""SCR-04 동선 최적화 — 이동시간 행렬 산출 + 순서 최적화 오케스트레이션 (#270, #274, #275).
 
 L2 캐시(route_matrix_cache)의 pair 는 그대로 쓰고(부분 히트 포함), 빠진 pair 는 개수에 따라
 per-leg computeRoutes(소수) 또는 Route Matrix 1회(다수)로 채운다. 키 부재/호출 실패/구간 누락 시
-haversine 추정으로 보강한 뒤 route_order_optimizer 로 Day 내 방문 순서를 푼다. I/O 경계 모듈.
+haversine 추정으로 보강하고, 짧은 구간은 도보 추정과 min 블렌딩(#275 mode)한 뒤
+제약(귀가/고정/예약시각) 유무에 따라 OR-tools 또는 Held-Karp/2-opt 로 순서를 푼다. I/O 경계 모듈.
 """
 
 from __future__ import annotations
@@ -10,10 +11,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 
 import httpx
 
-from app.fallback.estimated_route import estimate_leg
+from app.fallback.estimated_route import _haversine_meters, estimate_leg
 from app.schemas.parse import Coordinates
 from app.schemas.route import (
     OptimizeOrderRequest,
@@ -27,6 +29,7 @@ from app.services.route_optimizer import (
     _parse_duration_seconds,
     _places_api_key,
 )
+from app.services.route_order_constrained import solve_constrained
 from app.services.route_order_optimizer import optimize_visit_order, path_duration
 
 logger = logging.getLogger(__name__)
@@ -39,12 +42,48 @@ COMPUTE_ROUTE_MATRIX_URL = (
 # 초과하면 Route Matrix 1회로 전체 재계산(cold 시 호출 수 폭증 방지). #274 Phase B.
 PER_LEG_MAX_PAIRS = int(os.getenv("ROUTE_MATRIX_PER_LEG_MAX_PAIRS", "8"))
 
+# 하루 일정 시작 시각 가정(예약시각 → 일정 시작 기준 초 변환). #275
+DAY_START_SECONDS = 9 * 3600
+# 도보 추정: 직선거리 × 우회계수 / 보행속도(4.5km/h). 짧은 구간은 DRIVE 보다 빠를 수 있어
+# min 블렌딩으로 순서 최적화 비용에 반영한다(#275 mode — 추가 API 호출 없음).
+WALK_DETOUR_FACTOR = 1.3
+WALK_SPEED_MPS = 4_500 / 3600
+
+_RESERVED_TIME_RE = re.compile(r"^([01]?\d|2[0-3]):([0-5]\d)$")
+
 
 def _estimate_seconds(origin: Coordinates, destination: Coordinates) -> int:
     leg = RouteLeg(
         from_instance_id="o", to_instance_id="d", origin=origin, destination=destination
     )
     return estimate_leg(leg).duration_seconds
+
+
+def _walk_seconds(origin: Coordinates, destination: Coordinates) -> int:
+    meters = _haversine_meters(origin.lat, origin.lng, destination.lat, destination.lng)
+    return int(round(meters * WALK_DETOUR_FACTOR / WALK_SPEED_MPS))
+
+
+def _blend_walk_estimates(stops: list[OptimizeStop], matrix: list[list[int]]) -> None:
+    """구간별 비용을 min(DRIVE, 도보 추정) 으로 보정(#275 mode). 캐시 적재 후라 캐시는 DRIVE 원값 유지."""
+    n = len(stops)
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            walk = _walk_seconds(stops[i].coordinates, stops[j].coordinates)
+            if walk < matrix[i][j]:
+                matrix[i][j] = walk
+
+
+def _reserved_seconds(reserved_time: str | None) -> int | None:
+    """'HH:MM' 예약시각 → 일정 시작(DAY_START) 기준 초. 형식이 아니면 None."""
+    if not reserved_time:
+        return None
+    m = _RESERVED_TIME_RE.match(reserved_time.strip())
+    if not m:
+        return None
+    return max(0, int(m.group(1)) * 3600 + int(m.group(2)) * 60 - DAY_START_SECONDS)
 
 
 def _waypoint(coord: Coordinates) -> dict:
@@ -191,6 +230,24 @@ async def _build_matrix(
     return matrix, "google" if (used_google or filled) else "estimated"
 
 
+def _collect_constraints(
+    request: OptimizeOrderRequest, start_index: int | None, end_index: int | None
+) -> tuple[dict[int, int], dict[int, int], list[int]]:
+    """stops 에서 고정 위치/예약시각/체류시간 제약을 추출한다(앵커는 이미 고정이라 제외)."""
+    pinned_positions: dict[int, int] = {}
+    time_windows: dict[int, int] = {}
+    service_times = [(s.duration_min or 0) * 60 for s in request.stops]
+    for i, stop in enumerate(request.stops):
+        if i == start_index or i == end_index:
+            continue
+        reserved = _reserved_seconds(stop.reserved_time)
+        if reserved is not None:
+            time_windows[i] = reserved
+        elif stop.pinned:
+            pinned_positions[i] = i  # BE 가 day_order 순으로 보내므로 입력 인덱스 = 원래 위치
+    return pinned_positions, time_windows, service_times
+
+
 async def optimize_order(request: OptimizeOrderRequest) -> OptimizeOrderResponse:
     ids = [s.instance_id for s in request.stops]
     if len(ids) <= 1:
@@ -199,6 +256,7 @@ async def optimize_order(request: OptimizeOrderRequest) -> OptimizeOrderResponse
         )
 
     matrix, source = await _build_matrix(request.stops, _places_api_key())
+    _blend_walk_estimates(request.stops, matrix)
 
     start_index = None
     if request.start_instance_id is not None and request.start_instance_id in ids:
@@ -207,12 +265,45 @@ async def optimize_order(request: OptimizeOrderRequest) -> OptimizeOrderResponse
     end_index = None
     if request.end_instance_id is not None and request.end_instance_id in ids:
         end_index = ids.index(request.end_instance_id)
-    if end_index == start_index:  # 같은 앵커(귀가 등)는 종료 자유로 (후속 슬라이스)
+
+    # 시작=종료 앵커(숙소) → 귀가 closed-tour(숙소 복귀 비용 포함 최적화)
+    closed_tour = end_index is not None and end_index == start_index
+    if closed_tour:
         end_index = None
 
-    ordered_ids = optimize_visit_order(ids, matrix, start_index, end_index)
-    order_idx = [ids.index(x) for x in ordered_ids]
+    pinned_positions, time_windows, service_times = _collect_constraints(
+        request, start_index, end_index
+    )
+
+    order_idx: list[int] | None = None
+    solved_closed = False
+    if closed_tour or pinned_positions or time_windows:
+        order_idx = solve_constrained(
+            matrix,
+            start=start_index,
+            end=end_index,
+            closed_tour=closed_tour,
+            pinned_positions=pinned_positions,
+            time_windows=time_windows,
+            service_times=service_times,
+        )
+        if order_idx is None:
+            logger.warning(
+                "constrained solve infeasible | pins=%d windows=%d closed=%s — 무제약 폴백",
+                len(pinned_positions), len(time_windows), closed_tour,
+            )
+        else:
+            solved_closed = closed_tour
+
+    if order_idx is None:
+        ordered_ids = optimize_visit_order(ids, matrix, start_index, end_index)
+        order_idx = [ids.index(x) for x in ordered_ids]
+    else:
+        ordered_ids = [ids[i] for i in order_idx]
+
     total = path_duration(order_idx, matrix)
+    if solved_closed and len(order_idx) > 1:
+        total += matrix[order_idx[-1]][order_idx[0]]  # 귀가(복귀) 구간 포함
 
     return OptimizeOrderResponse(
         ordered_instance_ids=ordered_ids,

--- a/apps/ai-engine/requirements.txt
+++ b/apps/ai-engine/requirements.txt
@@ -14,6 +14,10 @@ google-api-core==2.19.1
 googlemaps==4.10.0
 httpx==0.28.1
 
+# ── Route Optimization (#275 제약 솔버) ───────────────
+# 9.13+ 는 protobuf 6.x 요구 → google-api-core(<6.0) 와 충돌해 9.12 고정
+ortools==9.12.4544
+
 # ── Environment ──────────────────────────────────────
 python-dotenv==1.2.2
 

--- a/apps/ai-engine/tests/test_route_order_constrained.py
+++ b/apps/ai-engine/tests/test_route_order_constrained.py
@@ -1,0 +1,132 @@
+"""SCR-04 동선 최적화 Phase 2 — OR-tools 제약 솔버 단위 테스트 (#275)."""
+
+import itertools
+
+from app.services.route_order_constrained import solve_constrained
+from app.services.route_order_optimizer import path_duration
+
+# 비대칭 5x5 행렬 (기존 optimizer 테스트와 동일 값 — 완전탐색 대조용)
+ASYM5 = [
+    [0, 5, 9, 8, 7],
+    [6, 0, 4, 11, 3],
+    [10, 4, 0, 2, 6],
+    [8, 12, 2, 0, 5],
+    [7, 3, 6, 5, 0],
+]
+
+
+def _line_matrix(positions: list[int]) -> list[list[int]]:
+    return [[abs(a - b) for b in positions] for a in positions]
+
+
+def _cycle_duration(order: list[int], matrix: list[list[int]]) -> int:
+    return path_duration(order, matrix) + matrix[order[-1]][order[0]]
+
+
+def test_empty_and_single() -> None:
+    assert solve_constrained([]) == []
+    assert solve_constrained([[0]]) == [0]
+
+
+def test_closed_tour_matches_brute_force() -> None:
+    n = len(ASYM5)
+    order = solve_constrained(ASYM5, start=2, closed_tour=True)
+    assert order is not None and order[0] == 2
+    assert sorted(order) == list(range(n))
+    best = min(
+        _cycle_duration([2, *p], ASYM5)
+        for p in itertools.permutations([i for i in range(n) if i != 2])
+    )
+    assert _cycle_duration(order, ASYM5) == best
+
+
+def test_closed_tour_without_start_degrades_to_open() -> None:
+    # 복귀 지점이 없으면 개방 경로로 강등 — 유효 순열이면 된다
+    order = solve_constrained(ASYM5, closed_tour=True)
+    assert order is not None
+    assert sorted(order) == list(range(len(ASYM5)))
+
+
+def test_pinned_position_free_start() -> None:
+    # 위치 A=0 B=10 C=20 D=30, 입력 순서 C,A,D,B — B(입력 3) 를 3번째 위치에 고정
+    m = _line_matrix([20, 0, 30, 10])
+    order = solve_constrained(m, pinned_positions={3: 3})
+    assert order is not None and order[3] == 3
+    # B 마지막 고정 시 유일 최적: D → C → A → B (10+20+10 = 40)
+    assert order == [2, 0, 1, 3]
+    assert path_duration(order, m) == 40
+
+
+def test_pinned_position_with_start_anchor_matches_brute_force() -> None:
+    n = len(ASYM5)
+    order = solve_constrained(ASYM5, start=2, pinned_positions={4: 1})
+    assert order is not None and order[0] == 2 and order[1] == 4
+    got = path_duration(order, ASYM5)
+    best = min(
+        path_duration([2, 4, *p], ASYM5)
+        for p in itertools.permutations([i for i in range(n) if i not in (2, 4)])
+    )
+    assert got == best
+
+
+def test_reserved_time_forces_reorder() -> None:
+    # S(0) R(1) X(2) Y(3). 무제약 최적은 S→X→Y→R(70) 이지만 R 도착이 70초 > 예약 60초 → 불능.
+    # 예약을 지키는 유일 최적은 S→R→X→Y (75).
+    m = [
+        [0, 60, 5, 50],
+        [60, 0, 10, 50],
+        [60, 60, 0, 5],
+        [60, 60, 50, 0],
+    ]
+    free = solve_constrained(m, start=0, pinned_positions={1: 3})  # sanity: R 마지막 고정땐 70
+    assert free is not None and path_duration(free, m) == 70
+
+    order = solve_constrained(m, start=0, time_windows={1: 60})
+    assert order == [0, 1, 2, 3]
+
+
+def test_service_time_counts_toward_reservation() -> None:
+    # S(0) A(1) R(2). A 체류 100초 때문에 S→A→R 은 R 도착 120초 > 예약 60초 → S→R→A 로 재배열.
+    m = [
+        [0, 10, 60],
+        [10, 0, 10],
+        [60, 10, 0],
+    ]
+    order = solve_constrained(
+        m, start=0, time_windows={2: 60}, service_times=[0, 100, 0]
+    )
+    assert order == [0, 2, 1]
+
+
+def test_infeasible_reservation_returns_none() -> None:
+    # 예약 시각 0초인데 어느 경로로도 이동시간 > 0 → 해 없음
+    m = _line_matrix([0, 100, 200])
+    assert solve_constrained(m, start=0, time_windows={2: 0}) is None
+
+
+def test_infeasible_pin_returns_none() -> None:
+    # 시작 앵커(위치 0)와 다른 노드를 위치 0 에 고정 → 충돌
+    m = _line_matrix([0, 100, 200])
+    assert solve_constrained(m, start=0, pinned_positions={2: 0}) is None
+
+
+def test_start_and_end_anchor_with_pin() -> None:
+    n = len(ASYM5)
+    order = solve_constrained(ASYM5, start=2, end=0, pinned_positions={4: 2})
+    assert order is not None
+    assert order[0] == 2 and order[-1] == 0 and order[2] == 4
+    got = path_duration(order, ASYM5)
+    mids = [i for i in range(n) if i not in (2, 0, 4)]
+    best = min(
+        path_duration([2, p[0], 4, p[1], 0], ASYM5)
+        for p in itertools.permutations(mids)
+    )
+    assert got == best
+
+
+def test_end_anchor_only_with_window() -> None:
+    # 시작 자유(dummy) + 종료 앵커 + 예약. dummy 오프셋 경로 검증.
+    m = _line_matrix([0, 10, 20, 30])
+    order = solve_constrained(m, end=0, time_windows={2: 40})
+    assert order is not None
+    assert order[-1] == 0 and sorted(order) == [0, 1, 2, 3]

--- a/apps/ai-engine/tests/test_route_order_optimizer.py
+++ b/apps/ai-engine/tests/test_route_order_optimizer.py
@@ -80,6 +80,58 @@ def test_fixed_start_matches_brute_force() -> None:
     assert got == best
 
 
+def test_fixed_end_respected_and_optimal() -> None:
+    ids = ["C", "A", "D", "B"]
+    pos = [20, 0, 30, 10]
+    m = _line_matrix(pos)
+    order = optimize_visit_order(ids, m, end_index=2)  # D(30) 에서 종료 고정
+    assert order[-1] == "D"
+    n = len(ids)
+    best = min(
+        path_duration([*p, 2], m)
+        for p in itertools.permutations([i for i in range(n) if i != 2])
+    )
+    assert path_duration([ids.index(x) for x in order], m) == best
+
+
+def test_fixed_start_and_end_matches_brute_force() -> None:
+    m = [
+        [0, 5, 9, 8, 7],
+        [6, 0, 4, 11, 3],
+        [10, 4, 0, 2, 6],
+        [8, 12, 2, 0, 5],
+        [7, 3, 6, 5, 0],
+    ]
+    n = len(m)
+    order = optimize_visit_order([str(i) for i in range(n)], m, start_index=2, end_index=0)
+    assert order[0] == "2" and order[-1] == "0"
+    got = path_duration([int(x) for x in order], m)
+    mids = [i for i in range(n) if i not in (2, 0)]
+    best = min(path_duration([2, *p, 0], m) for p in itertools.permutations(mids))
+    assert got == best
+
+
+def test_end_equal_start_is_ignored() -> None:
+    # start==end(귀가 closed-tour)는 후속 슬라이스 → 종료 자유로 처리, start 만 고정한 결과와 동일
+    ids = ["C", "A", "D", "B"]
+    pos = [20, 0, 30, 10]
+    m = _line_matrix(pos)
+    order = optimize_visit_order(ids, m, start_index=0, end_index=0)
+    assert order == ["C", "D", "B", "A"]
+
+
+def test_large_n_fixed_end_respected() -> None:
+    random.seed(7)
+    n = 30  # 휴리스틱(NN + 2-opt) 경로
+    pos = list(range(n))
+    random.shuffle(pos)
+    m = _line_matrix(pos)
+    ids = [str(i) for i in range(n)]
+    order = optimize_visit_order(ids, m, start_index=0, end_index=5)
+    assert order[0] == "0" and order[-1] == "5"
+    assert sorted(order) == sorted(ids)
+
+
 def test_large_n_returns_valid_permutation_and_not_worse_than_identity() -> None:
     random.seed(42)
     n = 30  # Held-Karp 한계 초과 → 휴리스틱(NN + 2-opt) 경로

--- a/apps/ai-engine/tests/test_route_order_service.py
+++ b/apps/ai-engine/tests/test_route_order_service.py
@@ -271,6 +271,132 @@ async def test_partial_cache_miss_uses_per_leg(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_closed_tour_when_start_equals_end(monkeypatch) -> None:
+    # 시작=종료 앵커(숙소 귀가) → 복귀 비용 포함 closed-tour 최적화 (#275)
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    elements = _line_matrix_elements()
+
+    async def fake_post(self, url, json, headers):
+        return httpx.Response(200, json=elements, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=_stops(), start_instance_id="C", end_instance_id="C")
+    )
+    assert res.source == "google"
+    assert res.ordered_instance_ids[0] == "C"
+    assert sorted(res.ordered_instance_ids) == ["A", "B", "C", "D"]
+    # 일직선 순환 비용 = 2 × 전체 구간(30) = 60 (복귀 구간 포함)
+    assert res.total_duration_seconds == 60
+
+
+@pytest.mark.asyncio
+async def test_pinned_stop_keeps_position(monkeypatch) -> None:
+    # 고정 카드(pin): B(입력 3번째, 예약시각 없음) 는 그 위치 그대로 유지 (#275)
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    elements = _line_matrix_elements()
+
+    async def fake_post(self, url, json, headers):
+        return httpx.Response(200, json=elements, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    stops = _stops()
+    stops[3] = stops[3].model_copy(update={"pinned": True})  # B @ index 3
+    res = await svc.optimize_order(OptimizeOrderRequest(stops=stops))
+    assert res.ordered_instance_ids[3] == "B"
+    # B 마지막 고정 시 유일 최적: D → C → A → B (40)
+    assert res.ordered_instance_ids == ["D", "C", "A", "B"]
+    assert res.total_duration_seconds == 40
+
+
+@pytest.mark.asyncio
+async def test_constraints_wired_to_solver(monkeypatch) -> None:
+    # 예약시각/고정/체류시간이 제약 솔버 인자로 올바르게 전달되는지 (#275)
+    monkeypatch.setattr(svc, "_places_api_key", lambda: None)
+
+    captured = {}
+
+    def fake_solve(matrix, start=None, end=None, closed_tour=False,
+                   pinned_positions=None, time_windows=None, service_times=None):
+        captured.update(
+            start=start, end=end, closed_tour=closed_tour,
+            pins=pinned_positions, windows=time_windows, services=service_times,
+        )
+        return [1, 0, 3, 2]
+
+    monkeypatch.setattr(svc, "solve_constrained", fake_solve)
+
+    stops = _stops()
+    stops[0] = stops[0].model_copy(update={"reserved_time": "14:30", "duration_min": 90})
+    stops[3] = stops[3].model_copy(update={"pinned": True})
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=stops, start_instance_id="A")
+    )
+    assert captured["start"] == 1 and captured["end"] is None
+    assert captured["closed_tour"] is False
+    assert captured["windows"] == {0: (14 * 3600 + 30 * 60) - svc.DAY_START_SECONDS}
+    assert captured["pins"] == {3: 3}
+    assert captured["services"][0] == 90 * 60
+    assert res.ordered_instance_ids == ["A", "C", "B", "D"]
+
+
+@pytest.mark.asyncio
+async def test_infeasible_constraints_fall_back_to_unconstrained(monkeypatch) -> None:
+    # 제약 충돌(해 없음) 시 무제약 최적화로 폴백 — 귀가(복귀) 비용도 미포함 (#275)
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    elements = _line_matrix_elements()
+
+    async def fake_post(self, url, json, headers):
+        return httpx.Response(200, json=elements, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(svc, "solve_constrained", lambda *a, **k: None)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=_stops(), start_instance_id="C", end_instance_id="C")
+    )
+    assert res.ordered_instance_ids == ["C", "D", "B", "A"]  # 개방 경로 폴백
+    assert res.total_duration_seconds == 40
+
+
+def test_blend_walk_estimates_prefers_walk_on_short_legs() -> None:
+    # 약 90m 구간: DRIVE 600초보다 도보 추정이 빠르면 min 으로 대체 (#275 mode)
+    stops = [
+        OptimizeStop(instance_id="P", coordinates=Coordinates(lat=34.70, lng=135.5000)),
+        OptimizeStop(instance_id="Q", coordinates=Coordinates(lat=34.70, lng=135.5010)),
+    ]
+    matrix = [[0, 600], [600, 0]]
+    svc._blend_walk_estimates(stops, matrix)
+    walk = svc._walk_seconds(stops[0].coordinates, stops[1].coordinates)
+    assert walk < 600
+    assert matrix[0][1] == walk and matrix[1][0] == walk
+
+
+def test_blend_walk_keeps_drive_on_long_legs() -> None:
+    # 약 9km 구간: 도보 추정(수천 초)보다 DRIVE 600초가 빠르면 유지
+    stops = [
+        OptimizeStop(instance_id="P", coordinates=Coordinates(lat=34.70, lng=135.50)),
+        OptimizeStop(instance_id="Q", coordinates=Coordinates(lat=34.70, lng=135.60)),
+    ]
+    matrix = [[0, 600], [600, 0]]
+    svc._blend_walk_estimates(stops, matrix)
+    assert matrix[0][1] == 600 and matrix[1][0] == 600
+
+
+def test_reserved_seconds_parsing() -> None:
+    assert svc._reserved_seconds("14:30") == (14 * 3600 + 30 * 60) - svc.DAY_START_SECONDS
+    assert svc._reserved_seconds("09:00") == 0
+    assert svc._reserved_seconds("07:00") == 0  # 일정 시작 이전은 0 으로 클램프
+    assert svc._reserved_seconds("9:05") == 300
+    assert svc._reserved_seconds(None) is None
+    assert svc._reserved_seconds("") is None
+    assert svc._reserved_seconds("25:00") is None
+    assert svc._reserved_seconds("정오쯤") is None
+
+
+@pytest.mark.asyncio
 async def test_many_misses_use_route_matrix_not_per_leg(monkeypatch) -> None:
     # 미스가 임계(PER_LEG_MAX_PAIRS=8)보다 많으면 per-leg 대신 Route Matrix 1회 (cold 폭증 방지)
     monkeypatch.setattr(svc, "_places_api_key", lambda: "k")

--- a/apps/ai-engine/tests/test_route_order_service.py
+++ b/apps/ai-engine/tests/test_route_order_service.py
@@ -69,6 +69,23 @@ async def test_respects_start_with_google_matrix(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_respects_end_anchor(monkeypatch) -> None:
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    elements = _line_matrix_elements()
+
+    async def fake_post(self, url, json, headers):
+        return httpx.Response(200, json=elements, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    res = await svc.optimize_order(
+        OptimizeOrderRequest(stops=_stops(), end_instance_id="A")  # A(@0) 에서 종료 고정
+    )
+    assert res.source == "google"
+    assert res.ordered_instance_ids[-1] == "A"
+
+
+@pytest.mark.asyncio
 async def test_http_failure_falls_back_to_estimate(monkeypatch) -> None:
     monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
 

--- a/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
@@ -16,8 +16,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * SCR-04 동선 최적화 1차
@@ -29,6 +32,9 @@ import java.util.UUID;
 public class OptimizeService {
 
     private static final double COORD_PRECISION = 100_000.0; // 좌표 5자리(약 1m) 반올림
+
+    // time_constraint 자유 텍스트(예: "14:30 예약")에서 예약 시각 추출 — #275 시간창 제약
+    private static final Pattern RESERVED_TIME = Pattern.compile("([01]?\\d|2[0-3]):([0-5]\\d)");
 
     private final TripRepository tripRepository;
     private final PlaceCardRepository placeCardRepository;
@@ -51,13 +57,18 @@ public class OptimizeService {
 
             List<AiOptimizeOrderRequest.Stop> stops = new ArrayList<>();
             for (PlaceCard card : cards) {
+                boolean pinned = card.getTimeConstraint() != null && !card.getTimeConstraint().isBlank();
                 stops.add(new AiOptimizeOrderRequest.Stop(
                         card.getInstanceId().toString(),
-                        new AiOptimizeOrderRequest.Coord(round(card.getLat()), round(card.getLng()))));
+                        new AiOptimizeOrderRequest.Coord(round(card.getLat()), round(card.getLng())),
+                        pinned,
+                        reservedTime(card.getTimeConstraint()),
+                        card.getEstimatedDurationMin() == null ? null : card.getEstimatedDurationMin().intValue()));
             }
 
+            String start = startAnchor(cards);
             AiOptimizeOrderResponse response = aiEngineClient.optimizeOrder(
-                    new AiOptimizeOrderRequest(stops, accommodationAnchor(cards), flightEndAnchor(cards)));
+                    new AiOptimizeOrderRequest(stops, start, endAnchor(cards, start)));
 
             List<UUID> orderedIds = response.orderedInstanceIds().stream()
                     .map(UUID::fromString)
@@ -70,7 +81,45 @@ public class OptimizeService {
         return OptimizeResponse.of(tripId, days);
     }
 
-    /** Day 시작 앵커 — 숙소 카드가 있으면 그 instance_id, 없으면 null(시작 자유). */
+    /**
+     * Day 시작 앵커 — 도착 항공편(outbound, 첫날 공항 도착 후 시작)이 있으면 그 카드,
+     * 없으면 숙소 카드, 둘 다 없으면 null(시작 자유). #275
+     */
+    private static String startAnchor(List<PlaceCard> cards) {
+        String outbound = flightByRole(cards, "outbound");
+        return outbound != null ? outbound : accommodationAnchor(cards);
+    }
+
+    /**
+     * Day 종료 앵커 — 출발 항공편(inbound, 마지막날 출발 전 종료)이 있으면 그 카드,
+     * 없으면 역할 없는 교통 카드(시작 앵커 제외), 그것도 없으면 숙소(귀가 closed-tour:
+     * 시작 앵커와 같은 id 가 전달되면 AI 가 숙소 복귀 순환 경로로 최적화한다). #275
+     * (좌표 없는 항공 카드는 stops 에 없어 AI 가 무시)
+     */
+    private static String endAnchor(List<PlaceCard> cards, String startAnchor) {
+        String inbound = flightByRole(cards, "inbound");
+        if (inbound != null) {
+            return inbound;
+        }
+        for (PlaceCard card : cards) {
+            if ("transport".equals(card.getCategory())
+                    && !Objects.equals(card.getInstanceId().toString(), startAnchor)) {
+                return card.getInstanceId().toString();
+            }
+        }
+        return accommodationAnchor(cards);
+    }
+
+    private static String flightByRole(List<PlaceCard> cards, String role) {
+        for (PlaceCard card : cards) {
+            if ("transport".equals(card.getCategory()) && role.equals(card.getFlightRole())) {
+                return card.getInstanceId().toString();
+            }
+        }
+        return null;
+    }
+
+    /** 숙소 카드가 있으면 그 instance_id, 없으면 null. */
     private static String accommodationAnchor(List<PlaceCard> cards) {
         for (PlaceCard card : cards) {
             if ("accommodation".equals(card.getCategory())) {
@@ -80,17 +129,16 @@ public class OptimizeService {
         return null;
     }
 
-    /**
-     * Day 종료 앵커 — 교통(항공) 카드가 있으면 그 instance_id(마지막날 출발 전 종료), 없으면 null(종료 자유).
-     * 시작 앵커(숙소)와 카테고리가 달라 충돌하지 않는다. (좌표 없는 항공 카드는 stops 에 없어 AI 가 무시)
-     */
-    private static String flightEndAnchor(List<PlaceCard> cards) {
-        for (PlaceCard card : cards) {
-            if ("transport".equals(card.getCategory())) {
-                return card.getInstanceId().toString();
-            }
+    /** time_constraint 자유 텍스트에서 첫 "HH:MM" 을 추출해 정규화. 없으면 null. */
+    private static String reservedTime(String timeConstraint) {
+        if (timeConstraint == null) {
+            return null;
         }
-        return null;
+        Matcher m = RESERVED_TIME.matcher(timeConstraint);
+        if (!m.find()) {
+            return null;
+        }
+        return String.format("%02d:%02d", Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)));
     }
 
     /** RouteService.groupByDay 와 동일 기준: 제외 X, day 있음, 좌표 있음, day_order 정렬. */

--- a/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
@@ -129,7 +129,7 @@ public class OptimizeService {
         return null;
     }
 
-    /** time_constraint 자유 텍스트에서 첫 "HH:MM" 을 추출해 정규화. 없으면 null. */
+    /** time_constraint 자유 텍스트에서 첫 "HH:MM" 을 추출해 정규화. 없거나 파싱 불가면 null. */
     private static String reservedTime(String timeConstraint) {
         if (timeConstraint == null) {
             return null;
@@ -138,7 +138,11 @@ public class OptimizeService {
         if (!m.find()) {
             return null;
         }
-        return String.format("%02d:%02d", Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)));
+        try {
+            return String.format("%02d:%02d", Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)));
+        } catch (NumberFormatException e) {
+            return null; // 정규식상 도달 불가지만 정적 분석 만족용 방어
+        }
     }
 
     /** RouteService.groupByDay 와 동일 기준: 제외 X, day 있음, 좌표 있음, day_order 정렬. */

--- a/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
@@ -57,7 +57,7 @@ public class OptimizeService {
             }
 
             AiOptimizeOrderResponse response = aiEngineClient.optimizeOrder(
-                    new AiOptimizeOrderRequest(stops, accommodationAnchor(cards)));
+                    new AiOptimizeOrderRequest(stops, accommodationAnchor(cards), flightEndAnchor(cards)));
 
             List<UUID> orderedIds = response.orderedInstanceIds().stream()
                     .map(UUID::fromString)
@@ -74,6 +74,19 @@ public class OptimizeService {
     private static String accommodationAnchor(List<PlaceCard> cards) {
         for (PlaceCard card : cards) {
             if ("accommodation".equals(card.getCategory())) {
+                return card.getInstanceId().toString();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Day 종료 앵커 — 교통(항공) 카드가 있으면 그 instance_id(마지막날 출발 전 종료), 없으면 null(종료 자유).
+     * 시작 앵커(숙소)와 카테고리가 달라 충돌하지 않는다. (좌표 없는 항공 카드는 stops 에 없어 AI 가 무시)
+     */
+    private static String flightEndAnchor(List<PlaceCard> cards) {
+        for (PlaceCard card : cards) {
+            if ("transport".equals(card.getCategory())) {
                 return card.getInstanceId().toString();
             }
         }

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderRequest.java
@@ -6,7 +6,8 @@ import java.util.List;
 
 public record AiOptimizeOrderRequest(
         List<Stop> stops,
-        @JsonProperty("start_instance_id") String startInstanceId
+        @JsonProperty("start_instance_id") String startInstanceId,
+        @JsonProperty("end_instance_id") String endInstanceId
 ) {
 
     public record Coord(double lat, double lng) {}

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderRequest.java
@@ -14,6 +14,9 @@ public record AiOptimizeOrderRequest(
 
     public record Stop(
             @JsonProperty("instance_id") String instanceId,
-            Coord coordinates
+            Coord coordinates,
+            boolean pinned,
+            @JsonProperty("reserved_time") String reservedTime,
+            @JsonProperty("duration_min") Integer durationMin
     ) {}
 }

--- a/apps/backend/src/test/java/com/tripkey/domain/optimize/OptimizeServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/optimize/OptimizeServiceTest.java
@@ -102,6 +102,36 @@ class OptimizeServiceTest {
     }
 
     @Test
+    void optimizePassesFlightCardAsEndAnchor() {
+        UUID tripId = UUID.randomUUID();
+        UUID acc = UUID.randomUUID();
+        UUID place = UUID.randomUUID();
+        UUID flight = UUID.randomUUID();
+
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard accCard = card(acc, 1, (short) 0, 34.70, 135.50, "accommodation", false);
+        PlaceCard placeCard = card(place, 1, (short) 1, 34.71, 135.51, "place", false);
+        PlaceCard flightCard = card(flight, 1, (short) 2, 34.79, 135.44, "transport", false);
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(accCard, placeCard, flightCard));
+        when(aiEngineClient.optimizeOrder(any())).thenReturn(
+                new AiOptimizeOrderResponse(
+                        List.of(acc.toString(), place.toString(), flight.toString()), 1200, "google"));
+
+        optimizeService.optimize(tripId);
+
+        ArgumentCaptor<AiOptimizeOrderRequest> captor =
+                ArgumentCaptor.forClass(AiOptimizeOrderRequest.class);
+        verify(aiEngineClient).optimizeOrder(captor.capture());
+        AiOptimizeOrderRequest req = captor.getValue();
+        // 시작=숙소, 종료=항공(교통) 카드
+        assertThat(req.startInstanceId()).isEqualTo(acc.toString());
+        assertThat(req.endInstanceId()).isEqualTo(flight.toString());
+    }
+
+    @Test
     void skipsDaysWithFewerThanTwoStopsAndDoesNotCallAi() {
         UUID tripId = UUID.randomUUID();
         when(tripRepository.existsById(tripId)).thenReturn(true);

--- a/apps/backend/src/test/java/com/tripkey/domain/optimize/OptimizeServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/optimize/OptimizeServiceTest.java
@@ -52,6 +52,7 @@ class OptimizeServiceTest {
         lenient().when(c.getLng()).thenReturn(lng);
         lenient().when(c.getCategory()).thenReturn(category);
         lenient().when(c.getIsExcluded()).thenReturn(excluded);
+        lenient().when(c.getEstimatedDurationMin()).thenReturn(null); // Mockito 기본값(0) 방지
         return c;
     }
 
@@ -94,11 +95,85 @@ class OptimizeServiceTest {
         verify(aiEngineClient, times(1)).optimizeOrder(captor.capture());
         AiOptimizeOrderRequest req = captor.getValue();
         assertThat(req.startInstanceId()).isEqualTo(acc.toString());
+        // 항공편 없음 → 종료 앵커 = 숙소(시작과 동일) → AI 가 귀가 closed-tour 로 최적화 (#275)
+        assertThat(req.endInstanceId()).isEqualTo(acc.toString());
         assertThat(req.stops()).hasSize(3);
         // day_order 정렬: acc(0) → place1(1) → place2(2)
         assertThat(req.stops().get(0).instanceId()).isEqualTo(acc.toString());
         assertThat(req.stops().get(1).instanceId()).isEqualTo(p1.toString());
         assertThat(req.stops().get(2).instanceId()).isEqualTo(p2.toString());
+    }
+
+    @Test
+    void optimizePassesOutboundFlightAsStartAnchor() {
+        UUID tripId = UUID.randomUUID();
+        UUID acc = UUID.randomUUID();
+        UUID place = UUID.randomUUID();
+        UUID flight = UUID.randomUUID();
+
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard accCard = card(acc, 1, (short) 0, 34.70, 135.50, "accommodation", false);
+        PlaceCard placeCard = card(place, 1, (short) 1, 34.71, 135.51, "place", false);
+        PlaceCard flightCard = card(flight, 1, (short) 2, 34.79, 135.44, "transport", false);
+        lenient().when(flightCard.getFlightRole()).thenReturn("outbound"); // 첫날 도착편
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(accCard, placeCard, flightCard));
+        when(aiEngineClient.optimizeOrder(any())).thenReturn(
+                new AiOptimizeOrderResponse(
+                        List.of(flight.toString(), place.toString(), acc.toString()), 1500, "google"));
+
+        optimizeService.optimize(tripId);
+
+        ArgumentCaptor<AiOptimizeOrderRequest> captor =
+                ArgumentCaptor.forClass(AiOptimizeOrderRequest.class);
+        verify(aiEngineClient).optimizeOrder(captor.capture());
+        AiOptimizeOrderRequest req = captor.getValue();
+        // 도착 항공(outbound) = 시작 앵커, 숙소 = 종료 앵커(공항 도착 → 관광 → 숙소 체크인)
+        assertThat(req.startInstanceId()).isEqualTo(flight.toString());
+        assertThat(req.endInstanceId()).isEqualTo(acc.toString());
+    }
+
+    @Test
+    void optimizePassesPinAndReservedTimeConstraints() {
+        UUID tripId = UUID.randomUUID();
+        UUID p1 = UUID.randomUUID();
+        UUID p2 = UUID.randomUUID();
+        UUID p3 = UUID.randomUUID();
+
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+
+        PlaceCard reserved = card(p1, 1, (short) 0, 34.70, 135.50, "food", false);
+        lenient().when(reserved.getTimeConstraint()).thenReturn("14:30 예약");
+        lenient().when(reserved.getEstimatedDurationMin()).thenReturn((short) 90);
+        PlaceCard pinnedNoTime = card(p2, 1, (short) 1, 34.71, 135.51, "place", false);
+        lenient().when(pinnedNoTime.getTimeConstraint()).thenReturn("오후 늦게");
+        PlaceCard free = card(p3, 1, (short) 2, 34.72, 135.52, "place", false);
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(reserved, pinnedNoTime, free));
+        when(aiEngineClient.optimizeOrder(any())).thenReturn(
+                new AiOptimizeOrderResponse(
+                        List.of(p1.toString(), p2.toString(), p3.toString()), 900, "google"));
+
+        optimizeService.optimize(tripId);
+
+        ArgumentCaptor<AiOptimizeOrderRequest> captor =
+                ArgumentCaptor.forClass(AiOptimizeOrderRequest.class);
+        verify(aiEngineClient).optimizeOrder(captor.capture());
+        List<AiOptimizeOrderRequest.Stop> stops = captor.getValue().stops();
+        // 예약 시각 파싱: pinned + reserved_time + 체류시간
+        assertThat(stops.get(0).pinned()).isTrue();
+        assertThat(stops.get(0).reservedTime()).isEqualTo("14:30");
+        assertThat(stops.get(0).durationMin()).isEqualTo(90);
+        // HH:MM 없는 time_constraint → 위치 고정만 (reserved_time 없음)
+        assertThat(stops.get(1).pinned()).isTrue();
+        assertThat(stops.get(1).reservedTime()).isNull();
+        // 제약 없는 카드
+        assertThat(stops.get(2).pinned()).isFalse();
+        assertThat(stops.get(2).reservedTime()).isNull();
+        assertThat(stops.get(2).durationMin()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용

> 동선 최적화에 현실 제약(시작/종료 앵커·귀가·고정카드·예약시각·이동수단)을 반영해 최적화 품질을 높인다. 제약이 있을 때는 OR-tools 라우팅 솔버로 푼다.

- **시작/종료 앵커**: `start/end_instance_id` — 숙소 시작, 항공(교통) 카드 종료. 도착 항공(outbound)=첫날 시작 앵커, 출발 항공(inbound)=마지막날 종료 앵커
- **귀가 closed-tour**: 시작=종료 앵커(숙소)면 숙소 복귀 비용까지 포함한 순환 경로로 최적화
- **고정 카드(pin)**: `time_constraint` 있는 카드 — 예약시각(HH:MM) 파싱되면 time window, 아니면 현재 순번 고정
- **예약시각 time window**: OR-tools Time 차원으로 해당 시각 방문 고정(조기 도착 대기 허용, 지각 불능). 체류시간(`estimated_duration_min`)을 service time 으로 누적. 제약 충돌(해 없음) 시 무제약 폴백
- **이동수단(mode)**: 구간 비용을 min(DRIVE, 도보 추정 4.5km/h×우회 1.3) 블렌딩 — 추가 API 과금 0, 캐시는 DRIVE 원값 유지
- **OR-tools 전환**: 제약 있을 때만 사용, 무제약 경로는 기존 Held-Karp/2-opt 유지(회귀 없음). `ortools==9.12.4544` (9.13+는 protobuf 6.x 요구로 google-api-core 와 충돌)

**범위 제외(사유)**: 영업시간 time window 는 영업시간 데이터가 DB/API 어디에도 없어 제외 — Google Places 연동 + 마이그레이션이 필요해 #292 로 분리.

## 🔗 관련 이슈

closes #275

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (AI 125 passed / BE 전체 BUILD SUCCESSFUL)
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인 — 무제약 경로는 기존 솔버 그대로)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? (#275 Phase 2 전체)

## 👀 리뷰어에게

> - `route_order_constrained.py`: 자유 시작/종료를 0 비용 dummy 노드로 모델링하는 부분과, 고정 카드의 Order 차원(순번 누적값 == 원래 위치) 제약을 중점적으로 봐주세요.
> - 예약시각은 하루 시작 09:00 가정(`DAY_START_SECONDS`) 기준 상대 초로 변환합니다. 09:00 이전 예약은 0으로 클램프됩니다.
> - 해가 없는 제약 조합(예: 예약시각까지 도달 불가)은 `None` → 무제약 최적화 폴백이라 API 는 항상 결과를 반환합니다.
> - 백엔드 `endAnchor` 우선순위: inbound 항공 → 역할 없는 교통(시작 앵커 제외) → 숙소(귀가). 기존 동작(교통=종료)과 호환됩니다.

## 📸 스크린샷

> 없음 (UI 변경 없음)
