### PR TITLE
refactor: 온보딩 캘린더 유연한 날짜 기본 노출 및 색상 통일

### DIFF
--- a/apps/frontend/src/components/onboarding/calendar/ExactCalendar.css
+++ b/apps/frontend/src/components/onboarding/calendar/ExactCalendar.css
@@ -1,7 +1,7 @@
 .rdp-root {
   width: 100%;
   font-size: 14px;
-  color: #111827;
+  color: var(--foreground);
 
   position: relative;
 }
@@ -38,7 +38,7 @@
   text-align: center;
   font-size: 12px;
   font-weight: 500;
-  color: #9ca3af;
+  color: var(--muted-foreground);
   padding: 6px 0;
 }
 
@@ -81,7 +81,7 @@
   border-radius: 50%;
   cursor: pointer;
   font-size: 13px;
-  color: #111827;
+  color: var(--foreground);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -89,7 +89,7 @@
 }
 
 .rdp-day_button:hover {
-  background: #f3f4f6;
+  background: var(--muted);
 }
 
 /* 일요일 */
@@ -104,15 +104,23 @@
 
 /* 범위 중간 배경 (셀 전체) */
 .rdp-range_middle {
-  background: #eef2ff;
+  background: color-mix(in oklch, var(--calendar-accent) 12%, transparent);
 }
 
 .rdp-range_start {
-  background: linear-gradient(to right, transparent 50%, #eef2ff 50%);
+  background: linear-gradient(
+    to right,
+    transparent 50%,
+    color-mix(in oklch, var(--calendar-accent) 12%, transparent) 50%
+  );
 }
 
 .rdp-range_end {
-  background: linear-gradient(to left, transparent 50%, #eef2ff 50%);
+  background: linear-gradient(
+    to left,
+    transparent 50%,
+    color-mix(in oklch, var(--calendar-accent) 12%, transparent) 50%
+  );
 }
 
 .rdp-range_start.rdp-range_end {
@@ -123,25 +131,25 @@
 .rdp-range_start .rdp-day_button,
 .rdp-range_end .rdp-day_button,
 .rdp-selected .rdp-day_button {
-  background: #6366f1;
-  color: #fff !important;
+  background: var(--calendar-accent);
+  color: var(--primary-foreground) !important;
   font-weight: 600;
   border-radius: 50%;
 }
 
 .rdp-range_middle .rdp-day_button {
   background: none;
-  color: #4338ca;
+  color: var(--calendar-accent);
   border-radius: 50%;
 }
 
 /* 비활성화 / 외부 날짜 */
 .rdp-outside .rdp-day_button {
-  color: #d1d5db;
+  color: var(--muted-foreground);
 }
 
 .rdp-disabled .rdp-day_button {
-  color: #d1d5db;
+  color: var(--muted-foreground);
   cursor: default;
 }
 
@@ -153,12 +161,12 @@
 .exact-calendar__footer {
   margin-top: 16px;
   padding-top: 12px;
-  border-top: 1px solid #f3f4f6;
+  border-top: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: space-between;
   font-size: 13px;
-  color: #6b7280;
+  color: var(--muted-foreground);
 }
 
 .exact-calendar__footer-dates {
@@ -174,12 +182,12 @@
 
 .exact-calendar__footer-dates p {
   font-size: 11px;
-  color: #9ca3af;
+  color: var(--muted-foreground);
   margin: 0;
 }
 
 .exact-calendar__footer-nights {
   font-size: 13px;
   font-weight: 600;
-  color: #6366f1;
+  color: var(--calendar-accent);
 }

--- a/apps/frontend/src/components/onboarding/calendar/FlexCalendar.css
+++ b/apps/frontend/src/components/onboarding/calendar/FlexCalendar.css
@@ -13,31 +13,31 @@
 
 .flex-calendar__month-btn {
   padding: 12px 0;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--border);
   border-radius: 10px;
-  background: #ffffff;
+  background: var(--background);
   font-size: 14px;
-  color: #111827;
+  color: var(--foreground);
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .flex-calendar__month-btn:hover:not(:disabled) {
-  border-color: #6366f1;
-  color: #6366f1;
+  border-color: var(--calendar-accent);
+  color: var(--calendar-accent);
 }
 
 .flex-calendar__month-btn--active {
-  background: #6366f1;
-  border-color: #6366f1;
-  color: #ffffff;
+  background: var(--calendar-accent-soft);
+  border-color: var(--calendar-accent-line);
+  color: var(--calendar-accent);
   font-weight: 600;
 }
 
 .flex-calendar__month-btn--disabled {
-  background: #f9fafb;
-  border-color: #f3f4f6;
-  color: #d1d5db;
+  background: var(--muted);
+  border-color: var(--border);
+  color: var(--muted-foreground);
   cursor: default;
 }
 
@@ -45,7 +45,7 @@
 .flex-calendar__label {
   font-size: 14px;
   font-weight: 600;
-  color: #111827;
+  color: var(--foreground);
   margin: 0;
 }
 
@@ -58,24 +58,24 @@
 
 .flex-calendar__duration-btn {
   padding: 8px 16px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--border);
   border-radius: 999px;
-  background: #ffffff;
+  background: var(--background);
   font-size: 13px;
-  color: #374151;
+  color: var(--foreground);
   cursor: pointer;
   white-space: nowrap;
   transition: all 0.15s;
 }
 
 .flex-calendar__duration-btn:hover {
-  border-color: #6366f1;
-  color: #6366f1;
+  border-color: var(--calendar-accent);
+  color: var(--calendar-accent);
 }
 
 .flex-calendar__duration-btn--active {
-  background: #6366f1;
-  border-color: #6366f1;
-  color: #ffffff;
+  background: var(--calendar-accent-soft);
+  border-color: var(--calendar-accent-line);
+  color: var(--calendar-accent);
   font-weight: 600;
 }

--- a/apps/frontend/src/components/onboarding/calendar/TripCalendar.css
+++ b/apps/frontend/src/components/onboarding/calendar/TripCalendar.css
@@ -1,3 +1,11 @@
+:root {
+  /* 캘린더 강조색 — 여행지 칩과 같은 언어(연한 틴트 + 보라 글자).
+     활성 상태는 아래 soft/line 틴트로 칠하고, 선택일만 단색(--calendar-accent)으로 또렷하게. */
+  --calendar-accent: var(--primary);
+  --calendar-accent-soft: color-mix(in oklch, var(--primary) 14%, transparent);
+  --calendar-accent-line: color-mix(in oklch, var(--primary) 35%, transparent);
+}
+
 .trip-calendar__tabs {
   display: flex;
   gap: 8px;
@@ -8,18 +16,18 @@
   flex: 1;
   padding: 10px;
   border-radius: 8px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border);
   font-size: 14px;
   cursor: pointer;
-  background-color: #ffffff;
-  color: #6b7280;
+  background-color: var(--background);
+  color: var(--muted-foreground);
   transition: all 0.15s;
 }
 
 .trip-calendar__tab--active {
-  background-color: #6366f1;
-  border-color: #6366f1;
-  color: #ffffff;
+  background-color: var(--calendar-accent-soft);
+  border-color: var(--calendar-accent-line);
+  color: var(--calendar-accent);
   font-weight: 600;
 }
 
@@ -34,26 +42,26 @@
 .calendar-nav__label {
   font-size: 15px;
   font-weight: 600;
-  color: #111827;
+  color: var(--foreground);
 }
 
 .calendar-nav__btn {
   width: 28px;
   height: 28px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--background);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 18px;
-  color: #6b7280;
+  color: var(--muted-foreground);
   transition: background 0.15s;
 }
 
 .calendar-nav__btn:hover {
-  background: #f3f4f6;
+  background: var(--muted);
 }
 
 .calendar-nav__btn:disabled {

--- a/apps/frontend/src/components/onboarding/calendar/TripCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/TripCalendar.tsx
@@ -8,12 +8,10 @@ import FlexCalendar from './FlexCalendar';
 
 const TripCalendar = () => {
   const storedTab = useCalendarStore((s) => s.type);
-  const [tab, setTab] = useState<'exact' | 'flexible'>(storedTab ?? 'exact');
+  const [tab, setTab] = useState<'exact' | 'flexible'>(storedTab ?? 'flexible');
 
   useEffect(() => {
-    if (storedTab === null) {
-      setTab('exact');
-    }
+    if (storedTab === null) setTab('flexible');
   }, [storedTab]);
 
   return (
@@ -21,17 +19,17 @@ const TripCalendar = () => {
       <div className="trip-calendar__tabs">
         <button
           type="button"
-          className={`trip-calendar__tab${tab === 'exact' ? ' trip-calendar__tab--active' : ''}`}
-          onClick={() => setTab('exact')}
-        >
-          정확한 날짜
-        </button>
-        <button
-          type="button"
           className={`trip-calendar__tab${tab === 'flexible' ? ' trip-calendar__tab--active' : ''}`}
           onClick={() => setTab('flexible')}
         >
           유연한 날짜
+        </button>
+        <button
+          type="button"
+          className={`trip-calendar__tab${tab === 'exact' ? ' trip-calendar__tab--active' : ''}`}
+          onClick={() => setTab('exact')}
+        >
+          정확한 날짜
         </button>
       </div>
       {tab === 'exact' ? <ExactCalendar /> : <FlexCalendar />}


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 온보딩 캘린더에서 유연한 날짜를 기본 탭으로 우선 노출하고, 캘린더 강조색을 토큰 기반으로 통일했습니다.

## 🔗 관련 이슈

closes #306

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (Docker dev에서 탭 전환·월/박수·range 선택 확인)
- [x] 기존 기능이 깨지지 않았나요? (calendar-store 구조·로직 무변경, exact/flexible 대칭 유지)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요? (하드코딩 hex → 토큰으로 제거)
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- 기본 탭만 exact → flexible로 변경 store·로직은 동일.
- 대표색상 통일 `--primary`에서 파생한 `--calendar-accent`(+ soft/line 틴트)로 통일.

## 📸 스크린샷

<img width="654" height="442" alt="image" src="https://github.com/user-attachments/assets/23624286-6e39-4695-b575-37f178fb9272" />
