### PR TITLE
style: 페이지 전환 진입 모션 적용

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -12,17 +12,19 @@ import GroupingPage from './pages/GroupingPage';
 import MainPage from './pages/MainPage';
 import OnboardingPage from './pages/OnboardingPage';
 
-const SPLASH_SEEN_KEY = 'tripkey:splash-seen';
+// 세션 리셋(로고/확정 화면) 직후에만 스플래시를 띄운다.
+// 리셋 시 sessionStorage.clear() 후 이 플래그를 심고 리로드하므로,
+// 일반 첫 진입(플래그 없음)에는 스플래시가 뜨지 않는다.
+const SPLASH_FLAG_KEY = 'tripkey:show-splash';
 
 const AppContent = () => {
   const navigate = useNavigate();
 
-  // 첫 진입 시 한 번 보여주는 스플래시.
   const [showSplash, setShowSplash] = useState(
-    () => sessionStorage.getItem(SPLASH_SEEN_KEY) !== '1'
+    () => sessionStorage.getItem(SPLASH_FLAG_KEY) === '1'
   );
   const handleSplashFinish = () => {
-    sessionStorage.setItem(SPLASH_SEEN_KEY, '1');
+    sessionStorage.removeItem(SPLASH_FLAG_KEY); // 일회용 — 소비
     setShowSplash(false);
   };
 

--- a/apps/frontend/src/components/common/PageTransition.tsx
+++ b/apps/frontend/src/components/common/PageTransition.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * 페이지 진입 모션 공용 클래스.
+ * tw-animate-css의 enter 키프레임을 마운트 시 한 번만 재생한다.
+ * 키프레임 방식이라 재생이 끝나면 잔여 transform이 남지 않아
+ * sticky/맵/드래그앤드롭 등 좌표 기반 레이아웃에 영향을 주지 않는다.
+ * motion-safe 로 감싸 prefers-reduced-motion 사용자는 자동 제외된다.
+ */
+
+// 기본: 살짝 떠오르며 페이드인 (자체 연출이 없는 일반 화면용).
+export const PAGE_ENTER =
+  'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-500 motion-safe:ease-out';
+
+// 페이드만: 지도 등 transform 에 민감한 화면용(슬라이드 없이 opacity 만).
+export const PAGE_ENTER_FADE =
+  'motion-safe:animate-in motion-safe:fade-in-0 motion-safe:duration-500 motion-safe:ease-out';
+
+/**
+ * Fragment 루트 페이지를 감싸 화면 전체가 부드럽게 떠오르도록 한다.
+ * 단일 루트 엘리먼트가 있는 페이지는 이 래퍼 대신 PAGE_ENTER(_FADE) 를 직접 붙이면 된다.
+ */
+const PageTransition = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => <div className={cn(PAGE_ENTER, className)}>{children}</div>;
+
+export default PageTransition;

--- a/apps/frontend/src/components/header/Header.tsx
+++ b/apps/frontend/src/components/header/Header.tsx
@@ -64,6 +64,7 @@ const Header = ({
       return;
     }
     sessionStorage.clear();
+    sessionStorage.setItem('tripkey:show-splash', '1'); // 리셋 후에만 스플래시 노출
     window.location.href = '/';
   };
 

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -16,6 +16,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import CardListPanel from '@/components/arrange/CardListPanel';
 import DayColumn from '@/components/arrange/DayColumn';
 import CardDetailPanel from '@/components/card-detail/CardDetailPanel';
+import { PAGE_ENTER } from '@/components/common/PageTransition';
 import AddCardModal from '@/components/grouping/AddCardModal';
 import Header from '@/components/header/Header';
 import { Button } from '@/components/ui/button';
@@ -31,6 +32,7 @@ import {
   useVerifyPlacementMutation,
 } from '@/hooks/useArrange';
 import { useTripDetailQuery } from '@/hooks/useTripDetail';
+import { cn } from '@/lib/utils';
 import type {
   ArrangeCardGroup,
   ArrangeCardViewModel,
@@ -888,7 +890,12 @@ const ArrangePage = () => {
   );
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-linear-to-b from-muted/50 to-background">
+    <div
+      className={cn(
+        'flex h-screen flex-col overflow-hidden bg-linear-to-b from-muted/50 to-background',
+        PAGE_ENTER
+      )}
+    >
       <Header
         fluid
         currentStepId="arrange"

--- a/apps/frontend/src/pages/ConfirmPage.tsx
+++ b/apps/frontend/src/pages/ConfirmPage.tsx
@@ -5,6 +5,7 @@
 import { useMemo, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
+import { PAGE_ENTER_FADE } from '@/components/common/PageTransition';
 import AlertCardList from '@/components/confirm/AlertCardList';
 import ContextCardList from '@/components/confirm/ContextCardList';
 import DayChecklist from '@/components/confirm/DayChecklist';
@@ -19,6 +20,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useArrangeCardsQuery, useDaysQuery } from '@/hooks/useArrange';
 import { useTripDetailQuery } from '@/hooks/useTripDetail';
+import { cn } from '@/lib/utils';
 import { formatDateRangeLabel, useCalendarStore } from '@/utils/calendar-store';
 import { mapToConfirmViewModel } from '@/utils/confirm-mapper';
 import { useOnboardingStore } from '@/utils/onboarding-store';
@@ -98,6 +100,7 @@ const ConfirmPage = () => {
     }
 
     sessionStorage.clear();
+    sessionStorage.setItem('tripkey:show-splash', '1'); // 리셋 후에만 스플래시 노출
     window.location.href = '/onboarding';
   };
 
@@ -119,7 +122,7 @@ const ConfirmPage = () => {
   );
 
   return (
-    <div className="flex min-h-screen flex-col bg-muted">
+    <div className={cn('flex min-h-screen flex-col bg-muted', PAGE_ENTER_FADE)}>
       <Header
         fluid
         currentStepId="confirm"

--- a/apps/frontend/src/pages/DumpPage.tsx
+++ b/apps/frontend/src/pages/DumpPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import PageTransition from '../components/common/PageTransition';
 import DumpForm from '../components/dump/DumpForm';
 import {
   DumpAiInfoCard,
@@ -110,7 +111,7 @@ const DumpPage = () => {
   }
 
   return (
-    <>
+    <PageTransition>
       <Header
         currentStepId="dump"
         destination={summary.destinations[0] ?? '여행'}
@@ -167,7 +168,7 @@ const DumpPage = () => {
           </div>
         </div>
       </main>
-    </>
+    </PageTransition>
   );
 };
 

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -28,6 +28,7 @@ import type {
 } from '@/types/grouping';
 import type { Card, Groups03Response } from '@/types/grouping-api';
 
+import PageTransition from '../components/common/PageTransition';
 import type { CardPatchRequest } from '../types/grouping-api';
 import {
   useCalendarStore,
@@ -677,7 +678,7 @@ const GroupingPage = () => {
   };
 
   return (
-    <>
+    <PageTransition>
       <Header
         currentStepId="organize"
         destination={summary.destinations[0] ?? '여행'}
@@ -888,7 +889,7 @@ const GroupingPage = () => {
           );
         }}
       />
-    </>
+    </PageTransition>
   );
 };
 

--- a/apps/frontend/src/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/pages/OnboardingPage.tsx
@@ -2,6 +2,7 @@ import { Calendar, MapPin, Minus, Plus, User } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import PageTransition from '../components/common/PageTransition';
 import ProgressStat from '../components/common/ProgressStat';
 import Header from '../components/header/Header';
 import TripCalendar from '../components/onboarding/calendar/TripCalendar';
@@ -84,7 +85,7 @@ const OnboardingPage = () => {
   };
 
   return (
-    <>
+    <PageTransition>
       <Header
         currentStepId="onboarding"
         showTripMeta={false}
@@ -225,7 +226,7 @@ const OnboardingPage = () => {
           </div>
         </div>
       </div>
-    </>
+    </PageTransition>
   );
 };
 


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 페이지 이동이 뚝 끊기던 문제를 온보딩~확정 단계 진입 모션으로 완화하고, 스플래시(가운데 로고)를 첫 진입이 아닌 세션 리셋 시에만 노출하도록 변경

## 🔗 관련 이슈

closes #325

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인) — tsc / eslint / vite build 통과
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- **진입 모션만(enter-only)입니다.** react-router `<Routes>`가 나가는 페이지를 즉시 언마운트해서 exit 애니메이션은 없고, 새 페이지가 마운트될 때 한 번 재생되는 방식입니다.
- **페이지별로 모션이 다릅니다** (레이아웃 리스크 기반):
  - 온보딩·dump·정리·배치: fade + slide-up (`PAGE_ENTER`)
  - **확정(ConfirmPage): fade만(`PAGE_ENTER_FADE`)** — Google Maps(@vis.gl) 컨테이너가 transform 중 초기화되면 마커/타일이 어긋날 수 있어 슬라이드 제외
  - **메인(MainPage): 미적용** — hero 페이드·`useReveal`·오로라 등 자체 연출과 중복 방지
- 키프레임 방식이라 재생 종료 후 잔여 `transform`이 남지 않아 sticky/맵/드래그앤드롭 좌표에 영향 없음. `motion-safe:`로 감싸 `prefers-reduced-motion` 사용자는 자동 제외.
- **스플래시 로직**: 리셋은 `sessionStorage.clear()` + 전체 리로드라 "첫 진입 vs 리셋 후"를 구분할 수 없어, `clear()` 직후 일회용 플래그(`tripkey:show-splash`)를 심고 다음 로드에서 1회 소비하는 방식으로 처리했습니다. 리셋 경로가 2곳(로고 클릭 `Header.tsx` / 확정화면 세션 초기화 `ConfirmPage.tsx`)이라 두 곳 모두 플래그를 세팅합니다.

## 📸 스크린샷