### PR TITLE
Feat/329 ai suggested itinerary

### DIFF
--- a/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeController.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeController.java
@@ -1,6 +1,9 @@
 package com.tripkey.domain.optimize;
 
 import com.tripkey.dto.optimize.OptimizeResponse;
+import com.tripkey.dto.optimize.SuggestedItineraryResponse;
+import com.tripkey.dto.optimize.SuggestedItineraryRequest;
+import org.springframework.web.bind.annotation.RequestBody;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,9 +19,19 @@ import java.util.UUID;
 public class OptimizeController {
 
     private final OptimizeService optimizeService;
+    private final SuggestedItineraryService suggestedItineraryService;
 
     @PostMapping
     public ResponseEntity<OptimizeResponse> optimize(@PathVariable UUID tripId) {
         return ResponseEntity.ok(optimizeService.optimize(tripId));
+    }
+
+    @PostMapping("/suggest-itinerary")
+    public ResponseEntity<SuggestedItineraryResponse> suggestItinerary(
+            @PathVariable UUID tripId, @RequestBody(required = false) SuggestedItineraryRequest request) {
+        SuggestedItineraryRequest normalized = request == null
+                ? new SuggestedItineraryRequest(null, null).normalized()
+                : request.normalized();
+        return ResponseEntity.ok(suggestedItineraryService.suggest(tripId, normalized));
     }
 }

--- a/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/optimize/OptimizeService.java
@@ -56,13 +56,25 @@ public class OptimizeService {
         List<OptimizeResponse.DayOrder> days = new ArrayList<>();
 
         for (Map.Entry<Integer, List<PlaceCard>> entry : byDay.entrySet()) {
-            List<PlaceCard> cards = entry.getValue();
-            if (cards.size() < 2) {
-                continue; // 최적화할 게 없음 (0~1개)
-            }
+            if (entry.getValue().size() < 2) continue;
+            DayOrderSuggestion suggestion = optimizeDay(trip, entry.getKey(), entry.getValue());
+            if (suggestion == null) continue;
+            days.add(new OptimizeResponse.DayOrder(entry.getKey(), suggestion.orderedInstanceIds(),
+                    suggestion.totalDurationSeconds(), suggestion.source()));
+        }
+
+        return OptimizeResponse.of(tripId, days);
+    }
+
+    /** DB 저장 없이 주어진 카드 묶음의 Day 내 방문 순서만 계산한다. */
+    public DayOrderSuggestion optimizeDay(Trip trip, int day, List<PlaceCard> cards) {
+        if (cards.isEmpty()) return null;
+        if (cards.size() == 1) {
+            return new DayOrderSuggestion(List.of(cards.get(0).getInstanceId()), 0, "single_stop");
+        }
 
             // Day N 의 요일(0=일~6=토, Google 규약). 여행 시작일이 없으면 null → 영업시간 제약 생략 (#292)
-            Integer weekday = weekdayOf(trip.getStartDate(), entry.getKey());
+            Integer weekday = weekdayOf(trip.getStartDate(), day);
 
             List<AiOptimizeOrderRequest.Stop> stops = new ArrayList<>();
             for (PlaceCard card : cards) {
@@ -86,12 +98,10 @@ public class OptimizeService {
                     .map(UUID::fromString)
                     .toList();
 
-            days.add(new OptimizeResponse.DayOrder(
-                    entry.getKey(), orderedIds, response.totalDurationSeconds(), response.source()));
-        }
-
-        return OptimizeResponse.of(tripId, days);
+        return new DayOrderSuggestion(orderedIds, response.totalDurationSeconds(), response.source());
     }
+
+    public record DayOrderSuggestion(List<UUID> orderedInstanceIds, int totalDurationSeconds, String source) {}
 
     /**
      * Day 시작 앵커 — 도착 항공편(outbound, 첫날 공항 도착 후 시작)이 있으면 그 카드,

--- a/apps/backend/src/main/java/com/tripkey/domain/optimize/SuggestedItineraryService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/optimize/SuggestedItineraryService.java
@@ -1,0 +1,130 @@
+package com.tripkey.domain.optimize;
+
+import com.tripkey.common.exception.TripNotFoundException;
+import com.tripkey.domain.place.PlaceCard;
+import com.tripkey.domain.place.PlaceCardRepository;
+import com.tripkey.domain.trip.Trip;
+import com.tripkey.domain.trip.TripRepository;
+import com.tripkey.dto.optimize.SuggestedItineraryResponse;
+import com.tripkey.dto.optimize.SuggestedItineraryRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SuggestedItineraryService {
+    private static final double CLUSTER_EPS_METERS = 1500.0;
+    private static final int DEFAULT_DURATION_MINUTES = 90;
+
+    private final TripRepository tripRepository;
+    private final PlaceCardRepository placeCardRepository;
+    private final OptimizeService optimizeService;
+
+    @Transactional(readOnly = true)
+    public SuggestedItineraryResponse suggest(UUID tripId, SuggestedItineraryRequest request) {
+        Policy policy = Policy.from(request);
+        Trip trip = tripRepository.findById(tripId).orElseThrow(() -> new TripNotFoundException(tripId));
+        int dayCount = Math.max(1, trip.getTravelDays().intValue());
+        List<PlaceCard> all = placeCardRepository.findAllByTripId(tripId);
+        Map<UUID, PlaceCard> eligible = new HashMap<>();
+        List<SuggestedItineraryResponse.UnplacedCard> unplaced = new ArrayList<>();
+        for (PlaceCard card : all) {
+            if (Boolean.TRUE.equals(card.getIsExcluded())) continue;
+            if (card.getGeom() == null) {
+                unplaced.add(new SuggestedItineraryResponse.UnplacedCard(card.getInstanceId(), "MISSING_COORDINATE"));
+            } else if ("processing".equals(card.getProcessingStatus()) || "blocked".equals(card.getPlacementStatus())
+                    || "undecided".equals(card.getClassification()) || "needs_input".equals(card.getPlacementStatus())) {
+                unplaced.add(new SuggestedItineraryResponse.UnplacedCard(card.getInstanceId(), "REQUIRES_USER_DECISION"));
+            } else {
+                eligible.put(card.getInstanceId(), card);
+            }
+        }
+
+        Map<Integer, List<PlaceCard>> clusters = new HashMap<>();
+        for (Object[] row : placeCardRepository.clusterAvailableCards(tripId, CLUSTER_EPS_METERS, 1)) {
+            PlaceCard card = eligible.get((UUID) row[0]);
+            if (card != null && row[1] != null) clusters.computeIfAbsent(((Number) row[1]).intValue(), k -> new ArrayList<>()).add(card);
+        }
+        List<List<PlaceCard>> byDay = new ArrayList<>();
+        List<Map<Integer, Integer>> clusterCountsByDay = new ArrayList<>();
+        for (int i = 0; i < dayCount; i++) byDay.add(new ArrayList<>());
+        for (int i = 0; i < dayCount; i++) clusterCountsByDay.add(new HashMap<>());
+
+        List<Map.Entry<Integer, List<PlaceCard>>> orderedClusters = clusters.entrySet().stream()
+                .sorted(Comparator.comparingInt((Map.Entry<Integer, List<PlaceCard>> e) -> durationOf(e.getValue())).reversed()).toList();
+        for (Map.Entry<Integer, List<PlaceCard>> clusterEntry : orderedClusters) {
+            int clusterId = clusterEntry.getKey();
+            List<PlaceCard> cards = clusterEntry.getValue().stream()
+                    .sorted(Comparator.comparingInt(card -> categoryPriority(card, policy))).toList();
+            for (PlaceCard card : cards) {
+                int target = bestDay(card, clusterId, byDay, clusterCountsByDay, policy);
+                if (target < 0) {
+                    String reason = isFood(card) && byDay.stream().allMatch(day -> foodCount(day) >= policy.maxFoodPerDay())
+                            ? "CATEGORY_CAPACITY_EXCEEDED" : "DAILY_CAPACITY_EXCEEDED";
+                    unplaced.add(new SuggestedItineraryResponse.UnplacedCard(card.getInstanceId(), reason));
+                    continue;
+                }
+                byDay.get(target).add(card);
+                clusterCountsByDay.get(target).merge(clusterId, 1, Integer::sum);
+            }
+        }
+
+        List<SuggestedItineraryResponse.SuggestedDay> days = new ArrayList<>();
+        for (int i = 0; i < byDay.size(); i++) {
+            List<PlaceCard> cards = byDay.get(i);
+            if (cards.isEmpty()) continue;
+            OptimizeService.DayOrderSuggestion order = optimizeService.optimizeDay(trip, i + 1, cards);
+            days.add(new SuggestedItineraryResponse.SuggestedDay(i + 1, "추천 동선", order.orderedInstanceIds(), order.totalDurationSeconds()));
+        }
+        return new SuggestedItineraryResponse(tripId, days, unplaced);
+    }
+
+    private int durationOf(List<PlaceCard> cards) { return cards.stream().mapToInt(this::durationOf).sum(); }
+    private int durationOf(PlaceCard card) { return card.getEstimatedDurationMin() == null ? DEFAULT_DURATION_MINUTES : card.getEstimatedDurationMin(); }
+
+    private int bestDay(PlaceCard card, int clusterId, List<List<PlaceCard>> byDay,
+                        List<Map<Integer, Integer>> clusterCountsByDay, Policy policy) {
+        int bestDay = -1;
+        int bestScore = Integer.MIN_VALUE;
+        for (int i = 0; i < byDay.size(); i++) {
+            List<PlaceCard> day = byDay.get(i);
+            if (day.size() >= policy.maxCardsPerDay()) continue;
+            if (durationOf(day) + durationOf(card) > policy.targetMinutes()) continue;
+            if (isFood(card) && foodCount(day) >= policy.maxFoodPerDay()) continue;
+            int sameCluster = clusterCountsByDay.get(i).getOrDefault(clusterId, 0);
+            int categoryPenalty = isFood(card) ? foodCount(day) * policy.foodRepeatPenalty() : 0;
+            int score = sameCluster * 100 - durationOf(day) - day.size() * 30 - categoryPenalty;
+            if (score > bestScore) { bestScore = score; bestDay = i; }
+        }
+        return bestDay;
+    }
+
+    private static boolean isFood(PlaceCard card) { return "food".equals(card.getCategory()); }
+    private static int foodCount(List<PlaceCard> cards) { return (int) cards.stream().filter(SuggestedItineraryService::isFood).count(); }
+    private static int categoryPriority(PlaceCard card, Policy policy) {
+        if (policy.sightseeingFirst() && !isFood(card)) return 0;
+        if (!policy.sightseeingFirst() && isFood(card)) return 0;
+        return 1;
+    }
+
+    private record Policy(int targetMinutes, int maxCardsPerDay, int maxFoodPerDay,
+                          int foodRepeatPenalty, boolean sightseeingFirst) {
+        static Policy from(SuggestedItineraryRequest request) {
+            int minutes = switch (request.pace()) { case RELAXED -> 360; case NORMAL -> 480; case PACKED -> 600; };
+            int cards = switch (request.pace()) { case RELAXED -> 4; case NORMAL -> 6; case PACKED -> 8; };
+            return switch (request.travelStyle()) {
+                case SIGHTSEEING -> new Policy(minutes, cards, 2, 120, true);
+                case FOOD -> new Policy(minutes, cards, 4, 20, false);
+                case BALANCED -> new Policy(minutes, cards, 3, 70, true);
+            };
+        }
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/domain/place/CardInputParsingProcessor.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/CardInputParsingProcessor.java
@@ -1,5 +1,6 @@
 package com.tripkey.domain.place;
 
+import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.trip.Trip;
 import com.tripkey.domain.trip.TripDestination;
 import com.tripkey.domain.trip.TripDestinationRepository;
@@ -24,6 +25,7 @@ public class CardInputParsingProcessor {
     private final TripRepository tripRepository;
     private final TripDestinationRepository tripDestinationRepository;
     private final PlaceCardRepository placeCardRepository;
+    private final AlertCardRepository alertCardRepository;
     private final AiEngineClient aiEngineClient;
 
     @Async("dumpTaskExecutor")
@@ -75,6 +77,14 @@ public class CardInputParsingProcessor {
                 card.markProcessingFailed();
             }
             placeCardRepository.save(card);
+            if ("completed".equals(card.getProcessingStatus())) {
+                // 카드 재파싱 전 상태에서 생성된 연결 alert는 더 이상 유효하다고 볼 수 없다.
+                // 카드 파서가 새 alert를 반환하지 않으므로 성공 시 기존 스냅샷을 무효화한다.
+                alertCardRepository.deleteAll(
+                        alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId).stream()
+                                .filter(alert -> alert.relatedInstanceUuids().contains(instanceId))
+                                .toList());
+            }
         } catch (Exception e) {
             card.markProcessingFailed();
             placeCardRepository.save(card);

--- a/apps/backend/src/main/java/com/tripkey/domain/place/CardService.java
+++ b/apps/backend/src/main/java/com/tripkey/domain/place/CardService.java
@@ -24,7 +24,9 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -43,10 +45,15 @@ public class CardService {
             throw new TripNotFoundException(tripId);
         }
 
-        List<CardDto> cards = placeCardRepository.findAllByTripId(tripId).stream()
+        List<PlaceCard> placeCards = placeCardRepository.findAllByTripId(tripId);
+        List<CardDto> cards = placeCards.stream()
                 .sorted(Comparator.comparing(PlaceCard::getCreatedAt))
                 .map(CardDto::from)
                 .toList();
+        Set<UUID> placedInstanceIds = placeCards.stream()
+                .filter(card -> card.getDay() != null)
+                .map(PlaceCard::getInstanceId)
+                .collect(Collectors.toSet());
 
         String contextSummary = dumpJobRepository
                 .findFirstByTripIdOrderByCreatedAtDesc(tripId)
@@ -55,6 +62,9 @@ public class CardService {
 
         List<AlertCardDto> alertCards = new ArrayList<>(
                 alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId).stream()
+                        // 특정 카드에 연결된 알림은 그 카드가 실제 Day에 배치된 경우에만 노출한다.
+                        .filter(alert -> alert.relatedInstanceUuids().isEmpty()
+                                || alert.relatedInstanceUuids().stream().allMatch(placedInstanceIds::contains))
                         .map(CardService::toAlertCardDto)
                         .toList());
         // Day 단위 conflict(route_warnings)를 scope=day 알림으로 조회 시점에 합성한다(미저장 → 항상 현재 배치 반영).

--- a/apps/backend/src/main/java/com/tripkey/dto/optimize/SuggestedItineraryRequest.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/optimize/SuggestedItineraryRequest.java
@@ -1,0 +1,12 @@
+package com.tripkey.dto.optimize;
+
+public record SuggestedItineraryRequest(TravelStyle travelStyle, Pace pace) {
+    public enum TravelStyle { BALANCED, SIGHTSEEING, FOOD }
+    public enum Pace { RELAXED, NORMAL, PACKED }
+
+    public SuggestedItineraryRequest normalized() {
+        return new SuggestedItineraryRequest(
+                travelStyle == null ? TravelStyle.BALANCED : travelStyle,
+                pace == null ? Pace.NORMAL : pace);
+    }
+}

--- a/apps/backend/src/main/java/com/tripkey/dto/optimize/SuggestedItineraryResponse.java
+++ b/apps/backend/src/main/java/com/tripkey/dto/optimize/SuggestedItineraryResponse.java
@@ -1,0 +1,10 @@
+package com.tripkey.dto.optimize;
+
+import java.util.List;
+import java.util.UUID;
+
+public record SuggestedItineraryResponse(UUID tripId, List<SuggestedDay> days, List<UnplacedCard> unplacedCards) {
+    public record SuggestedDay(int day, String label, List<UUID> orderedInstanceIds,
+                               int totalDurationSeconds) {}
+    public record UnplacedCard(UUID instanceId, String reason) {}
+}

--- a/apps/backend/src/test/java/com/tripkey/domain/place/CardInputParsingProcessorTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/CardInputParsingProcessorTest.java
@@ -1,11 +1,14 @@
 package com.tripkey.domain.place;
 
+import com.tripkey.domain.alert.AlertCard;
+import com.tripkey.domain.alert.AlertCardRepository;
 import com.tripkey.domain.trip.Trip;
 import com.tripkey.domain.trip.TripDestinationRepository;
 import com.tripkey.domain.trip.TripRepository;
 import com.tripkey.infra.aiengine.AiEngineClient;
 import com.tripkey.infra.aiengine.dto.AiCardParseRequest;
 import com.tripkey.infra.aiengine.dto.AiPlaceCardDto;
+import com.tripkey.infra.aiengine.dto.AiParseResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -35,6 +38,9 @@ class CardInputParsingProcessorTest {
     private PlaceCardRepository placeCardRepository;
 
     @Mock
+    private AlertCardRepository alertCardRepository;
+
+    @Mock
     private AiEngineClient aiEngineClient;
 
     @InjectMocks
@@ -51,6 +57,13 @@ class CardInputParsingProcessorTest {
         when(tripRepository.findById(tripId)).thenReturn(Optional.of(trip));
         when(tripDestinationRepository.findByTripTripIdOrderBySortOrder(tripId)).thenReturn(List.of());
         when(aiEngineClient.parseCard(any(AiCardParseRequest.class))).thenReturn(parsedCard());
+        AlertCard staleAlert = AlertCard.fromAiResponse(
+                new AiParseResponse.AlertCard(
+                        "stale", "missing_detail", "practical", "trip", null,
+                        "장소 확인 필요", List.of(instanceId)),
+                tripId, UUID.randomUUID());
+        when(alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId))
+                .thenReturn(List.of(staleAlert));
 
         processor.parseAndEnrich(tripId, instanceId, "도톤보리 글리코 사인으로 가자");
 
@@ -65,6 +78,7 @@ class CardInputParsingProcessorTest {
         assertThat(card.getAddress()).isEqualTo("1 Chome Dotonbori, Osaka");
         assertThat(card.getSearchAlias()).isEqualTo("Dotonbori Glico Sign");
         verify(placeCardRepository).save(card);
+        verify(alertCardRepository).deleteAll(List.of(staleAlert));
     }
 
     @Test

--- a/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
+++ b/apps/backend/src/test/java/com/tripkey/domain/place/CardServiceTest.java
@@ -78,9 +78,12 @@ class CardServiceTest {
     @Test
     void getCardsReturnsAlertCardsInCreatedAtAscOrder() {
         UUID tripId = UUID.randomUUID();
-        UUID relatedId = UUID.randomUUID();
+        PlaceCard placedCard = userPlaceCard(tripId);
+        placedCard.onCreate();
+        placedCard.applyDayPlacement(1, 0, (short) 60);
+        UUID relatedId = placedCard.getInstanceId();
         when(tripRepository.existsById(tripId)).thenReturn(true);
-        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of());
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(placedCard));
         when(dumpJobRepository.findFirstByTripIdOrderByCreatedAtDesc(tripId)).thenReturn(Optional.empty());
 
         AlertCard alert = AlertCard.fromAiResponse(
@@ -107,6 +110,27 @@ class CardServiceTest {
         assertThat(response.alertCards().get(0).scope()).isEqualTo("trip");
         assertThat(response.alertCards().get(0).day()).isNull();
         assertThat(response.alertCards().get(0).relatedInstanceIds()).containsExactly(relatedId);
+    }
+
+    @Test
+    void getCardsHidesAlertWhenAllRelatedCardsAreUnplaced() {
+        UUID tripId = UUID.randomUUID();
+        PlaceCard unplacedCard = userPlaceCard(tripId);
+        unplacedCard.onCreate();
+        when(tripRepository.existsById(tripId)).thenReturn(true);
+        when(placeCardRepository.findAllByTripId(tripId)).thenReturn(List.of(unplacedCard));
+        when(dumpJobRepository.findFirstByTripIdOrderByCreatedAtDesc(tripId)).thenReturn(Optional.empty());
+
+        AlertCard alert = AlertCard.fromAiResponse(
+                new AiParseResponse.AlertCard(
+                        "alert-unplaced", "timing_conflict", "practical", "trip", null,
+                        "미배치 카드 알림", List.of(unplacedCard.getInstanceId())),
+                tripId, UUID.randomUUID());
+        when(alertCardRepository.findAllByTripIdOrderByCreatedAtAsc(tripId)).thenReturn(List.of(alert));
+
+        CardsResponse response = cardService.getCards(tripId);
+
+        assertThat(response.alertCards()).isEmpty();
     }
 
     @Test

--- a/apps/frontend/src/components/arrange/ArrangeCard.tsx
+++ b/apps/frontend/src/components/arrange/ArrangeCard.tsx
@@ -47,6 +47,11 @@ const ArrangeCard = ({
   isDragging = false,
   isPlaced = false,
 }: ArrangeCardProps) => {
+  const visibleBadges = isPlaced && !badges.some(
+    (badge) => badge.kind === 'status' && badge.label === '배치됨'
+  )
+    ? [...badges, { kind: 'status' as const, label: '배치됨', tone: 'pending' as const }]
+    : badges;
   const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
     if (processing) {
       event.preventDefault();
@@ -85,9 +90,9 @@ const ArrangeCard = ({
             <p className="truncate text-sm font-semibold text-foreground">
               {name}
             </p>
-            {badges.length > 0 && (
+            {visibleBadges.length > 0 && (
               <div className="mt-1 flex items-center gap-1.5">
-                {badges.map((badge, index) => (
+                {visibleBadges.map((badge, index) => (
                   <PlaceCardBadge key={index} {...badge} />
                 ))}
               </div>

--- a/apps/frontend/src/components/arrange/DayColumn.tsx
+++ b/apps/frontend/src/components/arrange/DayColumn.tsx
@@ -38,6 +38,18 @@ const DropIndicator = () => (
   <div className="mx-1 h-0.5 rounded-full bg-primary" aria-hidden="true" />
 );
 
+const buildCompositionLabel = (cards: ScheduledCardViewModel[]): string => {
+  const counts = new Map<string, number>();
+  for (const card of cards) {
+    const category = card.badges?.find((badge) => badge.kind === 'category');
+    const label = category?.kind === 'category'
+      ? ({ food: '맛집', place: '장소', activity: '활동', shopping: '쇼핑', lodging: '숙소', transport: '이동' } as const)[category.category]
+      : '장소';
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([label, count]) => `${label} ${count}`).join(' · ');
+};
+
 const DayColumn = ({
   id,
   dayLabel,
@@ -52,6 +64,7 @@ const DayColumn = ({
   dragActive = false,
 }: DayColumnProps) => {
   const isEmpty = cards.length === 0;
+  const composition = buildCompositionLabel(cards);
   const [isOver, setIsOver] = useState(false);
   const [dropIndex, setDropIndex] = useState<number | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -123,6 +136,11 @@ const DayColumn = ({
           {cards.length}개
         </span>
       </header>
+      {composition && (
+        <p className="mt-2 px-1 text-xs leading-relaxed text-muted-foreground">
+          {composition}
+        </p>
+      )}
 
       {isEmpty ? (
         // 빈 컬럼 — 드롭 플레이스홀더

--- a/apps/frontend/src/components/confirm/TripChecklist.tsx
+++ b/apps/frontend/src/components/confirm/TripChecklist.tsx
@@ -1,7 +1,6 @@
 // TripChecklist — 확정 화면(SCR-05) 좌측 사이드의 "여행 전반 체크리스트".
 // 출국 전까지 처리해야 할 실무 항목(여권/항공권/숙소 바우처/보험 등) 목록.
 
-import { Pencil } from 'lucide-react';
 import { useState } from 'react';
 
 import { Checkbox } from '@/components/ui/checkbox';
@@ -23,20 +22,9 @@ const TripChecklist = ({ items }: TripChecklistProps) => {
   return (
     <section className="flex flex-col gap-3">
       <header className="flex items-center justify-between">
-        <h2 className="flex items-center gap-1.5 text-sm font-bold text-foreground">
+        <h2 className="text-sm font-bold text-foreground">
           여행 전반 체크리스트
-          {/* BE 컨트랙트 없는 FE 고정 목록 — 실데이터 연동 전까지 임시 표식 */}
-          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
-            목데이터
-          </span>
         </h2>
-        <button
-          type="button"
-          className="inline-flex items-center gap-1 text-xs text-muted-foreground"
-        >
-          <Pencil className="size-3.5" aria-hidden="true" />
-          편집
-        </button>
       </header>
 
       <ul className="flex flex-col gap-2">

--- a/apps/frontend/src/hooks/useArrange.ts
+++ b/apps/frontend/src/hooks/useArrange.ts
@@ -4,7 +4,7 @@
 
 import { useMutation, useQueries, useQuery } from '@tanstack/react-query';
 
-import type { DayViewModel, PlacementSaveRequest } from '@/types/arrange-api';
+import type { DayViewModel, PlacementSaveRequest, SuggestedItineraryRequest } from '@/types/arrange-api';
 import type { CardAddRequest, CardPatchRequest } from '@/types/grouping-api';
 
 import {
@@ -12,6 +12,7 @@ import {
   fetchDay,
   fetchGroups04,
   reorderGroups,
+  suggestItinerary,
   verifyPlacement,
 } from '../utils/arrange-api';
 import {
@@ -100,6 +101,12 @@ export const useVerifyPlacementMutation = (tripId: string | null) =>
   useMutation({
     mutationFn: (payload: PlacementSaveRequest) =>
       verifyPlacement(tripId as string, payload),
+  });
+
+export const useSuggestedItineraryMutation = (tripId: string | null) =>
+  useMutation({
+    mutationFn: (payload: SuggestedItineraryRequest) =>
+      suggestItinerary(tripId as string, payload),
   });
 
 export const useConfirmPlacementMutation = (tripId: string | null) =>

--- a/apps/frontend/src/hooks/useArrange.ts
+++ b/apps/frontend/src/hooks/useArrange.ts
@@ -11,6 +11,7 @@ import {
   confirmPlacement,
   fetchDay,
   fetchGroups04,
+  fetchRouteLegs,
   reorderGroups,
   suggestItinerary,
   verifyPlacement,
@@ -27,6 +28,7 @@ export const arrangeKeys = {
   cards: (tripId: string) => ['arrange', tripId, 'cards'] as const,
   day: (tripId: string, dayNumber: number) =>
     ['arrange', tripId, 'day', dayNumber] as const,
+  routeLegs: (tripId: string) => ['arrange', tripId, 'route-legs'] as const,
 };
 
 export const useGroups04Query = (tripId: string | null) =>
@@ -53,6 +55,13 @@ export const useArrangeCardsQuery = (tripId: string | null) =>
       if (!pending) return false;
       return query.state.dataUpdateCount > 15 ? false : 2000;
     },
+  });
+
+export const useRouteLegsQuery = (tripId: string | null) =>
+  useQuery({
+    queryKey: arrangeKeys.routeLegs(tripId ?? ''),
+    queryFn: () => fetchRouteLegs(tripId as string),
+    enabled: Boolean(tripId),
   });
 
 /**

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -9,7 +9,7 @@
 //    (백엔드에 카드별 day 저장 API 가 없어 스냅샷 일괄 전송만 가능)
 
 import { format } from 'date-fns';
-import { ArrowLeft, ArrowRight, Plus } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Plus, Sparkles } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -21,6 +21,14 @@ import { PAGE_ENTER } from '@/components/common/PageTransition';
 import Header from '@/components/header/Header';
 import { Button } from '@/components/ui/button';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
   useAddCardMutation,
   useArrangeCardsQuery,
   useConfirmPlacementMutation,
@@ -29,7 +37,7 @@ import {
   useGroups04Query,
   usePatchCardMutation,
   useReorderGroupsMutation,
-  useVerifyPlacementMutation,
+  useSuggestedItineraryMutation,
 } from '@/hooks/useArrange';
 import { useTripDetailQuery } from '@/hooks/useTripDetail';
 import { cn } from '@/lib/utils';
@@ -39,7 +47,7 @@ import type {
   DayColumnViewModel,
   ScheduledCardViewModel,
 } from '@/types/arrange';
-import type { RouteWarning } from '@/types/arrange-api';
+import type { RouteWarning, SuggestedItineraryRequest } from '@/types/arrange-api';
 import type { Card, CardPatchRequest } from '@/types/grouping-api';
 import type { ArrangeDragPayload } from '@/utils/arrange-dnd';
 
@@ -160,7 +168,7 @@ const ArrangePage = () => {
   const addCardMutation = useAddCardMutation(tripId);
   const duplicateCardMutation = useDuplicateCardMutation(tripId);
   const reorderMutation = useReorderGroupsMutation(tripId);
-  const verifyMutation = useVerifyPlacementMutation(tripId);
+  const suggestedItineraryMutation = useSuggestedItineraryMutation(tripId);
   const confirmMutation = useConfirmPlacementMutation(tripId);
 
   // 여행 메타는 GET /trips/{id}(옵션 A)를 1순위로, 미로딩 시 온보딩 스토어로 폴백한다.
@@ -242,6 +250,9 @@ const ArrangePage = () => {
   const [notice, setNotice] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [confirmed, setConfirmed] = useState(false);
+  const [suggestionDialogOpen, setSuggestionDialogOpen] = useState(false);
+  const [travelStyle, setTravelStyle] = useState<SuggestedItineraryRequest['travel_style']>('BALANCED');
+  const [pace, setPace] = useState<SuggestedItineraryRequest['pace']>('NORMAL');
 
   // 진행 중인 재처리 폴링 취소 핸들. 카드 전환/언마운트 시 정리한다.
   const resolvePollRef = useRef<(() => void) | null>(null);
@@ -775,6 +786,50 @@ const ArrangePage = () => {
     }
   };
 
+  const handleSuggestItinerary = async () => {
+    if (!tripId) return;
+    setActionError(null);
+    setNotice(null);
+    try {
+      const suggestion = await suggestedItineraryMutation.mutateAsync({
+        travel_style: travelStyle,
+        pace,
+      });
+      const cardsById = new Map<string, ScheduledCardViewModel>();
+      groups.flatMap((group) => group.cards).forEach((card) =>
+        cardsById.set(card.id, toScheduledCard(card))
+      );
+      days.flatMap((day) => day.cards).forEach((card) => cardsById.set(card.id, card));
+
+      setDays((previous) => previous.map((day, index) => {
+        const suggestedDay = suggestion.days.find((item) => item.day === index + 1);
+        const fixedCards = day.cards.filter((card) => card.fixedTime);
+        if (!suggestedDay) return { ...day, cards: fixedCards };
+        const fixedIds = new Set(fixedCards.map((card) => card.id));
+        const suggestedCards = suggestedDay.ordered_instance_ids
+          .filter((id) => !fixedIds.has(id))
+          .map((id) => cardsById.get(id))
+          .filter((card): card is ScheduledCardViewModel => card != null);
+        return {
+          ...day,
+          cards: [...fixedCards, ...suggestedCards],
+        };
+      }));
+      setRouteWarnings(null);
+      setConfirmed(false);
+      setSuggestionDialogOpen(false);
+      const placed = suggestion.days.reduce((sum, day) => sum + day.ordered_instance_ids.length, 0);
+      const unplaced = suggestion.unplaced_cards.length;
+      setNotice(
+        unplaced > 0
+          ? `${placed}개 카드로 여행 초안을 만들었어요. ${unplaced}개는 위치·일정 조건 때문에 카드 목록에 남겨뒀어요. 원하는 대로 옮겨서 완성해 보세요.`
+          : `${placed}개 카드로 여행 초안을 만들었어요. 원하는 대로 옮겨서 완성해 보세요.`
+      );
+    } catch (error) {
+      setActionError(errorMessageOf(error, '여행 초안을 만들지 못했어요.'));
+    }
+  };
+
   // 배치된 카드 중 좌표(지도 위치)가 없는 카드에 대한 안내 경고를 합성한다.
   // 백엔드 RouteValidator 는 geom 이 null 인 카드를 거리 검증에서 조용히 제외하고
   // 경고를 내려주지 않으므로(배치 자체는 허용), FE 가 검증 흐름에서 보완 안내한다.
@@ -799,28 +854,6 @@ const ArrangePage = () => {
       });
     });
     return warnings;
-  };
-
-  // 동선 검증 — POST /verify. 경고 목록을 배너로 표시.
-  const handleVerify = async () => {
-    if (!tripId) return;
-    setActionError(null);
-    setNotice(null);
-    try {
-      const result = await verifyMutation.mutateAsync(
-        buildPlacementRequest(days, durationByInstance)
-      );
-      const warnings = [
-        ...result.route_warnings,
-        ...buildMissingLocationWarnings(),
-      ];
-      setRouteWarnings(warnings);
-      setNotice(
-        warnings.length === 0 ? '동선 문제가 발견되지 않았어요.' : null
-      );
-    } catch (error) {
-      setActionError(errorMessageOf(error, '동선 검증에 실패했습니다.'));
-    }
   };
 
   // 일정 확정 — POST /confirm. 성공 시 확정 상태로 전환.
@@ -881,11 +914,11 @@ const ArrangePage = () => {
   const cardListTitle = viewModel?.cardListTitle ?? '카드 목록';
 
   const busy =
-    verifyMutation.isPending ||
     confirmMutation.isPending ||
     addCardMutation.isPending ||
     duplicateCardMutation.isPending ||
-    reorderMutation.isPending;
+    reorderMutation.isPending ||
+    suggestedItineraryMutation.isPending;
 
   // "재정렬이 필요한 카드" 그룹이 있을 때만 정리 반영 버튼을 노출한다.
   const hasPendingReorder = groups.some(
@@ -940,11 +973,13 @@ const ArrangePage = () => {
               </Button>
             )}
             <Button
-              variant="outline"
-              onClick={handleVerify}
+              onClick={() => setSuggestionDialogOpen(true)}
               disabled={!tripId || busy}
             >
-              {verifyMutation.isPending ? '검증 중…' : '동선 검증하기'}
+              <Sparkles aria-hidden="true" />
+              {suggestedItineraryMutation.isPending
+                ? '여행 초안 만드는 중…'
+                : '여행 초안 만들기'}
             </Button>
           </div>
         </div>
@@ -1044,6 +1079,59 @@ const ArrangePage = () => {
           </Button>
         </div>
       </footer>
+
+      <Dialog open={suggestionDialogOpen} onOpenChange={setSuggestionDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>여행 초안을 만들어볼까요?</DialogTitle>
+            <DialogDescription>
+              가까운 장소와 선택한 일정 밀도를 기준으로 Day별로 나눠드려요. 만든 뒤 자유롭게 옮길 수 있어요.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-6 py-2">
+            <fieldset>
+              <legend className="mb-3 text-sm font-semibold">여행 스타일</legend>
+              <div className="grid grid-cols-3 gap-2">
+                {([
+                  ['BALANCED', '균형 있게', '맛집과 관광을 고르게'],
+                  ['SIGHTSEEING', '관광 중심', '장소를 더 많이'],
+                  ['FOOD', '맛집 중심', '먹는 즐거움을 더'],
+                ] as const).map(([value, label, description]) => (
+                  <button key={value} type="button" onClick={() => setTravelStyle(value)}
+                    className={cn('rounded-xl border px-3 py-3 text-left transition-colors',
+                      travelStyle === value ? 'border-primary bg-primary/10 text-primary' : 'border-border hover:bg-muted')}>
+                    <span className="block text-sm font-semibold">{label}</span>
+                    <span className="mt-1 block text-xs text-muted-foreground">{description}</span>
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+            <fieldset>
+              <legend className="mb-3 text-sm font-semibold">일정 밀도</legend>
+              <div className="grid grid-cols-3 gap-2">
+                {([
+                  ['RELAXED', '여유롭게', '하루 3~4곳'],
+                  ['NORMAL', '보통', '하루 4~6곳'],
+                  ['PACKED', '알차게', '하루 6~8곳'],
+                ] as const).map(([value, label, description]) => (
+                  <button key={value} type="button" onClick={() => setPace(value)}
+                    className={cn('rounded-xl border px-3 py-3 text-left transition-colors',
+                      pace === value ? 'border-primary bg-primary/10 text-primary' : 'border-border hover:bg-muted')}>
+                    <span className="block text-sm font-semibold">{label}</span>
+                    <span className="mt-1 block text-xs text-muted-foreground">{description}</span>
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+          </div>
+          <DialogFooter>
+            <Button onClick={handleSuggestItinerary} disabled={suggestedItineraryMutation.isPending}>
+              <Sparkles aria-hidden="true" />
+              {suggestedItineraryMutation.isPending ? '초안 만드는 중…' : '초안 만들기'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* 카드 클릭 시 우측에서 열리는 상세 패널 */}
       <CardDetailPanel

--- a/apps/frontend/src/pages/ArrangePage.tsx
+++ b/apps/frontend/src/pages/ArrangePage.tsx
@@ -10,6 +10,7 @@
 
 import { format } from 'date-fns';
 import { ArrowLeft, ArrowRight, Plus, Sparkles } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -148,6 +149,7 @@ const toUpdatedScheduledCard = (
 
 const ArrangePage = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
   const urlTripId = searchParams.get('tripId');
   const storeTripId = useOnboardingStore((s) => s.tripId);
@@ -830,32 +832,6 @@ const ArrangePage = () => {
     }
   };
 
-  // 배치된 카드 중 좌표(지도 위치)가 없는 카드에 대한 안내 경고를 합성한다.
-  // 백엔드 RouteValidator 는 geom 이 null 인 카드를 거리 검증에서 조용히 제외하고
-  // 경고를 내려주지 않으므로(배치 자체는 허용), FE 가 검증 흐름에서 보완 안내한다.
-  const buildMissingLocationWarnings = (): RouteWarning[] => {
-    const noCoordsNames = new Map(
-      (cardsQuery.data?.cards ?? [])
-        .filter((card) => card.coordinates == null)
-        .map((card) => [card.instance_id, card.name])
-    );
-    const warnings: RouteWarning[] = [];
-    days.forEach((day, index) => {
-      day.cards.forEach((card) => {
-        if (!noCoordsNames.has(card.id)) return;
-        warnings.push({
-          type: 'missing_location',
-          day: index + 1,
-          instance_ids: [card.id],
-          message: `'${noCoordsNames.get(card.id) ?? card.name}' 카드는 위치 정보가 없어 거리 검증에서 제외됐어요. 정확한 장소를 확인해 주세요.`,
-          distance_meters: null,
-          total_minutes: null,
-        });
-      });
-    });
-    return warnings;
-  };
-
   // 일정 확정 — POST /confirm. 성공 시 확정 상태로 전환.
   const handleConfirm = async () => {
     if (!tripId) return;
@@ -867,9 +843,13 @@ const ArrangePage = () => {
       );
       setRouteWarnings([
         ...result.route_warnings,
-        ...buildMissingLocationWarnings(),
       ]);
       setConfirmed(true);
+      // 배치 화면과 확정 화면이 같은 arrange query key를 사용하므로,
+      // confirm 저장 직후 서버의 day/day_order를 다시 받아 stale 보드 진입을 막는다.
+      await queryClient.invalidateQueries({
+        queryKey: ['arrange', tripId],
+      });
       navigate(`/confirm${tripId ? `?tripId=${tripId}` : ''}`, {
         state: { notice: '일정이 확정되었습니다.' },
       });

--- a/apps/frontend/src/pages/ConfirmPage.tsx
+++ b/apps/frontend/src/pages/ConfirmPage.tsx
@@ -8,7 +8,6 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { PAGE_ENTER_FADE } from '@/components/common/PageTransition';
 import AlertCardList from '@/components/confirm/AlertCardList';
 import ContextCardList from '@/components/confirm/ContextCardList';
-import DayChecklist from '@/components/confirm/DayChecklist';
 import DaySummary from '@/components/confirm/DaySummary';
 import DayTabs from '@/components/confirm/DayTabs';
 import MapCard from '@/components/confirm/MapCard';
@@ -18,7 +17,7 @@ import TripHeroCard from '@/components/confirm/TripHeroCard';
 import Header from '@/components/header/Header';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import { useArrangeCardsQuery, useDaysQuery } from '@/hooks/useArrange';
+import { useArrangeCardsQuery, useDaysQuery, useRouteLegsQuery } from '@/hooks/useArrange';
 import { useTripDetailQuery } from '@/hooks/useTripDetail';
 import { cn } from '@/lib/utils';
 import { formatDateRangeLabel, useCalendarStore } from '@/utils/calendar-store';
@@ -48,6 +47,7 @@ const ConfirmPage = () => {
 
   const tripDetailQuery = useTripDetailQuery(tripId);
   const cardsQuery = useArrangeCardsQuery(tripId);
+  const routeLegsQuery = useRouteLegsQuery(tripId);
   const detail = tripDetailQuery.data;
 
   // Day 수 = travel_days(메타 미로딩 시 온보딩 form 폴백).
@@ -63,6 +63,7 @@ const ConfirmPage = () => {
       detail,
       cardsRes: cardsQuery.data,
       dayViewModels: daysQuery.dayViewModels,
+      routeLegs: routeLegsQuery.data?.route_legs ?? [],
       form,
       // formatDateRangeLabel 은 값이 없으면 '-' 를 반환 — 매퍼에서 '기간 미정' 으로 처리되게 빈 문자열로.
       dateRangeFallback: rawFallback === '-' ? '' : rawFallback,
@@ -71,6 +72,7 @@ const ConfirmPage = () => {
     detail,
     cardsQuery.data,
     daysQuery.dayViewModels,
+    routeLegsQuery.data,
     form,
     calType,
     exactDate,
@@ -243,7 +245,6 @@ const ConfirmPage = () => {
                       <div className="grid grid-cols-[minmax(0,1fr)_320px] items-start gap-6">
                         <ContextCardList cards={activeDay.contextCards} />
                         <div className="flex flex-col gap-6">
-                          <DayChecklist items={activeDay.dayChecklist} />
                           <SaveShareCard tripId={tripId} />
                         </div>
                       </div>

--- a/apps/frontend/src/types/arrange-api.ts
+++ b/apps/frontend/src/types/arrange-api.ts
@@ -51,6 +51,25 @@ export type PlacementSaveRequest = {
   days: PlacementDay[];
 };
 
+export type SuggestedItineraryResponse = {
+  trip_id: string;
+  days: Array<{
+    day: number;
+    label: string;
+    ordered_instance_ids: string[];
+    total_duration_seconds: number;
+  }>;
+  unplaced_cards: Array<{
+    instance_id: string;
+    reason: 'MISSING_COORDINATE' | 'REQUIRES_USER_DECISION' | 'DAILY_CAPACITY_EXCEEDED' | string;
+  }>;
+};
+
+export type SuggestedItineraryRequest = {
+  travel_style: 'BALANCED' | 'SIGHTSEEING' | 'FOOD';
+  pace: 'RELAXED' | 'NORMAL' | 'PACKED';
+};
+
 /** 동선 검증 경고. */
 export type RouteWarning = {
   type: string;

--- a/apps/frontend/src/types/arrange-api.ts
+++ b/apps/frontend/src/types/arrange-api.ts
@@ -94,6 +94,10 @@ export type RouteLeg = {
   source: string | null;
 };
 
+export type RouteLegsResponse = {
+  route_legs: RouteLeg[];
+};
+
 export type PlacementSaveResponse = {
   saved: boolean;
   trip_id: string;

--- a/apps/frontend/src/utils/arrange-api.ts
+++ b/apps/frontend/src/utils/arrange-api.ts
@@ -5,6 +5,7 @@ import type {
   PlacementSaveResponse,
   SuggestedItineraryResponse,
   SuggestedItineraryRequest,
+  RouteLegsResponse,
 } from '../types/arrange-api';
 
 import { apiClient } from './api-client';
@@ -66,6 +67,16 @@ export const suggestItinerary = async (
   const response = await apiClient.post<SuggestedItineraryResponse>(
     API_PATH.SUGGEST_ITINERARY(tripId),
     payload
+  );
+  return response.data;
+};
+
+/** 현재 확정 배치 기준으로 캐시에 저장된 인접 장소 이동 구간을 조회한다. */
+export const fetchRouteLegs = async (
+  tripId: string
+): Promise<RouteLegsResponse> => {
+  const response = await apiClient.get<RouteLegsResponse>(
+    API_PATH.ROUTE_LEGS(tripId)
   );
   return response.data;
 };

--- a/apps/frontend/src/utils/arrange-api.ts
+++ b/apps/frontend/src/utils/arrange-api.ts
@@ -3,6 +3,8 @@ import type {
   Groups04Response,
   PlacementSaveRequest,
   PlacementSaveResponse,
+  SuggestedItineraryResponse,
+  SuggestedItineraryRequest,
 } from '../types/arrange-api';
 
 import { apiClient } from './api-client';
@@ -51,6 +53,18 @@ export const verifyPlacement = async (
 ): Promise<PlacementSaveResponse> => {
   const response = await apiClient.post<PlacementSaveResponse>(
     API_PATH.VERIFY(tripId),
+    payload
+  );
+  return response.data;
+};
+
+/** 배치 가능한 카드를 지역별로 묶고 Day 내부 방문 순서를 최적화한 저장 전 제안. */
+export const suggestItinerary = async (
+  tripId: string,
+  payload: SuggestedItineraryRequest
+): Promise<SuggestedItineraryResponse> => {
+  const response = await apiClient.post<SuggestedItineraryResponse>(
+    API_PATH.SUGGEST_ITINERARY(tripId),
     payload
   );
   return response.data;

--- a/apps/frontend/src/utils/arrange-mapper.ts
+++ b/apps/frontend/src/utils/arrange-mapper.ts
@@ -550,9 +550,9 @@ export const mapToArrangeViewModel = (
     },
     heading: {
       title: '일정 배치',
+      // context_summary는 최초 전체 파싱 시점의 스냅샷이라 카드 수정 후 stale해질 수 있다.
       subtitle:
-        cardsRes.context_summary ??
-        '배치 가능한 카드를 Day별로 끌어다 놓아 일정을 완성하세요.',
+        '카드를 Day별로 직접 배치하거나 여행 초안을 만든 뒤 원하는 순서로 다듬어보세요.',
     },
     cardListTitle: '카드 목록',
     groups,

--- a/apps/frontend/src/utils/confirm-mapper.ts
+++ b/apps/frontend/src/utils/confirm-mapper.ts
@@ -10,12 +10,11 @@
 
 import type { OnboardingRequest } from '@/types/onboarding';
 
-import type { DayViewModel } from '../types/arrange-api';
+import type { DayViewModel, RouteLeg } from '../types/arrange-api';
 import type {
   ConfirmAlertCard,
   ConfirmCardViewModel,
   ConfirmChecklistItem,
-  ConfirmDayChecklistItem,
   ConfirmDayViewModel,
   ConfirmViewModel,
 } from '../types/confirm';
@@ -48,6 +47,7 @@ type ConfirmMapperInput = {
   detail: TripDetailResponse | undefined;
   cardsRes: CardsResponse | undefined;
   dayViewModels: (DayViewModel | undefined)[];
+  routeLegs: RouteLeg[];
   /** 온보딩 스토어 form — 메타 폴백 + 여행 이름(tripName) 출처. */
   form: OnboardingRequest;
   /** calendar store 라벨(formatDateRangeLabel) — 서버/항공편으로 날짜를 못 구할 때 폴백. */
@@ -110,35 +110,26 @@ const synthesizeDayTitle = (dayNumber: number, cards: Card[]): string => {
 const sumDuration = (cards: Card[]): number =>
   cards.reduce((acc, c) => acc + (c.estimated_duration_min ?? 0), 0);
 
-const isDayScope = (alert: AlertCard): boolean => alert.scope === 'day';
-
 const alertToConfirmAlert = (alert: AlertCard): ConfirmAlertCard => {
   const isInsight = alert.category === 'insight';
   return {
     id: alert.id,
     kind: isInsight ? 'AI 인사이트' : '실무 알림',
     category: isInsight ? 'insight' : 'practical',
-    body: alert.message,
+    body: alert.day ? `Day ${alert.day} · ${alert.message}` : alert.message,
   };
 };
-
-const alertToDayChecklistItem = (
-  alert: AlertCard
-): ConfirmDayChecklistItem => ({
-  id: alert.id,
-  label: alert.message,
-  done: false,
-});
 
 const buildDay = (
   dayNumber: number,
   dvm: DayViewModel | undefined,
-  alertCards: AlertCard[]
+  routeLegs: RouteLeg[]
 ): ConfirmDayViewModel => {
   const cards = dvm ? orderDayCards(dvm) : [];
-  const dayChecklist = alertCards
-    .filter((a) => isDayScope(a) && a.day === dayNumber)
-    .map(alertToDayChecklistItem);
+  const moveSeconds = routeLegs
+    .filter((leg) => leg.day === dayNumber && leg.duration_seconds != null)
+    .reduce((sum, leg) => sum + (leg.duration_seconds ?? 0), 0);
+  const moveMinutes = Math.ceil(moveSeconds / 60);
   return {
     id: `day-${dayNumber}`,
     dayLabel: `Day ${dayNumber}`,
@@ -146,10 +137,10 @@ const buildDay = (
     // Day 요약 문장(narrative)은 BE 미구현 → 생략.
     summary: '',
     // 이동시간은 confirm 응답 route_legs(#187) 연동 전까지 '-' 폴백.
-    totalMove: '-',
-    totalSpend: formatDuration(sumDuration(cards)) ?? '-',
+    totalMove: moveSeconds > 0 ? formatDuration(moveMinutes) ?? '-' : '-',
+    totalSpend: formatDuration(sumDuration(cards) + moveMinutes) ?? '-',
     contextCards: cards.map((card, idx) => cardToConfirmCard(card, idx + 1)),
-    dayChecklist,
+    dayChecklist: [],
   };
 };
 
@@ -157,6 +148,7 @@ export const mapToConfirmViewModel = ({
   detail,
   cardsRes,
   dayViewModels,
+  routeLegs,
   form,
   dateRangeFallback,
 }: ConfirmMapperInput): ConfirmViewModel => {
@@ -172,7 +164,7 @@ export const mapToConfirmViewModel = ({
 
   const days: ConfirmDayViewModel[] = Array.from(
     { length: Math.max(meta.travelDays, 0) },
-    (_, i) => buildDay(i + 1, dayViewModels[i], alerts)
+    (_, i) => buildDay(i + 1, dayViewModels[i], routeLegs)
   );
 
   return {
@@ -191,8 +183,8 @@ export const mapToConfirmViewModel = ({
       stats: [],
     },
     tripChecklist: DEFAULT_TRIP_CHECKLIST,
-    // scope!=='day' 알림만 좌측 Alert Cards 로. day-scope 는 해당 Day 체크리스트로 분기.
-    alertCards: alerts.filter((a) => !isDayScope(a)).map(alertToConfirmAlert),
+    // Day 체크리스트를 제거했으므로 문제성 Day alert도 좌측 Alert Cards에 함께 노출한다.
+    alertCards: alerts.map(alertToConfirmAlert),
     days,
   };
 };

--- a/apps/frontend/src/utils/constants.ts
+++ b/apps/frontend/src/utils/constants.ts
@@ -21,6 +21,7 @@ export const API_PATH = {
   VERIFY: (tripId: string) => `/trips/${tripId}/verify`,
   SUGGEST_ITINERARY: (tripId: string) =>
     `/trips/${tripId}/optimize/suggest-itinerary`,
+  ROUTE_LEGS: (tripId: string) => `/trips/${tripId}/route-legs`,
   CONFIRM: (tripId: string) => `/trips/${tripId}/confirm`,
 } as const;
 

--- a/apps/frontend/src/utils/constants.ts
+++ b/apps/frontend/src/utils/constants.ts
@@ -19,6 +19,8 @@ export const API_PATH = {
   DAY: (tripId: string, dayNumber: number) =>
     `/trips/${tripId}/days/${dayNumber}`,
   VERIFY: (tripId: string) => `/trips/${tripId}/verify`,
+  SUGGEST_ITINERARY: (tripId: string) =>
+    `/trips/${tripId}/optimize/suggest-itinerary`,
   CONFIRM: (tripId: string) => `/trips/${tripId}/confirm`,
 } as const;
 

--- a/apps/frontend/src/utils/grouping-mapper.ts
+++ b/apps/frontend/src/utils/grouping-mapper.ts
@@ -339,9 +339,8 @@ export const mapToGroupingViewModel = (
   return {
     heading: {
       title: '정보 정리하기',
-      subtitle:
-        options?.contextSummary ??
-        '카드별로 확인/수정/선택을 진행해 일정을 정리하세요',
+      // contextSummary는 최초 파싱 이후 카드별 수정 내용을 반영하지 못하므로 헤딩에 쓰지 않는다.
+      subtitle: '카드별로 필요한 정보를 확인하고 수정해 여행 준비를 정리하세요.',
     },
     progress: { percent, activeCount, doneCount },
     groups: actionGroups,


### PR DESCRIPTION
### 주요 기능

- `여행 초안 만들기` 기능 추가
  - 기존 거리 클러스터링으로 가까운 장소 그룹화
  - 여행 일수에 맞춰 Day별 카드 배치
  - 기존 Optimize를 이용해 Day 내부 방문 순서 최적화
  - 추천 결과는 즉시 저장하지 않고 배치 화면에 초안으로 반영
  - 최종 확정 시 기존 `/confirm → verifyAndSave` 흐름으로 저장·검증

- 사용자 취향 기반 추천 설정
  - 여행 스타일: 균형 있게 / 관광 중심 / 맛집 중심
  - 일정 밀도: 여유롭게 / 보통 / 알차게
  - 스타일별 하루 맛집 최대치 적용
  - 밀도별 하루 카드 수·총 체류시간 제한 적용
  - Day 균형, 동일 지역 선호, 반복 카테고리 패널티 반영

- 추천 제외 카드 처리
  - 좌표 없음
  - 사용자 결정 필요
  - 하루 일정 용량 초과
  - 제외된 카드는 왼쪽 카드 목록에 유지

### 확정 화면

- 확정 배치 기준 이동시간 조회
  - `GET /trips/{tripId}/route-legs` 연동
  - Day별 이동시간 합산
  - 총 소요시간에 체류시간과 이동시간 합산
  - 이동 정보가 없으면 `0분`이 아니라 `-` 표시

- Verify 경고 표시 정리
  - 문제가 있을 때만 Alert Cards에 노출
  - Day 범위 경고도 `Day N` 표시와 함께 Alert Cards로 통합
  - 정상일 때 별도 성공성 인사이트는 표시하지 않음

- 추천 당시 Day 요약 문장은 확정 화면으로 전달하지 않음
  - 확정 시점의 실제 카드·순서·이동시간만 사용

### Alert 관련 수정

- Day에 배치되지 않은 카드와 연결된 alert 숨김
- 카드 레벨 재파싱 성공 시 해당 카드의 과거 alert 무효화
  - 카드 수정 전 생성된 stale alert 삭제
- 여러 카드에 연결된 alert는 관련 카드가 모두 배치됐을 때만 표시

### 배치 상태 및 화면 전환 수정

- 카드 재파싱 이후에도 현재 Day에 올라가 있으면 `배치됨` 뱃지 표시
  - 서버의 `day`뿐 아니라 현재 FE 로컬 배치 상태도 사용

- 확정 직후 이전 배치가 보이던 캐시 문제 수정
  - `/confirm` 성공 후 React Query의 cards/days/route-legs 캐시 갱신
  - 최신 서버 배치를 받은 뒤 확정 화면으로 이동

- 좌표 없는 카드 확정 UX 수정
  - 기존 FE의 `동선 검증에서 제외됐어요` 합성 경고 제거
  - 일정 확정과 카드 표시는 정상 진행
  - 지도·이동 계산에서만 해당 카드 제외

### 체크리스트 정리

- Day 체크리스트 제거
- 여행 전반 체크리스트는 기본 제공 템플릿으로 유지
- `목데이터` 뱃지 제거
- 동작하지 않던 `편집` 버튼 제거
- 체크박스 기능은 유지

### 안내 문구 정리

오래된 `context_summary`를 화면 설명에 재사용하지 않도록 수정했습니다.

- 03 정보 정리:
  - 카드 정보를 확인하고 수정하는 화면 목적에 맞는 고정 안내

- 04 일정 배치:
  - 직접 배치하거나 여행 초안을 만든 뒤 사용자가 다듬는 흐름 안내

- `AI 추천 일정`이라는 과한 표현을 `여행 초안`으로 변경
  - “AI가 완성된 일정을 만든다”보다 “자동으로 초안을 만들고 사용자가 완성한다”는 방향으로 조정

추가로 Day 컬럼에는 감성적인 규칙 기반 요약 대신:

```text
장소 3 · 맛집 2
```

한 줄로 요약하면:

> 거리·일정 밀도·사용자 취향을 반영한 여행 초안 생성 기능을 추가하고, 확정 시 실제 이동시간과 Verify 경고를 연결했으며, 배치 상태·캐시·stale alert·체크리스트·안내 문구 관련 오류를 함께 정리했습니다