### PR TITLE
feat: 확정 화면 공유 링크 기능 및 공유 뷰 읽기 전용 처리

### DIFF
--- a/apps/frontend/src/components/confirm/SaveShareCard.tsx
+++ b/apps/frontend/src/components/confirm/SaveShareCard.tsx
@@ -1,9 +1,54 @@
 // SaveShareCard — 확정 화면(SCR-05) 우측 사이드 하단. 저장/공유 액션 카드.
-// 버튼 동작은 추후 연결 (UI 만).
+// 공유하기: 확정 화면은 tripId 만으로 인증 없이 조회되므로, 같은 URL 을 그대로 공유한다.
+//   Web Share API(모바일 네이티브 공유) → 없으면 클립보드 복사로 폴백.
+// 저장하기: 아직 준비 중 — 프로필 버튼과 동일하게 Tooltip 안내만.
 
 import { Download, Share2 } from 'lucide-react';
+import { useState } from 'react';
 
-const SaveShareCard = () => {
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+type SaveShareCardProps = {
+  tripId: string | null;
+};
+
+const SaveShareCard = ({ tripId }: SaveShareCardProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    if (!tripId) return;
+
+    // shared=1 : 공유 링크로 들어온 방문자는 확정 화면만 읽기 전용으로 보게 한다.
+    const shareUrl = `${window.location.origin}/confirm?tripId=${tripId}&shared=1`;
+
+    // 모바일 등 Web Share API 지원 환경에서는 네이티브 공유 시트를 띄운다.
+    // text 를 넣으면 "링크 복사" 시 브라우저가 url 뒤에 text 를 이어붙여
+    // tripId 파라미터가 오염되므로(=서버 404), url 만 공유한다.
+    if (navigator.share) {
+      try {
+        await navigator.share({ url: shareUrl });
+        return;
+      } catch (error) {
+        // 사용자가 공유 시트를 취소한 경우는 조용히 무시.
+        if (error instanceof DOMException && error.name === 'AbortError')
+          return;
+        // 그 외 실패는 클립보드 복사로 폴백.
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      window.prompt('아래 링크를 복사해 공유하세요.', shareUrl);
+    }
+  };
+
   return (
     <section className="rounded-2xl bg-card p-5 ring-1 ring-foreground/10">
       <h3 className="text-sm font-bold text-foreground">이 화면의 정체성</h3>
@@ -13,23 +58,29 @@ const SaveShareCard = () => {
       </p>
 
       <div className="mt-4 flex items-center gap-2">
-        {/* 저장(PDF)/공유는 아직 동작 미구현 — 임시 표식 */}
-        <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
-          미구현
-        </span>
+        {/* 저장하기는 준비 중 — 프로필 버튼과 동일하게 Tooltip 안내만. */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="저장하기 (준비 중)"
+              className="inline-flex cursor-default items-center gap-1.5 rounded-lg bg-muted px-4 py-2 text-sm font-medium text-muted-foreground"
+            >
+              <Download className="size-4" aria-hidden="true" />
+              저장하기
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>저장 기능은 준비 중이에요</TooltipContent>
+        </Tooltip>
+
         <button
           type="button"
-          className="inline-flex items-center gap-1.5 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background"
-        >
-          <Download className="size-4" aria-hidden="true" />
-          저장하기
-        </button>
-        <button
-          type="button"
-          className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+          onClick={handleShare}
+          disabled={!tripId}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Share2 className="size-4" aria-hidden="true" />
-          공유하기
+          {copied ? '링크 복사됨' : '공유하기'}
         </button>
       </div>
     </section>

--- a/apps/frontend/src/components/header/Header.tsx
+++ b/apps/frontend/src/components/header/Header.tsx
@@ -39,6 +39,8 @@ export type HeaderProps = {
   showTripMeta?: boolean;
   /** true면 헤더 내용을 전체폭으로(워크스페이스형: 배치·확정). 기본은 가운데 정렬(문서형). */
   fluid?: boolean;
+  /** false면 단계 진행바를 숨긴다(공유 링크 읽기 전용 뷰 등). 기본 노출. */
+  showStepper?: boolean;
 };
 
 const Header = ({
@@ -50,6 +52,7 @@ const Header = ({
   actions,
   showTripMeta = true,
   fluid = false,
+  showStepper = true,
 }: HeaderProps) => {
   const currentIndex = STEPS.findIndex((step) => step.id === currentStepId);
   const widthClass = fluid ? 'w-full' : 'mx-auto w-full max-w-6xl';
@@ -144,9 +147,11 @@ const Header = ({
           ) : (
             <div />
           )}
-          <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-            <Stepper currentIndex={currentIndex} />
-          </div>
+          {showStepper && (
+            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+              <Stepper currentIndex={currentIndex} />
+            </div>
+          )}
         </div>
       </div>
     </header>

--- a/apps/frontend/src/pages/ConfirmPage.tsx
+++ b/apps/frontend/src/pages/ConfirmPage.tsx
@@ -35,6 +35,10 @@ const ConfirmPage = () => {
   const form = useOnboardingStore((s) => s.form);
   const tripId = urlTripId ?? storeTripId;
 
+  // 공유 링크(?shared=1)로 들어온 방문자: 확정 화면만 읽기 전용으로 보여주고
+  // 단계 진행바·다른 화면으로 넘어가는 액션(배치/세션 초기화)을 숨긴다.
+  const isShared = searchParams.get('shared') === '1';
+
   // dateRange 폴백용 — 서버 start_date·출국편으로 날짜를 못 구할 때만 사용.
   const calType = useCalendarStore((s) => s.type);
   const exactDate = useCalendarStore((s) => s.exactDate);
@@ -123,26 +127,29 @@ const ConfirmPage = () => {
       <Header
         fluid
         currentStepId="confirm"
+        showStepper={!isShared}
         destination={summary.destination}
         extraDestinations={summary.extraDestinations}
         travelers={summary.travelers}
         dateRange={summary.dateRange}
         actions={
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={!tripId}
-              onClick={() =>
-                navigate(`/arrange${tripId ? `?tripId=${tripId}` : ''}`)
-              }
-            >
-              배치로 돌아가기
-            </Button>
-            <Button variant="outline" size="sm" onClick={handleResetSession}>
-              여행 세션 초기화
-            </Button>
-          </div>
+          isShared ? undefined : (
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!tripId}
+                onClick={() =>
+                  navigate(`/arrange${tripId ? `?tripId=${tripId}` : ''}`)
+                }
+              >
+                배치로 돌아가기
+              </Button>
+              <Button variant="outline" size="sm" onClick={handleResetSession}>
+                여행 세션 초기화
+              </Button>
+            </div>
+          )
         }
       />
 
@@ -234,7 +241,7 @@ const ConfirmPage = () => {
                         <ContextCardList cards={activeDay.contextCards} />
                         <div className="flex flex-col gap-6">
                           <DayChecklist items={activeDay.dayChecklist} />
-                          <SaveShareCard />
+                          <SaveShareCard tripId={tripId} />
                         </div>
                       </div>
                     </>


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 확정 화면(SCR-05)에 tripId 기반 공유 링크 기능을 추가하고, 공유 링크로 들어온 방문자는 확정 화면만 읽기 전용으로 보게 처리했습니다.

## 🔗 관련 이슈

closes #323

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

> 복잡한 로직이 있거나 특히 집중해서 봐줬으면 하는 부분을 적어주세요.

- **공유 방식**: 확정 화면 데이터가 인증 없이 tripId만으로 조회되는 현 구조를 활용해, 별도 백엔드/라우트 없이 `${origin}/confirm?tripId=…&shared=1` URL을 그대로 공유합니다.
- **공유 동작**: `navigator.share`(모바일 네이티브 시트) → 미지원 시 클립보드 복사 → 그마저 막히면 `prompt` 폴백. Web Share에 `text`를 넣으면 "링크 복사" 시 URL 뒤에 텍스트가 붙어 tripId가 오염되는 이슈가 있어 `url`만 공유합니다.
- **읽기 전용 뷰**: `shared=1` 플래그가 있으면 Header 단계 진행바와 액션 버튼(배치로 돌아가기·세션 초기화)을 숨겨 확정 화면에 고정합니다. 단, 이건 UI 가드 수준으로 플래그를 지우면 우회 가능 — 진짜 권한 분리는 백엔드 인증이 필요해 별도 이슈 대상입니다.
- **저장하기**: 아직 미구현이라 프로필 버튼과 동일한 "준비 중" Tooltip으로 통일했습니다.

## 📸 스크린샷
