### PR TITLE
feat(ai): #274 캐시 pair 공유(verify→matrix) + 적중률·과금 모니터링

### DIFF
--- a/apps/ai-engine/app/services/route_matrix_cache.py
+++ b/apps/ai-engine/app/services/route_matrix_cache.py
@@ -43,6 +43,27 @@ def pair_key(o_lat: float, o_lng: float, d_lat: float, d_lng: float, mode: str =
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()
 
 
+def build_row(
+    o_lat: float,
+    o_lng: float,
+    d_lat: float,
+    d_lng: float,
+    duration_seconds: int,
+    distance_meters,
+) -> dict:
+    """put_durations 적재용 row(DRIVE). 좌표는 pair_key 와 동일 기준으로 반올림해 저장한다."""
+    return {
+        "pair_key": pair_key(o_lat, o_lng, d_lat, d_lng),
+        "origin_lat": round_coord(o_lat),
+        "origin_lng": round_coord(o_lng),
+        "dest_lat": round_coord(d_lat),
+        "dest_lng": round_coord(d_lng),
+        "mode": MODE,
+        "duration_seconds": duration_seconds,
+        "distance_meters": distance_meters,
+    }
+
+
 def _headers() -> dict:
     return {
         "apikey": SUPABASE_SERVICE_ROLE_KEY,

--- a/apps/ai-engine/app/services/route_optimizer.py
+++ b/apps/ai-engine/app/services/route_optimizer.py
@@ -3,6 +3,10 @@
 설계 노트: 기존 destination_search/core_parse 와 동일하게 googlemaps 라이브러리
 대신 httpx 로 신형 Routes v1 REST 를 직접 호출한다. walking/transit/driving 을
 모두 조회해 duration 최소 모드 1개를 반환하고, 실패한 leg 는 직선거리 추정 폴백.
+
+#274 pair 공유: 어차피 3모드를 호출하므로 그중 DRIVE 결과를 optimize 캐시
+(route_matrix_cache, DRIVE 전용)에 교차 적재한다 — 추가 호출 0, 메트릭 충돌 0.
+(역방향 matrix→legs 공유는 verify 의 best-mode 의미를 깨므로 하지 않는다.)
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ import httpx
 from app.fallback.estimated_route import estimate_leg
 from app.schemas.parse import Coordinates
 from app.schemas.route import RouteLeg, RouteLegResult, RouteRequest, RouteResponse
+from app.services import route_matrix_cache
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +79,8 @@ async def _call_routes_api(
     return {"duration_seconds": duration, "distance_meters": int(distance)}
 
 
-async def _optimize_leg(leg: RouteLeg, api_key: str) -> RouteLegResult:
+async def _optimize_leg(leg: RouteLeg, api_key: str) -> tuple[RouteLegResult, dict | None]:
+    """leg 의 best-mode 결과와, 함께 얻은 DRIVE 결과의 matrix 캐시 row(없으면 None)."""
     candidates: list[tuple[str, dict]] = []
     for mode in _TRAVEL_MODES:
         result = await _call_routes_api(leg.origin, leg.destination, mode, api_key)
@@ -86,7 +92,18 @@ async def _optimize_leg(leg: RouteLeg, api_key: str) -> RouteLegResult:
             leg.from_instance_id,
             leg.to_instance_id,
         )
-        return estimate_leg(leg)
+        return estimate_leg(leg), None
+
+    # #274 pair 공유 — DRIVE 후보는 optimize 캐시 row 로 변환(적재는 호출 측에서 일괄)
+    drive = dict(candidates).get("DRIVE")
+    drive_row = None
+    if drive is not None:
+        drive_row = route_matrix_cache.build_row(
+            leg.origin.lat, leg.origin.lng,
+            leg.destination.lat, leg.destination.lng,
+            drive["duration_seconds"], drive["distance_meters"],
+        )
+
     best_mode, best = min(candidates, key=lambda c: c[1]["duration_seconds"])
     return RouteLegResult(
         from_instance_id=leg.from_instance_id,
@@ -95,12 +112,16 @@ async def _optimize_leg(leg: RouteLeg, api_key: str) -> RouteLegResult:
         distance_meters=best["distance_meters"],
         mode=_MODE_NAMES[best_mode],
         source="google",
-    )
+    ), drive_row
 
 
 async def optimize_routes(request: RouteRequest) -> RouteResponse:
     api_key = _places_api_key()
     if not api_key:
+        logger.info(
+            "verify legs stats | legs=%d google=0 estimated=%d drive_rows_shared=0 (no api key)",
+            len(request.legs), len(request.legs),
+        )
         return RouteResponse(legs=[estimate_leg(leg) for leg in request.legs])
     results = await asyncio.gather(
         *(_optimize_leg(leg, api_key) for leg in request.legs),
@@ -108,6 +129,7 @@ async def optimize_routes(request: RouteRequest) -> RouteResponse:
     )
 
     legs: list[RouteLegResult] = []
+    drive_rows: list[dict] = []
     for leg, result in zip(request.legs, results):
         if isinstance(result, Exception):
             logger.warning(
@@ -118,5 +140,21 @@ async def optimize_routes(request: RouteRequest) -> RouteResponse:
             )
             legs.append(estimate_leg(leg))
             continue
-        legs.append(result)
+        leg_result, drive_row = result
+        legs.append(leg_result)
+        if drive_row is not None:
+            drive_rows.append(drive_row)
+
+    # #274 pair 공유: verify 미스에서 얻은 DRIVE pair 를 optimize 캐시에 교차 적재.
+    # 실패해도 무해(put_durations 내부 에러 무해화) — verify 응답에는 영향 없음.
+    shared = 0
+    if drive_rows and route_matrix_cache.cache_enabled():
+        await route_matrix_cache.put_durations(drive_rows)
+        shared = len(drive_rows)
+
+    google_count = sum(1 for leg in legs if leg.source == "google")
+    logger.info(
+        "verify legs stats | legs=%d google=%d estimated=%d drive_rows_shared=%d",
+        len(legs), google_count, len(legs) - google_count, shared,
+    )
     return RouteResponse(legs=legs)

--- a/apps/ai-engine/app/services/route_order_service.py
+++ b/apps/ai-engine/app/services/route_order_service.py
@@ -174,19 +174,39 @@ async def _build_matrix(
     else:
         missing = list(pair_keys.keys())
 
+    # 적중률/과금 모니터링(#274): billed_elements 는 Google 과금 단위
+    # (per-leg = 호출 pair 수, Route Matrix = n×n 요소 수)
+    total_pairs, hits = len(pair_keys), len(pair_keys) - len(missing)
+
     # 2) 전부 캐시 히트 → Google 호출 없음
     if not missing:
+        logger.info(
+            "route_matrix stats | pairs=%d cache_hits=%d misses=0 fill=none billed_elements=0",
+            total_pairs, hits,
+        )
         return matrix, "google"
 
     # 3) 키 없음 → 남은 pair 는 추정 유지
     if not api_key:
+        logger.info(
+            "route_matrix stats | pairs=%d cache_hits=%d misses=%d fill=skip(no-key) billed_elements=0",
+            total_pairs, hits, len(missing),
+        )
         return matrix, "google" if used_google else "estimated"
 
     # 4) 하이브리드: 빠진 pair 가 적으면 per-leg, 많으면 Route Matrix 1회
     if len(missing) > PER_LEG_MAX_PAIRS:
         filled = await _fill_via_route_matrix(stops, api_key, matrix, pair_keys)
+        logger.info(
+            "route_matrix stats | pairs=%d cache_hits=%d misses=%d fill=matrix billed_elements=%d",
+            total_pairs, hits, len(missing), n * n if filled else 0,
+        )
     else:
         filled = await _fill_via_per_leg(stops, api_key, matrix, pair_keys, missing)
+        logger.info(
+            "route_matrix stats | pairs=%d cache_hits=%d misses=%d fill=per-leg billed_elements=%d",
+            total_pairs, hits, len(missing), len(missing),
+        )
 
     return matrix, "google" if (used_google or filled) else "estimated"
 

--- a/apps/ai-engine/tests/test_route_optimizer.py
+++ b/apps/ai-engine/tests/test_route_optimizer.py
@@ -121,6 +121,95 @@ async def test_optimize_falls_back_when_no_api_key(monkeypatch) -> None:
     assert resp.legs[0].source == "estimated"
 
 
+from app.services import route_matrix_cache
+
+
+def _leg_request() -> RouteRequest:
+    return RouteRequest(legs=[RouteLeg(
+        from_instance_id="a", to_instance_id="b",
+        origin=Coordinates(lat=34.70, lng=135.50),
+        destination=Coordinates(lat=34.67, lng=135.49),
+    )])
+
+
+@pytest.mark.asyncio
+async def test_verify_shares_drive_pair_to_matrix_cache(monkeypatch) -> None:
+    # #274 pair 공유: verify 미스에서 얻은 DRIVE 결과가 route_matrix_cache 에 교차 적재된다
+    async def fake_call(origin, destination, travel_mode, api_key):
+        table = {
+            "WALK": {"duration_seconds": 3000, "distance_meters": 4000},
+            "TRANSIT": {"duration_seconds": 1320, "distance_meters": 5400},
+            "DRIVE": {"duration_seconds": 1500, "distance_meters": 5200},
+        }
+        return table[travel_mode]
+
+    monkeypatch.setattr(route_optimizer, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_optimizer, "_call_routes_api", fake_call)
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    written: list[dict] = []
+
+    async def capture_put(rows):
+        written.extend(rows)
+
+    monkeypatch.setattr(route_matrix_cache, "put_durations", capture_put)
+
+    resp = await route_optimizer.optimize_routes(_leg_request())
+
+    # 응답은 best-mode(transit) 그대로 — 공유 적재가 verify 결과를 바꾸면 안 됨
+    assert resp.legs[0].mode == "transit"
+    assert resp.legs[0].duration_seconds == 1320
+    # 캐시에는 DRIVE 메트릭(1500)이 적재된다 (best-mode 1320 이 아니라)
+    assert len(written) == 1
+    row = written[0]
+    assert row["mode"] == route_matrix_cache.MODE
+    assert row["duration_seconds"] == 1500
+    assert row["distance_meters"] == 5200
+    assert row["pair_key"] == route_matrix_cache.pair_key(34.70, 135.50, 34.67, 135.49)
+
+
+@pytest.mark.asyncio
+async def test_no_share_when_cache_disabled(monkeypatch) -> None:
+    async def fake_call(origin, destination, travel_mode, api_key):
+        return {"duration_seconds": 600, "distance_meters": 2000}
+
+    monkeypatch.setattr(route_optimizer, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_optimizer, "_call_routes_api", fake_call)
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: False)
+
+    async def must_not_put(rows):
+        raise AssertionError("캐시 비활성 시 교차 적재하면 안 됨")
+
+    monkeypatch.setattr(route_matrix_cache, "put_durations", must_not_put)
+
+    resp = await route_optimizer.optimize_routes(_leg_request())
+    assert resp.legs[0].source == "google"
+
+
+@pytest.mark.asyncio
+async def test_no_share_when_drive_call_fails(monkeypatch) -> None:
+    # DRIVE 만 실패 → best-mode 는 정상 반환하되 matrix 캐시 적재는 없어야 함
+    async def fake_call(origin, destination, travel_mode, api_key):
+        if travel_mode == "DRIVE":
+            return None
+        return {"duration_seconds": 900, "distance_meters": 1500}
+
+    monkeypatch.setattr(route_optimizer, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_optimizer, "_call_routes_api", fake_call)
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    written: list[dict] = []
+
+    async def capture_put(rows):
+        written.extend(rows)
+
+    monkeypatch.setattr(route_matrix_cache, "put_durations", capture_put)
+
+    resp = await route_optimizer.optimize_routes(_leg_request())
+    assert resp.legs[0].source == "google"
+    assert written == []
+
+
 from httpx import ASGITransport, AsyncClient
 
 

--- a/apps/ai-engine/tests/test_route_order_service.py
+++ b/apps/ai-engine/tests/test_route_order_service.py
@@ -287,3 +287,64 @@ async def test_many_misses_use_route_matrix_not_per_leg(monkeypatch) -> None:
     assert res.source == "google"
     assert res.ordered_instance_ids == ["C", "D", "B", "A"]
     assert res.total_duration_seconds == 40
+
+
+@pytest.mark.asyncio
+async def test_matrix_stats_logged_on_full_hit(monkeypatch, caplog) -> None:
+    # 적중률/과금 모니터링(#274): 전체 히트 시 stats 로그(cache_hits=전체, billed=0)
+    import logging
+
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    stops = _stops()
+    cached = {}
+    for i in range(4):
+        for j in range(4):
+            if i != j:
+                a, b = stops[i].coordinates, stops[j].coordinates
+                cached[route_matrix_cache.pair_key(a.lat, a.lng, b.lat, b.lng)] = 100
+
+    async def fake_get_durations(keys):
+        return cached
+
+    monkeypatch.setattr(route_matrix_cache, "get_durations", fake_get_durations)
+
+    with caplog.at_level(logging.INFO, logger="app.services.route_order_service"):
+        await svc.optimize_order(OptimizeOrderRequest(stops=stops))
+
+    stats = [r.getMessage() for r in caplog.records if "route_matrix stats" in r.getMessage()]
+    assert len(stats) == 1
+    assert "pairs=12 cache_hits=12 misses=0 fill=none billed_elements=0" in stats[0]
+
+
+@pytest.mark.asyncio
+async def test_matrix_stats_logged_on_per_leg_fill(monkeypatch, caplog) -> None:
+    # 부분 미스 per-leg 경로: misses/billed_elements 가 빠진 pair 수와 일치해야 한다
+    import logging
+
+    monkeypatch.setattr(svc, "_places_api_key", lambda: "k")
+    monkeypatch.setattr(route_matrix_cache, "cache_enabled", lambda: True)
+
+    async def partial_get(keys):
+        ks = list(keys)
+        return {k: 600 for k in ks[:-2]}  # 마지막 2개만 미스
+
+    monkeypatch.setattr(route_matrix_cache, "get_durations", partial_get)
+
+    async def noop_put(rows):
+        return None
+
+    monkeypatch.setattr(route_matrix_cache, "put_durations", noop_put)
+
+    async def fake_routes(origin, destination, travel_mode, api_key):
+        return {"duration_seconds": 300, "distance_meters": 1000}
+
+    monkeypatch.setattr(svc, "_call_routes_api", fake_routes)
+
+    with caplog.at_level(logging.INFO, logger="app.services.route_order_service"):
+        await svc.optimize_order(OptimizeOrderRequest(stops=_stops()))
+
+    stats = [r.getMessage() for r in caplog.records if "route_matrix stats" in r.getMessage()]
+    assert len(stats) == 1
+    assert "pairs=12 cache_hits=10 misses=2 fill=per-leg billed_elements=2" in stats[0]


### PR DESCRIPTION
## 📝 작업 내용

> #274 마무리 — verify/optimize 캐시 pair 공유와 캐시 적중률·과금 모니터링을 추가한다.

- **pair 공유 (legs→matrix 단방향):** verify(`/route`)는 어차피 WALK/TRANSIT/DRIVE 3모드를 호출하므로, 그중 **DRIVE 결과를 `route_matrix_cache`에 교차 적재**한다. 추가 API 호출 0, 메트릭 충돌 0. verify 직후 동일 Day 재최적화 시 인접 pair 가 캐시 히트된다.
  - 역방향(matrix→legs) 공유는 verify 의 best-mode 의미를 깨므로 **설계상 제외** — "메트릭 통일(best-mode vs DRIVE)" 결정 자체가 불필요해짐
  - 교차 적재 실패는 무해화(`put_durations` 내부 처리) — verify 응답에 영향 없음
- **모니터링(구조화 로그):**
  - `route_matrix stats | pairs=.. cache_hits=.. misses=.. fill=none|per-leg|matrix|skip(no-key) billed_elements=..` — 적중률 = cache_hits/pairs, 과금 proxy = billed_elements(per-leg=호출 pair 수, Route Matrix=n×n 요소 수)
  - `verify legs stats | legs=.. google=.. estimated=.. drive_rows_shared=..`
- `route_matrix_cache.build_row()` 공용 row 빌더 추가

## 🔗 관련 이슈

closes #274

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (AI 107 passed — 신규 5개 포함)
- [x] 기존 기능이 깨지지 않았나요? (verify 응답/최적화 결과 불변 — 캐시 적재·로그만 추가)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> - `_optimize_leg` 반환이 `(RouteLegResult, drive_row|None)` 튜플로 바뀌었습니다. 외부(라우터) 계약은 그대로입니다.
> - DB 변경 없음 — 기존 `route_matrix_cache`(V014) 테이블에 쓰기 경로만 하나 추가된 것입니다.
> - develop 기반 브랜치라 #291(#275)과 독립적으로 머지 가능합니다. 둘 다 `route_order_service.py`를 건드리지만 다른 영역(hunk)이라 충돌 없을 것으로 예상, 나중에 머지되는 쪽에서 확인 필요.

## 📸 스크린샷

> 없음 (UI 변경 없음)
