### PR TITLE
refactor: 온보딩 여행지 선택 단일화

### DIFF
--- a/apps/frontend/src/components/onboarding/DestinationDropdown.css
+++ b/apps/frontend/src/components/onboarding/DestinationDropdown.css
@@ -7,9 +7,10 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: white;
+  background: var(--popover);
+  color: var(--popover-foreground);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   max-height: 220px;
   overflow-y: auto;
@@ -24,12 +25,18 @@
 }
 
 .destination-dropdown li:hover {
-  background: #f5f5f5;
+  background: var(--muted);
 }
 
 .destination-dropdown__country {
-  color: #888;
-  font-size: 13px;
+  flex-shrink: 0;
+  align-self: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 500;
 }
 
 .destination-dropdown__hint {

--- a/apps/frontend/src/components/onboarding/DestinationDropdown.tsx
+++ b/apps/frontend/src/components/onboarding/DestinationDropdown.tsx
@@ -35,8 +35,7 @@ const DestinationDropdown = ({ placeholder }: { placeholder?: string }) => {
   }, [query]);
 
   const handleSelect = (destination: Destination) => {
-    if (destinations.includes(destination.name)) return;
-    setForm({ destinations: [...destinations, destination.name] });
+    setForm({ destinations: [destination.name] });
     setQuery('');
     setShowHint(false);
   };

--- a/apps/frontend/src/components/onboarding/DestinationInput.css
+++ b/apps/frontend/src/components/onboarding/DestinationInput.css
@@ -9,8 +9,9 @@
   gap: 8px;
   align-items: center;
   width: 100%;
+  min-height: 52px;
   padding: 14px 16px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border);
   border-radius: 10px;
   font-size: 15px;
   box-sizing: border-box;
@@ -18,7 +19,7 @@
 }
 
 .destination-input__box:focus-within {
-  border-color: #6c5ce7;
+  border-color: var(--ring);
 }
 
 .destination-input__box input {
@@ -27,11 +28,12 @@
   flex: 1;
   min-width: 80px;
   font-size: 15px;
-  color: #333333;
+  background: transparent;
+  color: var(--foreground);
 }
 
 .destination-input__box input::placeholder {
-  color: #aaaaaa;
+  color: var(--muted-foreground);
 }
 
 .destination-input__tag {
@@ -39,9 +41,11 @@
   align-items: center;
   gap: 4px;
   padding: 4px 10px;
-  background: #ededff;
+  background: color-mix(in oklch, var(--primary) 12%, transparent);
+  color: var(--primary);
   border-radius: 20px;
   font-size: 13px;
+  font-weight: 500;
 }
 
 .destination-input__tag button {
@@ -49,7 +53,7 @@
   border: none;
   cursor: pointer;
   font-size: 14px;
-  color: #888;
+  color: color-mix(in oklch, var(--primary) 60%, transparent);
   padding: 0;
 }
 

--- a/apps/frontend/src/components/onboarding/DestinationInput.tsx
+++ b/apps/frontend/src/components/onboarding/DestinationInput.tsx
@@ -24,7 +24,9 @@ const DestinationInput = ({ placeholder }: { placeholder?: string }) => {
             </button>
           </span>
         ))}
-        <DestinationDropdown placeholder={placeholder} />
+        {destinations.length === 0 && (
+          <DestinationDropdown placeholder={placeholder} />
+        )}
       </div>
 
       {import.meta.env.MODE === 'development' && (


### PR DESCRIPTION
## 📝 작업 내용

- 온보딩 여행지 선택을 다중 → 단일로 변경하고, 관련 UI 색상을 디자인 토큰으로 통일했습니다.

## 🔗 관련 이슈

closes #304

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (Docker dev 환경에서 선택/해제/드롭다운 확인)
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인 — destinations 배열 계약 유지, 다운스트림 무영향)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요? (하드코딩 hex → 토큰으로 오히려 제거)
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

<img width="630" height="177" alt="image" src="https://github.com/user-attachments/assets/82b8916b-cd3b-4100-a02f-cca4c1072ec1" />
