### PR TITLE
feat: 유연한 날짜 박수 직접 입력 및 여행 길이 최대 9박10일 제한

### DIFF
--- a/apps/frontend/src/components/onboarding/calendar/ExactCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/ExactCalendar.tsx
@@ -2,7 +2,12 @@ import { format, differenceInDays } from 'date-fns';
 import { useEffect, useState } from 'react';
 import { type DateRange, DayPicker } from 'react-day-picker';
 
-import { useCalendarStore } from '@/utils/calendar-store';
+import Callout from '@/components/common/Callout';
+import {
+  MAX_TRIP_DAYS,
+  MAX_TRIP_NIGHTS,
+  useCalendarStore,
+} from '@/utils/calendar-store';
 import { useOnboardingStore } from '@/utils/onboarding-store';
 
 import { CalendarNav } from './CalendarNav';
@@ -18,10 +23,12 @@ export const ExactCalendar = () => {
     from: exactDate?.from,
     to: exactDate?.to,
   }));
+  const [showLimit, setShowLimit] = useState(false);
 
   useEffect(() => {
     if (exactDate === null) {
       setRange({ from: undefined, to: undefined });
+      setShowLimit(false);
     }
   }, [exactDate]);
 
@@ -30,13 +37,23 @@ export const ExactCalendar = () => {
     const to =
       newRange?.to?.getTime() === from?.getTime() ? undefined : newRange?.to;
 
-    setRange({ from, to });
-
     if (from && to) {
       const nights = differenceInDays(to, from);
+      if (nights + 1 > MAX_TRIP_DAYS) {
+        // 상한 초과: 반영하지 않고 방금 클릭한 날짜를 새 시작일로 두어 다시 고르게 함
+        setShowLimit(true);
+        setRange({ from: to, to: undefined });
+        clearExactDate();
+        setForm({ travel_days: 0 });
+        return;
+      }
+      setShowLimit(false);
+      setRange({ from, to });
       setExactDate({ from, to, nights });
       setForm({ travel_days: nights + 1 });
     } else {
+      setShowLimit(false);
+      setRange({ from, to });
       clearExactDate();
       setForm({ travel_days: 0 });
     }
@@ -69,6 +86,11 @@ export const ExactCalendar = () => {
           {nights ? `${nights}박 ${nights + 1}일` : '-'}
         </div>
       </footer>
+      {showLimit && (
+        <Callout tone="warning" className="mt-2">
+          최대 {MAX_TRIP_NIGHTS}박 {MAX_TRIP_DAYS}일까지 선택할 수 있어요.
+        </Callout>
+      )}
     </>
   );
 };

--- a/apps/frontend/src/components/onboarding/calendar/FlexCalendar.css
+++ b/apps/frontend/src/components/onboarding/calendar/FlexCalendar.css
@@ -79,3 +79,45 @@
   color: var(--calendar-accent);
   font-weight: 600;
 }
+
+/* 직접 입력 (인라인 스테퍼) */
+.flex-calendar__custom {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+}
+
+.flex-calendar__custom-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--calendar-accent-line);
+  border-radius: 50%;
+  background: var(--background);
+  font-size: 16px;
+  line-height: 1;
+  color: var(--calendar-accent);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.flex-calendar__custom-step:hover:not(:disabled) {
+  background: var(--calendar-accent);
+  color: var(--background);
+}
+
+.flex-calendar__custom-step:disabled {
+  color: var(--muted-foreground);
+  border-color: var(--border);
+  cursor: default;
+  opacity: 0.5;
+}
+
+.flex-calendar__custom-value {
+  min-width: 60px;
+  text-align: center;
+  white-space: nowrap;
+}

--- a/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
@@ -1,7 +1,7 @@
 import './FlexCalendar.css';
 import { useEffect, useState } from 'react';
 
-import { useCalendarStore } from '@/utils/calendar-store';
+import { MAX_TRIP_NIGHTS, useCalendarStore } from '@/utils/calendar-store';
 import { useOnboardingStore } from '@/utils/onboarding-store';
 
 const FlexCalendar = () => {
@@ -21,7 +21,7 @@ const FlexCalendar = () => {
 
   const durationOptions = [1, 2, 3, 4];
   const MIN_NIGHTS = 1;
-  const MAX_NIGHTS = 30;
+  const MAX_NIGHTS = MAX_TRIP_NIGHTS;
 
   const [showCustom, setShowCustom] = useState(
     flexDate?.nights != null && !durationOptions.includes(flexDate.nights)
@@ -67,7 +67,7 @@ const FlexCalendar = () => {
   const handleCustomToggle = () => {
     setShowCustom(true);
     if (durationNights === null || durationOptions.includes(durationNights)) {
-      handleDurationClick(8);
+      handleDurationClick(5);
     }
   };
 

--- a/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
+++ b/apps/frontend/src/components/onboarding/calendar/FlexCalendar.tsx
@@ -19,11 +19,20 @@ const FlexCalendar = () => {
     flexDate?.nights ?? null
   );
 
+  const durationOptions = [1, 2, 3, 4];
+  const MIN_NIGHTS = 1;
+  const MAX_NIGHTS = 30;
+
+  const [showCustom, setShowCustom] = useState(
+    flexDate?.nights != null && !durationOptions.includes(flexDate.nights)
+  );
+
   useEffect(() => {
     if (flexDate === null) {
       setSelectedYear(new Date().getFullYear());
       setSelectedMonth(null);
       setDurationNights(null);
+      setShowCustom(false);
     }
   }, [flexDate]);
 
@@ -50,7 +59,23 @@ const FlexCalendar = () => {
     }
   };
 
-  const durationOptions = [2, 3, 4, 5, 6, 7];
+  const handlePresetClick = (nights: number) => {
+    setShowCustom(false);
+    handleDurationClick(nights);
+  };
+
+  const handleCustomToggle = () => {
+    setShowCustom(true);
+    if (durationNights === null || durationOptions.includes(durationNights)) {
+      handleDurationClick(8);
+    }
+  };
+
+  const handleCustomStep = (delta: number) => {
+    const base = durationNights ?? MIN_NIGHTS;
+    const next = Math.min(MAX_NIGHTS, Math.max(MIN_NIGHTS, base + delta));
+    handleDurationClick(next);
+  };
 
   return (
     <div className="flex-calendar">
@@ -94,12 +119,45 @@ const FlexCalendar = () => {
           <button
             key={nights}
             type="button"
-            className={`flex-calendar__duration-btn${durationNights === nights ? ' flex-calendar__duration-btn--active' : ''}`}
-            onClick={() => handleDurationClick(nights)}
+            className={`flex-calendar__duration-btn${!showCustom && durationNights === nights ? ' flex-calendar__duration-btn--active' : ''}`}
+            onClick={() => handlePresetClick(nights)}
           >
             {nights}박 {nights + 1}일
           </button>
         ))}
+        {showCustom ? (
+          <div className="flex-calendar__duration-btn flex-calendar__duration-btn--active flex-calendar__custom">
+            <button
+              type="button"
+              className="flex-calendar__custom-step"
+              disabled={(durationNights ?? MIN_NIGHTS) <= MIN_NIGHTS}
+              onClick={() => handleCustomStep(-1)}
+              aria-label="박수 줄이기"
+            >
+              −
+            </button>
+            <span className="flex-calendar__custom-value">
+              {durationNights ?? MIN_NIGHTS}박 {(durationNights ?? MIN_NIGHTS) + 1}일
+            </span>
+            <button
+              type="button"
+              className="flex-calendar__custom-step"
+              disabled={(durationNights ?? MIN_NIGHTS) >= MAX_NIGHTS}
+              onClick={() => handleCustomStep(1)}
+              aria-label="박수 늘리기"
+            >
+              +
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="flex-calendar__duration-btn"
+            onClick={handleCustomToggle}
+          >
+            직접 입력
+          </button>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/utils/calendar-store.ts
+++ b/apps/frontend/src/utils/calendar-store.ts
@@ -2,6 +2,10 @@ import { format } from 'date-fns';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
+/** 여행 길이 상한 — 배치 단계의 Day 카드/요청 폭발 방지 (유연·정확 공통) */
+export const MAX_TRIP_NIGHTS = 9; // 9박 10일
+export const MAX_TRIP_DAYS = MAX_TRIP_NIGHTS + 1;
+
 type ExactDate = { from: Date; to: Date; nights: number };
 type FlexDate = { year: number; month: number; nights: number };
 


### PR DESCRIPTION
## 📝 작업 내용

> 어떤 문제를 해결했는지 한 줄로 요약해주세요.

- 유연한 날짜에 박수 직접 입력(커스텀) 기능을 추가하고, 배치 단계의 Day 카드/요청 폭발을 막기 위해 여행 길이를 최대 9박 10일로 제한했습니다.

## 🔗 관련 이슈

closes #327

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [x] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [ ] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 동작 확인했나요?
- [x] 기존 기능이 깨지지 않았나요? (회귀 확인)
- [x] 하드코딩된 값이나 임시 주석(TODO, FIXME)은 없나요?
- [x] PR 범위가 하나의 기능 단위로 잘 잘려 있나요?

## 👀 리뷰어에게

- **여행 길이 상한**은 `calendar-store.ts`의 `MAX_TRIP_NIGHTS`(9박) / `MAX_TRIP_DAYS`(10일) 공통 상수로 관리하며, 유연·정확 캘린더가 함께 참조합니다.
- **유연한 날짜**: 프리셋(1~4박) + "직접 입력" 태그를 인라인 스테퍼(−/+)로 전환. `+`가 9박에서 disabled 되어 초과 자체가 불가합니다. 커스텀 값도 월 선택 시에만 `flexDate`/`travel_days`에 커밋됩니다.
- **정확한 날짜**: 범위가 10일을 초과하면 반영하지 않고 방금 클릭한 날짜를 새 시작일로 리셋한 뒤 안내 Callout을 노출합니다. (기존엔 상한이 없어 무제한 선택 → 배치에서 Day당 fetchDay 요청이 그대로 폭증하던 문제)

## 📸 스크린샷
<img width="453" height="86" alt="image" src="https://github.com/user-attachments/assets/20063a1a-d01f-4468-9a38-2402d7517209" />

<img width="584" height="106" alt="image" src="https://github.com/user-attachments/assets/df84f6e0-aee2-4bde-9046-e1d2ed7a5906" />

