### PR TITLE
feat: detail map coord refresh

### DIFF
--- a/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
+++ b/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
@@ -3,6 +3,7 @@ import { Dialog } from 'radix-ui';
 import { useState } from 'react';
 
 import PanelActions from '@/components/common/PanelActions';
+import PlaceLocationMap from '@/components/common/PlaceLocationMap';
 import SidePanel from '@/components/common/SidePanel';
 import {
   AnswerField,
@@ -16,10 +17,7 @@ import PlaceCardBadge from '@/components/grouping/PlaceCardBadge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
-import type {
-  PlaceCardAccent,
-  PlaceCardBadgeSpec,
-} from '@/types/grouping';
+import type { PlaceCardAccent, PlaceCardBadgeSpec } from '@/types/grouping';
 import type { CardPatchRequest } from '@/types/grouping-api';
 
 export type CommonCardDetailViewModel = {
@@ -31,6 +29,7 @@ export type CommonCardDetailViewModel = {
   estimatedDurationMin?: number | null;
   userIntent?: string;
   aiHint?: string;
+  coordinates?: { lat: number; lng: number };
   includedInItinerary?: boolean;
   memo?: string;
   question?: string;
@@ -383,6 +382,15 @@ const CardDetailBody = ({
               />
             )}
           </ul>
+          {detail.coordinates && (
+            <div className="mt-3.5">
+              <PlaceLocationMap
+                lat={detail.coordinates.lat}
+                lng={detail.coordinates.lng}
+                name={card.name}
+              />
+            </div>
+          )}
         </section>
 
         <Separator />

--- a/apps/frontend/src/components/common/PlaceLocationMap.tsx
+++ b/apps/frontend/src/components/common/PlaceLocationMap.tsx
@@ -1,0 +1,48 @@
+// PlaceLocationMap — 단일 장소 위치용 지도. 카드 상세 패널에서 좌표 하나를 핀으로 표시.
+// 확정 화면 MapCard와 동일한 라이브러리(@vis.gl/react-google-maps)·API 키를 쓰되,
+// 순서 번호·동선 없이 핀 하나만 두는 경량 버전.
+import { APIProvider, AdvancedMarker, Map } from '@vis.gl/react-google-maps';
+import { MapPin } from 'lucide-react';
+
+import { GOOGLE_MAPS_API_KEY } from '@/utils/constants';
+
+type PlaceLocationMapProps = {
+  lat: number;
+  lng: number;
+  name?: string;
+};
+
+const PlaceLocationMap = ({ lat, lng, name }: PlaceLocationMapProps) => {
+  if (!GOOGLE_MAPS_API_KEY) {
+    return (
+      <div className="flex h-44 items-center justify-center rounded-xl bg-muted text-xs text-muted-foreground">
+        지도 API 키가 설정되지 않았어요.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl ring-1 ring-foreground/10">
+      <APIProvider apiKey={GOOGLE_MAPS_API_KEY}>
+        <Map
+          defaultCenter={{ lat, lng }}
+          defaultZoom={15}
+          gestureHandling="cooperative"
+          mapId="tripkey-place-map"
+          style={{ width: '100%', height: '176px' }}
+          disableDefaultUI
+          zoomControl
+          clickableIcons={false}
+        >
+          <AdvancedMarker position={{ lat, lng }} title={name}>
+            <div className="flex size-7 items-center justify-center rounded-full bg-violet-600 text-white shadow-md ring-2 ring-white">
+              <MapPin className="size-4" aria-hidden="true" />
+            </div>
+          </AdvancedMarker>
+        </Map>
+      </APIProvider>
+    </div>
+  );
+};
+
+export default PlaceLocationMap;

--- a/apps/frontend/src/components/grouping/CardDetailPanel.tsx
+++ b/apps/frontend/src/components/grouping/CardDetailPanel.tsx
@@ -29,6 +29,7 @@ const toCommonCard = (
         estimatedDurationMin: detail.estimatedDurationMin,
         userIntent: detail.userIntent,
         aiHint: detail.aiHint ?? card.reminder,
+        coordinates: detail.coordinates,
         memo: detail.memo,
         includedInItinerary: detail.includedInItinerary,
       }
@@ -60,10 +61,7 @@ const toCommonCard = (
   };
 };
 
-const GroupingCardDetailPanel = ({
-  card,
-  ...props
-}: CardDetailPanelProps) => {
+const GroupingCardDetailPanel = ({ card, ...props }: CardDetailPanelProps) => {
   return <CardDetailPanel {...props} card={toCommonCard(card)} />;
 };
 

--- a/apps/frontend/src/hooks/useArrange.ts
+++ b/apps/frontend/src/hooks/useArrange.ts
@@ -40,6 +40,18 @@ export const useArrangeCardsQuery = (tripId: string | null) =>
     queryKey: arrangeKeys.cards(tripId ?? ''),
     queryFn: () => fetchCards(tripId as string),
     enabled: Boolean(tripId),
+    // 좌표(Places) enrichment가 끝나기 전에 화면에 들어와도 지도가 비지 않도록,
+    // 처리 중(processing) 카드가 있으면 자동으로 다시 받아오고 모두 정착되면 멈춘다.
+    // dataUpdateCount 로 상한을 둬(최대 ~30초) 무한 폴링을 방지한다.
+    refetchInterval: (query) => {
+      const cards = query.state.data?.cards;
+      if (!cards) return false;
+      const pending = cards.some(
+        (card) => card.processing_status === 'processing'
+      );
+      if (!pending) return false;
+      return query.state.dataUpdateCount > 15 ? false : 2000;
+    },
   });
 
 /**

--- a/apps/frontend/src/types/arrange.ts
+++ b/apps/frontend/src/types/arrange.ts
@@ -6,6 +6,7 @@
  * 1차는 정적 UI(드래그앤드롭 동작 = depth, 이후 작업)만 다룬다.
  */
 import type { PlaceCardAccent, PlaceCardBadgeSpec } from './grouping';
+import type { Coordinates } from './grouping-api';
 
 /**
  * 좌측 "카드 목록"의 카드 한 장.
@@ -48,6 +49,8 @@ export type ArrangeCardDetailViewModel = {
   fixedTimeLabel?: string;
   /** "상세 정보" — 위치(📍). 없으면 행 생략 */
   region?: string;
+  /** 장소 좌표(있으면 상세 패널에 지도 표시). 미해결/미도착 카드는 없음 */
+  coordinates?: Coordinates;
   /** "상세 정보" — 예상 소요 시간/체크인 정보(⏱). 없으면 행 생략 */
   durationLabel?: string;
   /** 이름/소요시간 표시 수정용 원본 예상 소요 시간(분). 없으면 빈 입력으로 표시 */

--- a/apps/frontend/src/types/grouping.ts
+++ b/apps/frontend/src/types/grouping.ts
@@ -4,6 +4,8 @@
  */
 import type { LucideIcon } from 'lucide-react';
 
+import type { Coordinates } from './grouping-api';
+
 export type PlaceCardAccent = 'blue' | 'green' | 'amber' | 'red' | 'muted';
 
 export type PlaceCategory =
@@ -117,6 +119,8 @@ export type CardDetailViewModel = {
    * (리스트의 reminder 배너 = 짧은 넛지 / 패널의 이 행 = 좀 더 자세한 AI 노트 — 라는 구분)
    */
   aiHint?: string;
+  /** 장소 좌표(있으면 상세 패널에 지도 표시). 미해결/미도착 카드는 없음 */
+  coordinates?: Coordinates;
   /** "사용자 메모" textarea 초기값. 보통 ''(저장된 메모가 있으면 그 값). 입력값이 이 값과 달라지면 "메모 저장"이 활성화된다 */
   memo?: string;
   /**

--- a/apps/frontend/src/utils/arrange-mapper.ts
+++ b/apps/frontend/src/utils/arrange-mapper.ts
@@ -253,6 +253,7 @@ const cardToDetail = (card: Card): ArrangeCardDetailViewModel => {
     placementStatus: placementLabel(card),
     fixedTimeLabel: flightLabel(card),
     region: card.location ?? undefined,
+    coordinates: card.coordinates ?? undefined,
     durationLabel: detailDuration(card),
     estimatedDurationMin: card.estimated_duration_min,
     userIntent: card.user_context ?? undefined,

--- a/apps/frontend/src/utils/grouping-mapper.ts
+++ b/apps/frontend/src/utils/grouping-mapper.ts
@@ -96,6 +96,7 @@ const toReviewCard = (card: Card): PlaceCardViewModel => ({
     estimatedDurationMin: card.estimated_duration_min,
     userIntent: card.user_context ?? undefined,
     aiHint: card.tips ?? undefined,
+    coordinates: card.coordinates ?? undefined,
     memo: card.memo ?? '',
     includedInItinerary: !card.is_excluded,
   },


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 확정 화면 이전에도 장소 위치를 확인할 수 있도록 정리(03)·배치(04) 카드 상세 패널에 지도를 추가하고, 좌표가 늦게 도착해도 확정 화면 지도가 자동으로 채워지도록 폴링을 붙였습니다.

## 🔗 관련 이슈

closes #313

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (03 상세 패널 지도 확인 / 04는 동일한 공유 패널·좌표 소스 사용 / 확정 폴링은 타이밍 버그라 코드 기준 검증)
- [x] 기존 기능이 깨지지 않았나요? (뷰모델 필드는 optional 추가, 지도는 좌표 있을 때만 렌더, 폴링은 처리 중일 때만 도는 구조)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? (지도 + 좌표 신선도)

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- **좌표 전달 경로**: `card.coordinates` → 뷰모델(Card/Arrange DetailViewModel) → 공유 상세 패널(`CommonCardDetailViewModel.coordinates`). 03·04가 같은 공유 패널을 써서, 좌표만 detail에 실으면 지도가 렌더됩니다.
- **좌표 신선도 폴링**: `useArrangeCardsQuery`에 `refetchInterval` 추가 — 처리 중(`processing_status === 'processing'`) 카드가 있을 때만 2초 폴링, 정착되면 중단(`dataUpdateCount` 상한 ~30초). 확정 화면이 이 쿼리를 쓰므로 좌표 도착 시 지도가 자동 갱신됩니다.
- **지도 컴포넌트**: 확정 화면 `MapCard`(@vis.gl/react-google-maps)는 순서·동선용이라, 단일 위치용 `PlaceLocationMap`(핀 1개)을 분리해 재사용했습니다.
- 참고: "배치 변경 후 재진입 stale 좌표"는 React Query 기본 `refetchOnMount`로 재진입 시 갱신돼 커버됩니다. 선택/편집 상세 패널은 해당 카드가 대개 좌표가 없어 지도를 붙이지 않았습니다.


## 📸 스크린샷

<img width="462" height="1211" alt="image" src="https://github.com/user-attachments/assets/12896d74-ac64-4e9f-8d38-a6c5220120b9" />