### PR TITLE
Feat: logo select session reset

### DIFF
--- a/apps/frontend/src/components/common/SplashScreen.tsx
+++ b/apps/frontend/src/components/common/SplashScreen.tsx
@@ -38,16 +38,17 @@ const SplashScreen = ({
       }}
     >
       <div
-        className="flex items-center gap-3 transition-all duration-700 ease-out"
+        className="flex flex-col items-center gap-4 text-center transition-all duration-700 ease-out"
         style={{
           opacity: entered ? 1 : 0,
           transform: entered ? 'translateY(0)' : 'translateY(8px)',
         }}
       >
-        <span className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary text-2xl font-bold text-primary-foreground">
-          T
-        </span>
-        <span className="text-3xl font-bold tracking-tight">TripKey</span>
+        <span className="text-5xl font-bold tracking-tight">TripKey</span>
+
+        <p className="text-sm text-muted-foreground">
+          떠오르는 대로 적어보세요, 정리는 트립키가
+        </p>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/header/Header.tsx
+++ b/apps/frontend/src/components/header/Header.tsx
@@ -54,6 +54,19 @@ const Header = ({
   const currentIndex = STEPS.findIndex((step) => step.id === currentStepId);
   const widthClass = fluid ? 'w-full' : 'mx-auto w-full max-w-6xl';
 
+  // 로고 클릭 = 세션 초기화 후 메인으로. (확정 화면 '여행 세션 초기화'와 동일 방식)
+  const handleLogoReset = () => {
+    if (
+      !window.confirm(
+        '지금까지 계획한 여행이 모두 초기화돼요. 처음부터 다시 시작할까요?'
+      )
+    ) {
+      return;
+    }
+    sessionStorage.clear();
+    window.location.href = '/';
+  };
+
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background">
       <div
@@ -62,9 +75,14 @@ const Header = ({
           widthClass
         )}
       >
-        <Link to="/" className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleLogoReset}
+          className="flex items-center gap-2"
+          aria-label="TripKey 홈 — 세션 초기화"
+        >
           <span className="text-xl font-bold tracking-tight">TripKey</span>
-        </Link>
+        </button>
         <Tooltip>
           <TooltipTrigger asChild>
             <button


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 트립키 로고 클릭 시 확인 후 세션을 초기화하고 메인으로 이동하도록 하고, 초기화 후 다시 뜨는 스플래시 화면을 단정하게 정리했습니다.

## 🔗 관련 이슈

closes #321

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요? (로고 클릭 → 확인 → 세션 초기화·메인 이동·스플래시 표시 확인)
- [x] 기존 기능이 깨지지 않았나요? (헤더 공용 컴포넌트, 로고만 링크 → 버튼으로 변경)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요? (로고 세션 초기화 + 관련 스플래시)

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- **UI/전역 헤더 변경**입니다. 백엔드 없음.
- 로고: 공용 `Header.tsx`의 `<Link to="/">` → `<button>`으로 변경. 클릭 시 `window.confirm` 확인 후 `sessionStorage.clear()` + 메인(`/`) 전체 새로고침 이동. (확정 화면 '여행 세션 초기화'와 동일 방식, 이동 경로만 메인)
  - sessionStorage 기반 스토어(온보딩/캘린더/덤프)가 한 번에 초기화됩니다.
- 스플래시(`SplashScreen.tsx`): 'T' 아이콘 박스 제거, 워드마크 확대(text-5xl), 하단 태그라인 추가. (세션 초기화로 splash-seen 플래그가 지워져 초기화 직후 다시 노출됨)

## 📸 스크린샷