### PR TITLE
Refactor: detail panel layout

### DIFF
--- a/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
+++ b/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
@@ -95,7 +95,7 @@ const CardDetailPanel = ({
     <SidePanel open={open} onOpenChange={onOpenChange}>
       {card?.detail ? (
         <CardDetailBody
-          key={card.id}
+          key={`${card.id}:${card.detail?.question ?? ''}`}
           card={card}
           onClose={() => onOpenChange(false)}
           onSaveMemo={onSaveMemo}

--- a/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
+++ b/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
@@ -538,7 +538,7 @@ const QuestionInputSection = ({
               className={cn(
                 'rounded-lg border px-3 py-2 text-sm transition-colors disabled:opacity-50',
                 active
-                  ? 'border-indigo-300 bg-indigo-50 font-medium text-indigo-700 dark:border-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-200'
+                  ? 'border-primary/40 bg-primary/10 font-medium text-primary dark:border-primary/40 dark:bg-primary/20 dark:text-primary'
                   : 'border-input bg-background text-foreground hover:border-muted-foreground/30 hover:bg-muted/50'
               )}
             >

--- a/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
+++ b/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { Clock, Info, MapPin, Plane, User, X } from 'lucide-react';
+import { Bot, Clock, Info, MapPin, Plane, User, X } from 'lucide-react';
 import { Dialog } from 'radix-ui';
 import { useState } from 'react';
 
@@ -9,7 +9,6 @@ import {
   AnswerField,
   DetailRow,
   ItineraryInclusionBox,
-  QuestionBox,
   StructuredEditSection,
   UserMemoField,
 } from '@/components/grouping/CardDetailParts';
@@ -522,10 +521,20 @@ const QuestionInputSection = ({
 }) => (
   <section>
     <h3 className="text-sm font-semibold text-foreground">질문 / 입력</h3>
-    <QuestionBox question={question} />
 
+    {/* AI 질문 — 말풍선 */}
+    <div className="mt-3 flex gap-2.5">
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Bot className="size-4" aria-hidden="true" />
+      </div>
+      <div className="min-w-0 rounded-2xl rounded-tl-md bg-muted/60 px-4 py-3 text-sm leading-relaxed text-foreground">
+        {question}
+      </div>
+    </div>
+
+    {/* 선택지 — 퀵리플라이 */}
     {choices.length > 0 && (
-      <div className="mt-3 flex flex-wrap gap-2">
+      <div className="mt-3 flex flex-wrap gap-2 pl-10.5">
         {choices.map((choice) => {
           const active = selectedChoices.includes(choice);
           return (
@@ -536,7 +545,7 @@ const QuestionInputSection = ({
               disabled={disabled}
               onClick={() => onToggleChoice(choice)}
               className={cn(
-                'rounded-lg border px-3 py-2 text-sm transition-colors disabled:opacity-50',
+                'rounded-full border px-3.5 py-1.5 text-sm transition-colors disabled:opacity-50',
                 active
                   ? 'border-primary/40 bg-primary/10 font-medium text-primary dark:border-primary/40 dark:bg-primary/20 dark:text-primary'
                   : 'border-input bg-background text-foreground hover:border-muted-foreground/30 hover:bg-muted/50'
@@ -549,11 +558,14 @@ const QuestionInputSection = ({
       </div>
     )}
 
-    <AnswerField
-      value={answer}
-      onChange={onAnswerChange}
-      placeholder="선택한 내용 외에 더 남기고 싶은 내용을 적어주세요..."
-      disabled={disabled}
-    />
+    {/* 답변 입력 */}
+    <div className="mt-3 pl-10.5">
+      <AnswerField
+        value={answer}
+        onChange={onAnswerChange}
+        placeholder="선택하거나, 직접 답변을 입력하세요..."
+        disabled={disabled}
+      />
+    </div>
   </section>
 );

--- a/apps/frontend/src/components/common/SidePanel.tsx
+++ b/apps/frontend/src/components/common/SidePanel.tsx
@@ -17,8 +17,8 @@ const SidePanel = ({ open, onOpenChange, children }: SidePanelProps) => {
         {/* 배경 dim. 클릭하면 닫힘(radix 기본) */}
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0" />
 
-        {/* 오른쪽에 붙는 세로 패널. 모바일은 풀폭, 그 위로는 ~448px(max-w-md) */}
-        <Dialog.Content className="fixed inset-y-0 right-0 z-50 flex w-full flex-col bg-card shadow-xl outline-none sm:max-w-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right data-[state=open]:duration-300 data-[state=closed]:duration-200">
+        {/* 오른쪽에 붙는 세로 패널. 모바일은 풀폭, 그 위로는 ~512px(max-w-lg) */}
+        <Dialog.Content className="fixed inset-y-0 right-0 z-50 flex w-full flex-col bg-card shadow-xl outline-none sm:max-w-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right data-[state=open]:duration-300 data-[state=closed]:duration-200">
           {children || (
             // 내용 없이 열린 경우(이론상 없음) — radix a11y 경고 방지용 최소 마크업.
             <>

--- a/apps/frontend/src/components/common/SidePanel.tsx
+++ b/apps/frontend/src/components/common/SidePanel.tsx
@@ -17,8 +17,8 @@ const SidePanel = ({ open, onOpenChange, children }: SidePanelProps) => {
         {/* 배경 dim. 클릭하면 닫힘(radix 기본) */}
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0" />
 
-        {/* 오른쪽에 붙는 세로 패널. 모바일은 풀폭, 그 위로는 ~512px(max-w-lg) */}
-        <Dialog.Content className="fixed inset-y-0 right-0 z-50 flex w-full flex-col bg-card shadow-xl outline-none sm:max-w-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right data-[state=open]:duration-300 data-[state=closed]:duration-200">
+        {/* 오른쪽에 뜨는 세로 패널. 모바일은 풀폭 서랍, 그 위로는 가장자리에서 띄운 ~512px 카드 */}
+        <Dialog.Content className="fixed inset-y-0 right-0 z-50 flex w-full flex-col overflow-hidden bg-card shadow-xl outline-none sm:inset-y-4 sm:right-4 sm:max-w-lg sm:rounded-2xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right data-[state=open]:duration-300 data-[state=closed]:duration-200">
           {children || (
             // 내용 없이 열린 경우(이론상 없음) — radix a11y 경고 방지용 최소 마크업.
             <>

--- a/apps/frontend/src/components/grouping/CardDetailParts.tsx
+++ b/apps/frontend/src/components/grouping/CardDetailParts.tsx
@@ -197,7 +197,7 @@ export const StatusInfoBox = ({
   classification: string;
   placementStatus: string;
 }) => (
-  <section className="rounded-xl bg-muted/60 p-4">
+  <section className="rounded-2xl bg-muted/60 p-4">
     <h3 className="text-sm font-semibold text-foreground">상태 정보</h3>
     <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
       <div className="min-w-0">
@@ -254,7 +254,7 @@ export const ItineraryInclusionBox = ({
   //포함하기(included=false 일 때만 보임)
   onInclude?: () => void;
 }) => (
-  <div className="flex items-center justify-between gap-3 rounded-xl bg-muted/60 p-4">
+  <div className="flex items-center justify-between gap-3 rounded-2xl bg-muted/60 p-4">
     <div className="min-w-0">
       <p className="text-sm font-semibold text-foreground">
         {included ? '일정에 포함된 항목이에요' : '현재 제외된 항목이에요'}
@@ -292,7 +292,7 @@ export const ItineraryInclusionBox = ({
 
 // 질문 박스
 export const QuestionBox = ({ question }: { question: string }) => (
-  <div className="mt-3 rounded-xl bg-primary/10 px-4 py-3.5 dark:bg-primary/15">
+  <div className="mt-3 rounded-2xl bg-primary/10 px-4 py-3.5 dark:bg-primary/15">
     <p className="text-xs font-semibold text-primary dark:text-primary">
       질문
     </p>

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -612,11 +612,14 @@ const ArrangePage = () => {
           .flatMap((group) => group.cards)
           .find((card) => card.id === instanceId);
         if (refreshed) setDetailCard(refreshed);
-        setResolveError(
-          timedOut
-            ? '재처리가 시간 내에 끝나지 않았어요. 잠시 후 다시 시도해 주세요.'
-            : '현재 정보로는 위치를 찾지 못했어요. 장소명이나 주소를 더 정확히 입력해 주세요.'
-        );
+        // 후속 질문이 있으면 대화가 이어지는 것이므로 에러 대신 질문을 보여준다.
+        if (!refreshed?.detail?.question) {
+          setResolveError(
+            timedOut
+              ? '재처리가 시간 내에 끝나지 않았어요. 잠시 후 다시 시도해 주세요.'
+              : '현재 정보로는 위치를 찾지 못했어요. 장소명이나 주소를 더 정확히 입력해 주세요.'
+          );
+        }
       }
     };
 
@@ -669,7 +672,7 @@ const ArrangePage = () => {
         payload: { notes },
       });
       applyUpdatedCardLocally(updated);
-      setDetailOpen(false);
+      // 닫지 않고 유지 — 재파싱 후 후속 질문이 있으면 이어서 보여준다(startResolvePoll).
     } catch (error) {
       setResolving(false);
       setResolveError(errorMessageOf(error, '재처리 요청에 실패했습니다.'));

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -218,6 +218,8 @@ const GroupingPage = () => {
   const [reviewOpen, setReviewOpen] = useState(false);
   const [selectCard, setSelectCard] = useState<PlaceCardViewModel | null>(null);
   const [selectOpen, setSelectOpen] = useState(false);
+  // 답변 후 재파싱 결과에 후속 질문이 있으면 패널을 이어서 유지하기 위한 대기 카드 id
+  const [awaitingSelectId, setAwaitingSelectId] = useState<string | null>(null);
   const [editCard, setEditCard] = useState<PlaceCardViewModel | null>(null);
   const [editOpen, setEditOpen] = useState(false);
   const [addCardOpen, setAddCardOpen] = useState(false);
@@ -647,7 +649,23 @@ const GroupingPage = () => {
     activeCount: 0,
     doneCount: 0,
   };
-  const groups = viewModel?.groups ?? [];
+  const groups = useMemo(() => viewModel?.groups ?? [], [viewModel]);
+
+  // 답변 후: 재파싱이 끝나면(폴링으로 groups 갱신) 후속 질문이 있으면 그 질문으로 패널을 갱신(유지),
+  // 없으면(해결) 닫는다. — 패널이 닫혀서 후속 질문을 놓치던 문제 해결.
+  useEffect(() => {
+    if (!awaitingSelectId) return;
+    const updated = groups
+      .flatMap((group) => group.cards)
+      .find((card) => card.id === awaitingSelectId);
+    if (!updated || updated.processing) return; // 아직 처리 중이면 다음 폴링까지 대기
+    if (updated.selectDetail?.question) {
+      setSelectCard(updated); // 후속 질문으로 재바인딩 — 패널 유지
+    } else {
+      setSelectOpen(false); // 해결됨 — 닫기
+    }
+    setAwaitingSelectId(null);
+  }, [groups, awaitingSelectId]);
   const nights = exactDate?.nights ?? flexDate?.nights ?? 0;
   const summary: TripSummaryViewModel = {
     ...(viewModel?.summary ?? FALLBACK_SUMMARY),
@@ -796,16 +814,23 @@ const GroupingPage = () => {
 
       <SelectCardDetailPanel
         open={selectOpen}
-        onOpenChange={setSelectOpen}
+        onOpenChange={(open) => {
+          setSelectOpen(open);
+          if (!open) setAwaitingSelectId(null);
+        }}
         card={selectCard}
-        pending={busy}
+        pending={busy || awaitingSelectId != null}
         error={state.phase === 'ready' ? state.errorMessage : null}
         onConfirm={async (payload) => {
           const cardId = selectCard?.id;
           if (await handleConfirmSelect(selectCard, payload)) {
-            setSelectOpen(false);
-            // 재파싱이 끝나면 결과가 자동 반영되도록 폴링 새로고침 시작
-            if (cardId) pollUntilCardSettled(cardId);
+            // 닫지 않고, 재파싱 후 후속 질문이 있으면 이어서 보여준다(위 effect).
+            if (cardId) {
+              setAwaitingSelectId(cardId);
+              pollUntilCardSettled(cardId);
+            } else {
+              setSelectOpen(false);
+            }
           }
         }}
         onExclude={async () => {


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 상세 패널을 넓히고 카드형·챗 말풍선 UI로 정리하고, 답변 후 후속 질문이 패널 안에서 이어 보이도록 개선했습니다. (정리·배치 동일)

## 🔗 관련 이슈

closes #317

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (패널 레이아웃 + 03·04 후속 질문 흐름 확인)
- [x] 기존 기능이 깨지지 않았나요? (resolve/patch API·파싱 로직 무변경, 패널 닫기 흐름만 조정)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? (상세 패널 UI + 후속 질문 표시)

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- **UI 전용 + 프론트 닫기 흐름 조정**입니다. 백엔드/재파싱 로직은 변경 없습니다.
- 후속 질문 흐름(핵심):
  - **정리(GroupingPage)**: 답변 후 즉시 닫지 않고, 폴링으로 `groups` 갱신을 감지하는 effect에서 재파싱된 카드에 후속 질문이 있으면 그 질문으로 패널 재바인딩(유지), 없으면 닫기.
  - **배치(ArrangePage)**: `handleResolveByNotes`의 즉시 닫기를 제거하고 기존 `startResolvePoll` 재바인딩을 활용, settle 시 후속 질문이 있으면 에러 대신 질문을 노출.
  - **공유 패널**: `CardDetailBody`의 `key`에 질문을 포함해 후속 질문 도착 시 입력 상태를 초기화.
- SidePanel 폭 `max-w-md → max-w-lg`, 가장자리에서 띄운 둥근 카드 형태(sm 이상), 질문/입력을 챗 말풍선 UI로 정리, 선택지 칩 `indigo → primary` 정합.

## 📸 스크린샷
<img width="536" height="1135" alt="image" src="https://github.com/user-attachments/assets/167facf9-9dd5-491a-95fe-fb7ef483cfea" />
