### PR TITLE
feat: #292 동선 최적화 영업시간 time window 반영 (Places 영업시간 연동)

### DIFF
--- a/apps/ai-engine/app/schemas/parse.py
+++ b/apps/ai-engine/app/schemas/parse.py
@@ -94,6 +94,8 @@ class CardResponse(BaseModel):
     coordinates: Optional[Coordinates] = None
     location: Optional[str] = None
     address: Optional[str] = None
+    # 영업시간 {요일(0=일~6=토): [["HH:MM","HH:MM"], ...]} — Places regularOpeningHours 정규화(#292)
+    opening_hours: Optional[dict[str, list[list[str]]]] = None
 
     time_constraint: Optional[str] = None
     question_text: Optional[str] = None

--- a/apps/ai-engine/app/schemas/route.py
+++ b/apps/ai-engine/app/schemas/route.py
@@ -53,6 +53,10 @@ class OptimizeStop(BaseModel):
     reserved_time: str | None = None
     # 체류 시간(분, estimated_duration_min). 예약시각 제약 계산의 service time 으로 사용.
     duration_min: int | None = None
+    # 해당 Day 요일의 영업시간 "HH:MM" (BE 가 opening_hours 에서 추출). 방문 시작이 이 구간 안이어야 한다(#292).
+    # 예약시각이 있으면 예약이 우선(사용자의 명시적 약속). 둘 다 None 이면 제약 없음.
+    open_time: str | None = None
+    close_time: str | None = None
 
 
 class OptimizeOrderRequest(BaseModel):

--- a/apps/ai-engine/app/services/core_parse.py
+++ b/apps/ai-engine/app/services/core_parse.py
@@ -44,6 +44,9 @@ PLACES_FIELD_MASK = ",".join(
         "places.formattedAddress",
         "places.location",
         "places.shortFormattedAddress",
+        # #292 영업시간(time window). Advanced SKU 필드 — 과금 등급 상승, 팀 합의됨.
+        # 필드 추가로 mask_version 이 바뀌어 기존 places_cache 는 1회 전체 미스(재적재)된다.
+        "places.regularOpeningHours",
     ]
 )
 PLACES_CACHE_SHAPE = f"{PLACES_FIELD_MASK}|ps5"
@@ -828,6 +831,36 @@ async def _search_place(query: str, api_key: str, region_code: str | None = None
         return response.json()
 
 
+def _normalize_opening_hours(raw: dict | None) -> dict[str, list[list[str]]] | None:
+    """Google regularOpeningHours → {요일(0=일~6=토): [["HH:MM","HH:MM"], ...]} 정규화(#292).
+
+    - close 없는 단일 period 는 24시간 영업(Google 규약) → 전 요일 00:00~23:59.
+    - 자정을 넘기는 구간(close.day != open.day)은 open 요일의 23:59 로 절단한다.
+    - periods 가 없거나 형식이 다르면 None(영업시간 제약 없음).
+    """
+    if not raw:
+        return None
+    periods = raw.get("periods")
+    if not isinstance(periods, list) or not periods:
+        return None
+    result: dict[str, list[list[str]]] = {}
+    for period in periods:
+        open_ = (period or {}).get("open") or {}
+        day = open_.get("day")
+        if day is None:
+            continue
+        close = period.get("close") or {}
+        if not close:
+            return {str(d): [["00:00", "23:59"]] for d in range(7)}
+        start = f"{int(open_.get('hour', 0)):02d}:{int(open_.get('minute', 0)):02d}"
+        if close.get("day") == day:
+            end = f"{int(close.get('hour', 0)):02d}:{int(close.get('minute', 0)):02d}"
+        else:
+            end = "23:59"
+        result.setdefault(str(int(day)), []).append([start, end])
+    return result or None
+
+
 def _apply_place_match(card: ParsedCard, place: dict) -> ParsedCard:
     location = place.get("location") or {}
     coordinates = None
@@ -842,6 +875,7 @@ def _apply_place_match(card: ParsedCard, place: dict) -> ParsedCard:
             "coordinates": coordinates,
             "address": place.get("formattedAddress"),
             "location": resolved_location,
+            "opening_hours": _normalize_opening_hours(place.get("regularOpeningHours")),
         }
     )
 

--- a/apps/ai-engine/app/services/route_order_constrained.py
+++ b/apps/ai-engine/app/services/route_order_constrained.py
@@ -5,8 +5,9 @@
 
 - closed_tour: start 에서 출발해 모든 정점을 돌고 start 로 복귀(숙소 귀가).
 - pinned_positions: {노드: 원래 위치} — 해당 노드를 방문 순서상 그 위치에 고정.
-- time_windows: {노드: 예약시각(일정 시작 기준 초)} — 해당 시각에 정확히 방문 시작
-  (일찍 도착하면 대기(slack), 늦으면 불능). service_times 가 체류 시간으로 누적된다.
+- time_windows: {노드: 방문 시작 시각 제약(일정 시작 기준 초)} — int 는 예약시각 고정 [t, t],
+  (earliest, latest) 튜플은 영업시간 구간 창(#292). 일찍 도착하면 대기(slack), 창 밖이면 불능.
+  service_times 가 체류 시간으로 누적된다.
 - 자유 시작/종료는 0 비용 dummy 노드로 모델링한다(개방 경로 표준 기법).
 
 해가 없으면(제약 충돌) None 을 반환한다 — 호출 측이 무제약 폴백을 수행한다.
@@ -29,15 +30,22 @@ def solve_constrained(
     end: int | None = None,
     closed_tour: bool = False,
     pinned_positions: dict[int, int] | None = None,
-    time_windows: dict[int, int] | None = None,
+    time_windows: dict[int, int | tuple[int, int]] | None = None,
     service_times: list[int] | None = None,
 ) -> list[int] | None:
-    """제약을 만족하는 최소 이동시간 방문 순서(인덱스). 해가 없으면 None."""
+    """제약을 만족하는 최소 이동시간 방문 순서(인덱스). 해가 없으면 None.
+
+    time_windows 값은 방문 시작 시각 제약 — int 면 그 시각 고정(예약 [t, t]),
+    (earliest, latest) 튜플이면 구간 창(영업시간 #292).
+    """
     n = len(matrix)
     if n <= 1:
         return list(range(n))
     pinned_positions = pinned_positions or {}
-    time_windows = time_windows or {}
+    time_windows = {
+        node: (w, w) if isinstance(w, int) else (int(w[0]), int(w[1]))
+        for node, w in (time_windows or {}).items()
+    }
     service_times = service_times or [0] * n
 
     if closed_tour and start is None:
@@ -100,8 +108,8 @@ def solve_constrained(
             time_cb, DAY_HORIZON_SECONDS, DAY_HORIZON_SECONDS, True, "Time"
         )
         time_dim = routing.GetDimensionOrDie("Time")
-        for node, at in time_windows.items():
-            time_dim.CumulVar(manager.NodeToIndex(node)).SetRange(at, at)
+        for node, (earliest, latest) in time_windows.items():
+            time_dim.CumulVar(manager.NodeToIndex(node)).SetRange(earliest, latest)
 
     params = pywrapcp.DefaultRoutingSearchParameters()
     params.first_solution_strategy = (

--- a/apps/ai-engine/app/services/route_order_service.py
+++ b/apps/ai-engine/app/services/route_order_service.py
@@ -250,20 +250,42 @@ async def _build_matrix(
     return matrix, "google" if (used_google or filled) else "estimated"
 
 
+def _opening_window(stop: OptimizeStop) -> tuple[int, int] | None:
+    """영업시간 [open, close] → 일정 시작 기준 초 구간(#292). 유효하지 않으면 None(제약 없음).
+
+    close 가 일정 시작(09:00) 이전이거나 open 이상이 아니면 하루 관점에서 의미 없는 창 → 제약 생략.
+    """
+    if stop.open_time is None or stop.close_time is None:
+        return None
+    open_sec = _reserved_seconds(stop.open_time)
+    close_sec = _reserved_seconds(stop.close_time)
+    if open_sec is None or close_sec is None or close_sec <= 0 or close_sec <= open_sec:
+        return None
+    return open_sec, close_sec
+
+
 def _collect_constraints(
     request: OptimizeOrderRequest, start_index: int | None, end_index: int | None
-) -> tuple[dict[int, int], dict[int, int], list[int]]:
-    """stops 에서 고정 위치/예약시각/체류시간 제약을 추출한다(앵커는 이미 고정이라 제외)."""
+) -> tuple[dict[int, int], dict[int, tuple[int, int]], list[int]]:
+    """stops 에서 고정 위치/시간창(예약·영업시간)/체류시간 제약을 추출한다(앵커는 이미 고정이라 제외).
+
+    time_windows 값은 방문 시작 시각의 (earliest, latest) 구간 — 예약은 [t, t] 고정,
+    영업시간은 [open, close] 구간(#292). 예약이 있으면 예약이 우선한다.
+    """
     pinned_positions: dict[int, int] = {}
-    time_windows: dict[int, int] = {}
+    time_windows: dict[int, tuple[int, int]] = {}
     service_times = [(s.duration_min or 0) * 60 for s in request.stops]
     for i, stop in enumerate(request.stops):
         if i == start_index or i == end_index:
             continue
         reserved = _reserved_seconds(stop.reserved_time)
         if reserved is not None:
-            time_windows[i] = reserved
-        elif stop.pinned:
+            time_windows[i] = (reserved, reserved)
+            continue
+        window = _opening_window(stop)
+        if window is not None:
+            time_windows[i] = window
+        if stop.pinned:
             pinned_positions[i] = i  # BE 가 day_order 순으로 보내므로 입력 인덱스 = 원래 위치
     return pinned_positions, time_windows, service_times
 

--- a/apps/ai-engine/tests/test_card_parse.py
+++ b/apps/ai-engine/tests/test_card_parse.py
@@ -246,3 +246,46 @@ async def test_card_parse_endpoint_can_return_non_confirmed_card(monkeypatch: py
     assert body["classification"] == "undecided"
     assert body["placement_status"] == "needs_input"
     assert body["question_text"]
+
+
+# ── #292 영업시간 정규화 ─────────────────────────────────────
+
+
+def test_normalize_opening_hours_basic() -> None:
+    from app.services.core_parse import _normalize_opening_hours
+
+    raw = {
+        "periods": [
+            {"open": {"day": 1, "hour": 10, "minute": 0}, "close": {"day": 1, "hour": 18, "minute": 30}},
+            {"open": {"day": 1, "hour": 19, "minute": 0}, "close": {"day": 1, "hour": 22, "minute": 0}},
+            {"open": {"day": 2, "hour": 9, "minute": 0}, "close": {"day": 2, "hour": 17, "minute": 0}},
+        ]
+    }
+    got = _normalize_opening_hours(raw)
+    assert got == {
+        "1": [["10:00", "18:30"], ["19:00", "22:00"]],
+        "2": [["09:00", "17:00"]],
+    }
+
+
+def test_normalize_opening_hours_overnight_truncated() -> None:
+    from app.services.core_parse import _normalize_opening_hours
+
+    # 금요일 18:00 ~ 토요일 02:00 → open 요일(5)의 23:59 로 절단
+    raw = {"periods": [{"open": {"day": 5, "hour": 18, "minute": 0}, "close": {"day": 6, "hour": 2, "minute": 0}}]}
+    assert _normalize_opening_hours(raw) == {"5": [["18:00", "23:59"]]}
+
+
+def test_normalize_opening_hours_24h_and_invalid() -> None:
+    from app.services.core_parse import _normalize_opening_hours
+
+    # close 없는 단일 period = 24시간 영업 → 전 요일 00:00~23:59
+    raw_24h = {"periods": [{"open": {"day": 0, "hour": 0, "minute": 0}}]}
+    got = _normalize_opening_hours(raw_24h)
+    assert got is not None and set(got) == {str(d) for d in range(7)}
+    assert got["3"] == [["00:00", "23:59"]]
+
+    assert _normalize_opening_hours(None) is None
+    assert _normalize_opening_hours({}) is None
+    assert _normalize_opening_hours({"periods": []}) is None
+    assert _normalize_opening_hours({"weekdayDescriptions": ["..."]}) is None

--- a/apps/ai-engine/tests/test_route_order_constrained.py
+++ b/apps/ai-engine/tests/test_route_order_constrained.py
@@ -130,3 +130,41 @@ def test_end_anchor_only_with_window() -> None:
     order = solve_constrained(m, end=0, time_windows={2: 40})
     assert order is not None
     assert order[-1] == 0 and sorted(order) == [0, 1, 2, 3]
+
+
+def test_window_range_allows_span_and_blocks_outside() -> None:
+    # 영업시간 구간 창(#292): 방문 시작이 [open, close] 안이면 허용, 밖이면 불능
+    # S(0)→A(1)=100, A→B(2)=100. B 영업 [150, 300] → S,A,B(도착 200) 허용
+    m = [
+        [0, 100, 250],
+        [100, 0, 100],
+        [250, 100, 0],
+    ]
+    order = solve_constrained(m, start=0, time_windows={2: (150, 300)})
+    assert order == [0, 1, 2]
+
+    # B 영업 [0, 150] → S,A,B 는 도착 200 > 150 불능, S→B 직행(250)도 불능 → 해 없음
+    assert solve_constrained(m, start=0, time_windows={2: (0, 150)}) is None
+
+
+def test_window_range_forces_early_visit() -> None:
+    # 일찍 닫는 가게는 뒤로 미룰 수 없다: B(2) 창 [0, 120] → S→B 먼저(100) 방문 강제
+    m = [
+        [0, 100, 100],
+        [100, 0, 100],
+        [100, 100, 0],
+    ]
+    order = solve_constrained(m, start=0, time_windows={2: (0, 120)})
+    assert order is not None and order[1] == 2  # B 를 첫 방문지로
+
+
+def test_int_window_still_means_fixed_time() -> None:
+    # 하위호환: int 는 여전히 [t, t] 예약 고정으로 동작
+    m = [
+        [0, 60, 5, 50],
+        [60, 0, 10, 50],
+        [60, 60, 0, 5],
+        [60, 60, 50, 0],
+    ]
+    assert solve_constrained(m, start=0, time_windows={1: 60}) == [0, 1, 2, 3]
+    assert solve_constrained(m, start=0, time_windows={1: (60, 60)}) == [0, 1, 2, 3]

--- a/apps/ai-engine/tests/test_route_order_service.py
+++ b/apps/ai-engine/tests/test_route_order_service.py
@@ -330,13 +330,19 @@ async def test_constraints_wired_to_solver(monkeypatch) -> None:
 
     stops = _stops()
     stops[0] = stops[0].model_copy(update={"reserved_time": "14:30", "duration_min": 90})
+    stops[2] = stops[2].model_copy(update={"open_time": "10:00", "close_time": "18:00"})
     stops[3] = stops[3].model_copy(update={"pinned": True})
     res = await svc.optimize_order(
         OptimizeOrderRequest(stops=stops, start_instance_id="A")
     )
     assert captured["start"] == 1 and captured["end"] is None
     assert captured["closed_tour"] is False
-    assert captured["windows"] == {0: (14 * 3600 + 30 * 60) - svc.DAY_START_SECONDS}
+    reserved = (14 * 3600 + 30 * 60) - svc.DAY_START_SECONDS
+    # 예약 = [t, t] 고정, 영업시간 = [open, close] 구간 창 (#292)
+    assert captured["windows"] == {
+        0: (reserved, reserved),
+        2: (3600, 9 * 3600),  # 10:00~18:00 → 09:00 기준 +1h ~ +9h
+    }
     assert captured["pins"] == {3: 3}
     assert captured["services"][0] == 90 * 60
     assert res.ordered_instance_ids == ["A", "C", "B", "D"]
@@ -491,3 +497,42 @@ async def test_matrix_stats_logged_on_per_leg_fill(monkeypatch, caplog) -> None:
     stats = [r.getMessage() for r in caplog.records if "route_matrix stats" in r.getMessage()]
     assert len(stats) == 1
     assert "pairs=12 cache_hits=10 misses=2 fill=per-leg billed_elements=2" in stats[0]
+
+
+def test_opening_window_parsing() -> None:
+    # 영업시간 → 일정 시작(09:00) 기준 초 구간. 유효하지 않으면 None (#292)
+    def stop(open_time, close_time):
+        return OptimizeStop(
+            instance_id="x", coordinates=Coordinates(lat=1.0, lng=2.0),
+            open_time=open_time, close_time=close_time,
+        )
+
+    assert svc._opening_window(stop("10:00", "18:00")) == (3600, 9 * 3600)
+    assert svc._opening_window(stop("07:00", "22:00")) == (0, 13 * 3600)  # 09:00 이전은 0 클램프
+    assert svc._opening_window(stop(None, None)) is None
+    assert svc._opening_window(stop("10:00", None)) is None
+    assert svc._opening_window(stop("07:00", "08:30")) is None  # 일정 시작 전에 닫음 → 제약 무의미
+    assert svc._opening_window(stop("18:00", "10:00")) is None  # 역전 구간
+    assert svc._opening_window(stop("정오", "18:00")) is None  # 형식 오류
+
+
+@pytest.mark.asyncio
+async def test_reserved_time_overrides_opening_hours(monkeypatch) -> None:
+    # 같은 카드에 예약시각과 영업시간이 모두 있으면 예약(고정 창)이 우선 (#292)
+    monkeypatch.setattr(svc, "_places_api_key", lambda: None)
+
+    captured = {}
+
+    def fake_solve(matrix, start=None, end=None, closed_tour=False,
+                   pinned_positions=None, time_windows=None, service_times=None):
+        captured["windows"] = time_windows
+        return [0, 1, 2, 3]
+
+    monkeypatch.setattr(svc, "solve_constrained", fake_solve)
+
+    stops = _stops()
+    stops[1] = stops[1].model_copy(update={
+        "reserved_time": "12:00", "open_time": "10:00", "close_time": "18:00",
+    })
+    await svc.optimize_order(OptimizeOrderRequest(stops=stops))
+    assert captured["windows"] == {1: (3 * 3600, 3 * 3600)}  # 12:00 예약 고정

--- a/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
@@ -1,8 +1,11 @@
 package com.tripkey.domain.optimize;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.Trip;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.optimize.OptimizeResponse;
 import com.tripkey.infra.aiengine.AiEngineClient;
@@ -12,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -36,15 +40,17 @@ public class OptimizeService {
     // time_constraint 자유 텍스트(예: "14:30 예약")에서 예약 시각 추출 — #275 시간창 제약
     private static final Pattern RESERVED_TIME = Pattern.compile("([01]?\\d|2[0-3]):([0-5]\\d)");
 
+    // opening_hours jsonb 파싱용 — 읽기 전용이라 공유 안전 (#292)
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private final TripRepository tripRepository;
     private final PlaceCardRepository placeCardRepository;
     private final AiEngineClient aiEngineClient;
 
     @Transactional(readOnly = true)
     public OptimizeResponse optimize(UUID tripId) {
-        if (!tripRepository.existsById(tripId)) {
-            throw new TripNotFoundException(tripId);
-        }
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new TripNotFoundException(tripId));
 
         Map<Integer, List<PlaceCard>> byDay = groupByDay(tripId);
         List<OptimizeResponse.DayOrder> days = new ArrayList<>();
@@ -55,15 +61,21 @@ public class OptimizeService {
                 continue; // 최적화할 게 없음 (0~1개)
             }
 
+            // Day N 의 요일(0=일~6=토, Google 규약). 여행 시작일이 없으면 null → 영업시간 제약 생략 (#292)
+            Integer weekday = weekdayOf(trip.getStartDate(), entry.getKey());
+
             List<AiOptimizeOrderRequest.Stop> stops = new ArrayList<>();
             for (PlaceCard card : cards) {
                 boolean pinned = card.getTimeConstraint() != null && !card.getTimeConstraint().isBlank();
+                String[] window = openingWindow(card.getOpeningHours(), weekday);
                 stops.add(new AiOptimizeOrderRequest.Stop(
                         card.getInstanceId().toString(),
                         new AiOptimizeOrderRequest.Coord(round(card.getLat()), round(card.getLng())),
                         pinned,
                         reservedTime(card.getTimeConstraint()),
-                        card.getEstimatedDurationMin() == null ? null : card.getEstimatedDurationMin().intValue()));
+                        card.getEstimatedDurationMin() == null ? null : card.getEstimatedDurationMin().intValue(),
+                        window == null ? null : window[0],
+                        window == null ? null : window[1]));
             }
 
             String start = startAnchor(cards);
@@ -127,6 +139,50 @@ public class OptimizeService {
             }
         }
         return null;
+    }
+
+    /** Day N(1-based)의 요일 — 0=일 ~ 6=토(Google 규약). 시작일이 없거나 유효하지 않으면 null. */
+    private static Integer weekdayOf(LocalDate startDate, Integer day) {
+        if (startDate == null || day == null || day < 1) {
+            return null;
+        }
+        // DayOfWeek: MON=1..SUN=7 → %7 로 SUN=0..SAT=6 변환
+        return startDate.plusDays(day - 1L).getDayOfWeek().getValue() % 7;
+    }
+
+    /**
+     * opening_hours jsonb 에서 해당 요일의 영업시간 전체 스팬 [open, close] 추출 (#292).
+     * 구간이 여럿(브레이크 타임)이면 가장 이른 open ~ 가장 늦은 close 를 쓴다(보수적 완화).
+     * 데이터 없음/휴무/파싱 실패 시 null(제약 없음).
+     */
+    private static String[] openingWindow(String openingHoursJson, Integer weekday) {
+        if (openingHoursJson == null || weekday == null) {
+            return null;
+        }
+        try {
+            JsonNode intervals = OBJECT_MAPPER.readTree(openingHoursJson).path(String.valueOf(weekday));
+            if (!intervals.isArray() || intervals.isEmpty()) {
+                return null; // 해당 요일 데이터 없음 = 휴무 또는 미수집 → 제약 생략
+            }
+            String open = null;
+            String close = null;
+            for (JsonNode interval : intervals) {
+                if (!interval.isArray() || interval.size() < 2) {
+                    continue;
+                }
+                String o = interval.get(0).asText(null);
+                String c = interval.get(1).asText(null);
+                if (o == null || c == null) {
+                    continue;
+                }
+                // "HH:MM" 제로패딩 형식이라 문자열 비교 = 시각 비교
+                open = (open == null || o.compareTo(open) < 0) ? o : open;
+                close = (close == null || c.compareTo(close) > 0) ? c : close;
+            }
+            return (open == null || close == null) ? null : new String[]{open, close};
+        } catch (Exception e) {
+            return null; // 방어: 영업시간 파싱 실패가 최적화를 깨면 안 됨
+        }
     }
 
     /** time_constraint 자유 텍스트에서 첫 "HH:MM" 을 추출해 정규화. 없거나 파싱 불가면 null. */

--- a/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/PlaceCard.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.locationtech.jts.geom.Point;
 
 import java.time.OffsetDateTime;
@@ -100,6 +102,11 @@ public class PlaceCard {
 
     @Column(name = "time_constraint", columnDefinition = "text")
     private String timeConstraint;
+
+    // 영업시간 {요일(0=일~6=토): [["HH:MM","HH:MM"],...]} — Places regularOpeningHours 정규화 (#292)
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "opening_hours", columnDefinition = "jsonb")
+    private String openingHours;
 
     @Column(name = "user_context", columnDefinition = "text")
     private String userContext;
@@ -450,6 +457,7 @@ public class PlaceCard {
             this.lng = null;
         }
         this.address = trimToNull(dto.address());
+        this.openingHours = toJsonText(dto.openingHours()); // 장소 매칭 결과 기준으로 갱신 (#292)
 
         this.name = defaultString(dto.name(), this.name);
         this.category = normalizeCategory(dto.category() != null ? dto.category() : this.category);
@@ -491,6 +499,7 @@ public class PlaceCard {
         this.lat = null;
         this.lng = null;
         this.address = null;
+        this.openingHours = null; // 장소 미확정 → 영업시간도 초기화 (#292)
 
         this.name = defaultString(dto.name(), this.name);
         this.category = normalizeCategory(dto.category() != null ? dto.category() : this.category);
@@ -615,6 +624,7 @@ public class PlaceCard {
         }
         card.location = trimToNull(dto.location());
         card.address = trimToNull(dto.address());
+        card.openingHours = toJsonText(dto.openingHours()); // #292
         card.timeConstraint = trimToNull(dto.timeConstraint());
         card.userContext = trimToNull(dto.userContext());
         card.tips = trimToNull(dto.tips());
@@ -631,6 +641,11 @@ public class PlaceCard {
 
         card.demoteWhenCoordinatesMissing();
         return card;
+    }
+
+    /** AI 응답의 opening_hours JSON 노드 → jsonb 저장용 문자열 (#292). */
+    private static String toJsonText(com.fasterxml.jackson.databind.JsonNode node) {
+        return node == null || node.isNull() ? null : node.toString();
     }
 
     @PrePersist

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiOptimizeOrderRequest.java
@@ -17,6 +17,9 @@ public record AiOptimizeOrderRequest(
             Coord coordinates,
             boolean pinned,
             @JsonProperty("reserved_time") String reservedTime,
-            @JsonProperty("duration_min") Integer durationMin
+            @JsonProperty("duration_min") Integer durationMin,
+            // 해당 Day 요일의 영업시간 [open, close] "HH:MM" — 없으면 null(제약 없음) (#292)
+            @JsonProperty("open_time") String openTime,
+            @JsonProperty("close_time") String closeTime
     ) {}
 }

--- a/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiPlaceCardDto.java
+++ b/apps/backend/src/main/java/com/tripkey/infra/aiengine/dto/AiPlaceCardDto.java
@@ -2,6 +2,7 @@ package com.tripkey.infra.aiengine.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.List;
 
@@ -68,8 +69,68 @@ public record AiPlaceCardDto(
         String flightRole,
 
         @JsonProperty("search_alias")
-        String searchAlias
+        String searchAlias,
+
+        // 영업시간 {요일(0=일~6=토): [["HH:MM","HH:MM"],...]} — jsonb 저장용 (#292)
+        @JsonProperty("opening_hours")
+        JsonNode openingHours
 ) {
+
+    // 하위호환: opening_hours 도입(#292) 이전 시그니처
+    public AiPlaceCardDto(
+            String placeId,
+            String name,
+            String category,
+            String classification,
+            String placementStatus,
+            Boolean isAiGenerated,
+            Boolean allowDuplicate,
+            Short estimatedDurationMin,
+            Coordinates coordinates,
+            String location,
+            String address,
+            String timeConstraint,
+            String userContext,
+            String tips,
+            String questionText,
+            List<String> options,
+            String blockedReason,
+            List<String> tags,
+            String checkIn,
+            String checkOut,
+            String flightNumber,
+            String flightDatetime,
+            String flightRole,
+            String searchAlias
+    ) {
+        this(
+                placeId,
+                name,
+                category,
+                classification,
+                placementStatus,
+                isAiGenerated,
+                allowDuplicate,
+                estimatedDurationMin,
+                coordinates,
+                location,
+                address,
+                timeConstraint,
+                userContext,
+                tips,
+                questionText,
+                options,
+                blockedReason,
+                tags,
+                checkIn,
+                checkOut,
+                flightNumber,
+                flightDatetime,
+                flightRole,
+                searchAlias,
+                null
+        );
+    }
 
     public AiPlaceCardDto(
             String placeId,
@@ -120,6 +181,7 @@ public record AiPlaceCardDto(
                 flightNumber,
                 flightDatetime,
                 flightRole,
+                null,
                 null
         );
     }
@@ -169,6 +231,7 @@ public record AiPlaceCardDto(
                 checkIn,
                 checkOut,
                 flightNumber,
+                null,
                 null,
                 null,
                 null

--- a/apps/backend/src/test/java/com/tripkey/domain/optimize/OptimizeServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/optimize/OptimizeServiceTest.java
@@ -3,6 +3,7 @@ package com.tripkey.domain.optimize;
 import com.tripkey.common.exception.TripNotFoundException;
 import com.tripkey.domain.place.PlaceCard;
 import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.Trip;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.dto.optimize.OptimizeResponse;
 import com.tripkey.infra.aiengine.AiEngineClient;
@@ -15,7 +16,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,6 +59,12 @@ class OptimizeServiceTest {
         return c;
     }
 
+    private void stubTrip(UUID tripId, LocalDate startDate) {
+        Trip trip = org.mockito.Mockito.mock(Trip.class);
+        lenient().when(trip.getStartDate()).thenReturn(startDate);
+        when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
+    }
+
     @Test
     void optimizeReturnsPerDaySuggestionWithAccommodationAnchor() {
         UUID tripId = UUID.randomUUID();
@@ -63,7 +72,7 @@ class OptimizeServiceTest {
         UUID p1 = UUID.randomUUID();
         UUID p2 = UUID.randomUUID();
 
-        when(tripRepository.existsById(tripId)).thenReturn(true);
+        stubTrip(tripId, null);
 
         PlaceCard accCard = card(acc, 1, (short) 0, 34.70, 135.50, "accommodation", false);
         PlaceCard place1 = card(p1, 1, (short) 1, 34.71, 135.51, "place", false);
@@ -111,7 +120,7 @@ class OptimizeServiceTest {
         UUID place = UUID.randomUUID();
         UUID flight = UUID.randomUUID();
 
-        when(tripRepository.existsById(tripId)).thenReturn(true);
+        stubTrip(tripId, null);
 
         PlaceCard accCard = card(acc, 1, (short) 0, 34.70, 135.50, "accommodation", false);
         PlaceCard placeCard = card(place, 1, (short) 1, 34.71, 135.51, "place", false);
@@ -142,7 +151,7 @@ class OptimizeServiceTest {
         UUID p2 = UUID.randomUUID();
         UUID p3 = UUID.randomUUID();
 
-        when(tripRepository.existsById(tripId)).thenReturn(true);
+        stubTrip(tripId, null);
 
         PlaceCard reserved = card(p1, 1, (short) 0, 34.70, 135.50, "food", false);
         lenient().when(reserved.getTimeConstraint()).thenReturn("14:30 예약");
@@ -183,7 +192,7 @@ class OptimizeServiceTest {
         UUID place = UUID.randomUUID();
         UUID flight = UUID.randomUUID();
 
-        when(tripRepository.existsById(tripId)).thenReturn(true);
+        stubTrip(tripId, null);
 
         PlaceCard accCard = card(acc, 1, (short) 0, 34.70, 135.50, "accommodation", false);
         PlaceCard placeCard = card(place, 1, (short) 1, 34.71, 135.51, "place", false);
@@ -207,9 +216,70 @@ class OptimizeServiceTest {
     }
 
     @Test
+    void optimizePassesOpeningHoursWindowForDayWeekday() {
+        UUID tripId = UUID.randomUUID();
+        UUID shop = UUID.randomUUID();
+        UUID noHours = UUID.randomUUID();
+
+        // 2026-07-06 = 월요일 → Day 1 의 요일 = 1(월, Google 규약 0=일~6=토)
+        stubTrip(tripId, LocalDate.of(2026, 7, 6));
+
+        PlaceCard shopCard = card(shop, 1, (short) 0, 34.70, 135.50, "place", false);
+        // 월요일 브레이크 타임 영업(10-14, 17-21) → 전체 스팬 10:00~21:00 로 전달
+        lenient().when(shopCard.getOpeningHours()).thenReturn(
+                "{\"1\": [[\"10:00\",\"14:00\"],[\"17:00\",\"21:00\"]], \"2\": [[\"09:00\",\"18:00\"]]}");
+        PlaceCard plainCard = card(noHours, 1, (short) 1, 34.71, 135.51, "place", false);
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(shopCard, plainCard));
+        when(aiEngineClient.optimizeOrder(any())).thenReturn(
+                new AiOptimizeOrderResponse(
+                        List.of(shop.toString(), noHours.toString()), 600, "google"));
+
+        optimizeService.optimize(tripId);
+
+        ArgumentCaptor<AiOptimizeOrderRequest> captor =
+                ArgumentCaptor.forClass(AiOptimizeOrderRequest.class);
+        verify(aiEngineClient).optimizeOrder(captor.capture());
+        List<AiOptimizeOrderRequest.Stop> stops = captor.getValue().stops();
+        assertThat(stops.get(0).openTime()).isEqualTo("10:00");
+        assertThat(stops.get(0).closeTime()).isEqualTo("21:00");
+        // 영업시간 없는 카드 → 제약 없음
+        assertThat(stops.get(1).openTime()).isNull();
+        assertThat(stops.get(1).closeTime()).isNull();
+    }
+
+    @Test
+    void optimizeSkipsOpeningHoursWhenTripHasNoStartDate() {
+        UUID tripId = UUID.randomUUID();
+        UUID shop = UUID.randomUUID();
+        UUID other = UUID.randomUUID();
+
+        stubTrip(tripId, null); // 유연한 날짜 여행 → 요일 계산 불가
+
+        PlaceCard shopCard = card(shop, 1, (short) 0, 34.70, 135.50, "place", false);
+        lenient().when(shopCard.getOpeningHours()).thenReturn("{\"1\": [[\"10:00\",\"18:00\"]]}");
+        PlaceCard otherCard = card(other, 1, (short) 1, 34.71, 135.51, "place", false);
+
+        when(placeCardRepository.findAllByTripId(tripId))
+                .thenReturn(List.of(shopCard, otherCard));
+        when(aiEngineClient.optimizeOrder(any())).thenReturn(
+                new AiOptimizeOrderResponse(
+                        List.of(shop.toString(), other.toString()), 600, "google"));
+
+        optimizeService.optimize(tripId);
+
+        ArgumentCaptor<AiOptimizeOrderRequest> captor =
+                ArgumentCaptor.forClass(AiOptimizeOrderRequest.class);
+        verify(aiEngineClient).optimizeOrder(captor.capture());
+        assertThat(captor.getValue().stops().get(0).openTime()).isNull();
+        assertThat(captor.getValue().stops().get(0).closeTime()).isNull();
+    }
+
+    @Test
     void skipsDaysWithFewerThanTwoStopsAndDoesNotCallAi() {
         UUID tripId = UUID.randomUUID();
-        when(tripRepository.existsById(tripId)).thenReturn(true);
+        stubTrip(tripId, null);
         PlaceCard single = card(UUID.randomUUID(), 1, (short) 0, 34.70, 135.50, "place", false);
         when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(single));
 
@@ -222,7 +292,7 @@ class OptimizeServiceTest {
     @Test
     void throwsWhenTripNotFound() {
         UUID tripId = UUID.randomUUID();
-        when(tripRepository.existsById(tripId)).thenReturn(false);
+        when(tripRepository.findById(tripId)).thenReturn(Optional.empty());
         assertThatThrownBy(() -> optimizeService.optimize(tripId))
                 .isInstanceOf(TripNotFoundException.class);
     }

--- a/apps/backend/src/test/resources/postgis-test-schema.sql
+++ b/apps/backend/src/test/resources/postgis-test-schema.sql
@@ -61,6 +61,7 @@ create table place_cards (
   location               text,
   address                text,
   time_constraint        text,
+  opening_hours          jsonb,
   user_context           text,
   tips                   text,
   question_text          text,

--- a/shared/docs/migrations/V015__place_cards_opening_hours.sql
+++ b/shared/docs/migrations/V015__place_cards_opening_hours.sql
@@ -1,0 +1,9 @@
+-- V015: place_cards 영업시간 컬럼 (#292)
+-- Google Places regularOpeningHours 를 요일별로 정규화해 저장한다.
+-- 형식: {"0": [["10:00","18:00"], ...], ...} — key 는 요일(0=일 ~ 6=토, Google 규약),
+--       value 는 그 요일의 [open, close] 구간 목록(브레이크 타임 있는 곳은 2개 이상).
+--       자정 넘김 구간은 open 요일의 23:59 로 절단해 저장(수집 시 정규화).
+-- 동선 최적화(#292)가 Day 요일의 영업시간 time window 로 사용한다. 없으면 제약 없음.
+
+alter table public.place_cards
+  add column if not exists opening_hours jsonb;

--- a/shared/docs/schema.sql
+++ b/shared/docs/schema.sql
@@ -72,6 +72,7 @@ create table if not exists public.place_cards (
   location               text,                                     -- 지역명/주소 요약
   address                text,                                     -- 상세 주소 (Blocking Enrichment 보강)
   time_constraint        text,                                     -- 시간 제약 설명
+  opening_hours          jsonb,                                    -- 영업시간 {요일(0=일~6=토): [[open,close],...]} (#292)
 
   -- 사용자/AI 컨텍스트
   user_context           text,                                     -- 사용자 맥락 반영 문구


### PR DESCRIPTION
## 📝 작업 내용

> 장소 영업시간을 수집·저장하고, 동선 최적화가 "영업시간 안에 방문 시작"하도록 time window 제약으로 반영한다.

**데이터 파이프라인**
- 기존 Places `searchText` 보강 호출의 필드마스크에 `regularOpeningHours` 추가 — **추가 API 호출 0** (기존 호출 편승)
- 요일별 `[open, close]` 정규화: 24시간 영업(전 요일 00:00~23:59), 자정 넘김(open 요일 23:59 절단), 브레이크 타임(구간 복수) 처리
- `place_cards.opening_hours` jsonb 컬럼(**V015**) — AI 응답 → `JsonNode` DTO → 엔티티 저장

**최적화 반영**
- BE: `Trip.startDate`로 Day N 의 요일(0=일~6=토, Google 규약) 계산 → 해당 요일 영업시간 **전체 스팬**을 `open_time`/`close_time`으로 전달 (시작일 없는 유연한 날짜 여행은 제약 생략)
- AI: OR-tools Time 차원 `SetRange(open, close)` **구간 창** — 예약시각 `[t,t]` 고정과 달리 방문 시작이 구간 안이면 허용
- 우선순위: 같은 카드에 예약시각이 있으면 **예약이 우선** (사용자의 명시적 약속)
- 폴백: 유효하지 않은 창(일정 시작 09:00 이전 마감 등)은 제약 생략, 해 없는 제약 조합은 기존 무제약 폴백 유지 → API 는 항상 결과 반환

## 🔗 관련 이슈

closes #292

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [x] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [x] 공통 / 설정 / 문서 (V015 마이그레이션, schema.sql)

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (AI 138 passed / BE 전체 BUILD SUCCESSFUL — 통합테스트 포함)
- [x] 기존 기능이 깨지지 않았나요? (영업시간 없는 카드는 기존 동작 그대로)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> - ✅ **V015 적용 완료**: TripKey(develop)·TripKey-prod 양쪽 Supabase 에 `opening_hours jsonb` 컬럼을 이미 수동 적용했습니다 (additive/idempotent — 구버전 코드에 영향 없음). 머지/배포 시 별도 DB 작업 불필요합니다.
> - ⚠️ **과금**: `regularOpeningHours` 는 Advanced SKU 필드라 searchText 호출 단가가 오릅니다. 또한 필드마스크 변경으로 `places_cache` 가 1회 전체 미스(재적재)됩니다.
> - 영업시간이 여러 구간(브레이크 타임)이면 보수적으로 전체 스팬(가장 이른 open ~ 가장 늦은 close)을 씁니다 — 점심 브레이크에 걸리는 방문까지 막지는 않는 완화입니다.
> - `solve_constrained` 의 time_windows 는 int(예약 [t,t])와 (earliest, latest) 튜플을 모두 받습니다 (하위호환).

## 📸 스크린샷

> 없음 (UI 변경 없음)
