### PR TITLE
fix: 정확한 날짜 재선택 시 유연한 날짜 탭으로 전환되는 현상 수정

### DIFF
--- a/apps/frontend/src/components/onboarding/calendar/TripCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/TripCalendar.tsx
@@ -1,5 +1,5 @@
 import './TripCalendar.css';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { useCalendarStore } from '@/utils/calendar-store';
 
@@ -9,10 +9,6 @@ import FlexCalendar from './FlexCalendar';
 const TripCalendar = () => {
   const storedTab = useCalendarStore((s) => s.type);
   const [tab, setTab] = useState<'exact' | 'flexible'>(storedTab ?? 'flexible');
-
-  useEffect(() => {
-    if (storedTab === null) setTab('flexible');
-  }, [storedTab]);
 
   return (
     <div>


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 정확한 날짜 탭에서 기간 재선택 시 유연한 날짜 탭으로 튕기던 현상 수정

## 🔗 관련 이슈

closes #318

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.
> 없으면 "없음"으로 남겨주세요.

`TripCalendar`의 탭 상태를 store `type`에 종속시키던 `useEffect`를 제거했습니다.
- 원인: range 모드에서 완성된 범위가 있을 때 새 날짜를 클릭하면 react-day-picker가 `{ from, to: undefined }`로 초기화 → `ExactCalendar`가 `clearExactDate()`로 `type: null`을 만들고 → `useEffect`가 이를 감지해 탭을 `flexible`로 강제 전환하던 흐름
- 탭은 로컬 네비게이션 상태이므로 store `type`에 반응할 필요가 없고, 초기 마운트 기본값은 `storedTab ?? 'flexible'`로 그대로 유지됩니다.

## 📸 스크린샷

