### PR TITLE
Refactor/331 dump guide

### DIFF
--- a/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
+++ b/apps/frontend/src/components/card-detail/CardDetailPanel.tsx
@@ -45,6 +45,8 @@ export type CommonCardDetailViewModel = {
   memo?: string;
   question?: string;
   choices?: string[];
+  /** 질문 선택지를 Google Maps에서 검색할 때 함께 사용할 여행지 문맥. */
+  choiceMapContext?: string;
   selectedChoices?: string[];
   answer?: string;
   canResolveByNotes?: boolean;
@@ -457,6 +459,7 @@ const CardDetailBody = ({
           <QuestionInputSection
             question={detail.question!}
             choices={detail.choices ?? []}
+            mapContext={detail.choiceMapContext}
             selectedChoices={selectedChoices}
             onToggleChoice={toggleChoice}
             answer={answer}
@@ -533,6 +536,7 @@ const CardDetailBody = ({
 const QuestionInputSection = ({
   question,
   choices,
+  mapContext,
   selectedChoices,
   onToggleChoice,
   answer,
@@ -541,6 +545,7 @@ const QuestionInputSection = ({
 }: {
   question: string;
   choices: string[];
+  mapContext?: string;
   selectedChoices: string[];
   onToggleChoice: (choice: string) => void;
   answer: string;
@@ -565,22 +570,34 @@ const QuestionInputSection = ({
       <div className="mt-3 flex flex-wrap gap-2 pl-10.5">
         {choices.map((choice) => {
           const active = selectedChoices.includes(choice);
+          const mapUrl = googleMapsSearchUrl(choice, mapContext);
           return (
-            <button
-              key={choice}
-              type="button"
-              aria-pressed={active}
-              disabled={disabled}
-              onClick={() => onToggleChoice(choice)}
-              className={cn(
-                'rounded-full border px-3.5 py-1.5 text-sm transition-colors disabled:opacity-50',
-                active
-                  ? 'border-primary/40 bg-primary/10 font-medium text-primary dark:border-primary/40 dark:bg-primary/20 dark:text-primary'
-                  : 'border-input bg-background text-foreground hover:border-muted-foreground/30 hover:bg-muted/50'
-              )}
-            >
-              {choice}
-            </button>
+            <div key={choice} className="flex items-center gap-1">
+              <button
+                type="button"
+                aria-pressed={active}
+                disabled={disabled}
+                onClick={() => onToggleChoice(choice)}
+                className={cn(
+                  'rounded-full border px-3.5 py-1.5 text-sm transition-colors disabled:opacity-50',
+                  active
+                    ? 'border-primary/40 bg-primary/10 font-medium text-primary dark:border-primary/40 dark:bg-primary/20 dark:text-primary'
+                    : 'border-input bg-background text-foreground hover:border-muted-foreground/30 hover:bg-muted/50'
+                )}
+              >
+                {choice}
+              </button>
+              <a
+                href={mapUrl}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={`${choice} Google 지도에서 보기`}
+                title="Google 지도에서 보기"
+                className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <ExternalLink className="size-3.5" aria-hidden="true" />
+              </a>
+            </div>
           );
         })}
       </div>
@@ -597,6 +614,12 @@ const QuestionInputSection = ({
     </div>
   </section>
 );
+
+const googleMapsSearchUrl = (choice: string, context?: string) => {
+  const query = [choice, context].filter(Boolean).join(' ');
+  const params = new URLSearchParams({ api: '1', query });
+  return `https://www.google.com/maps/search/?${params.toString()}`;
+};
 
 const googleMapsPlaceUrl = ({
   name,
@@ -615,8 +638,7 @@ const googleMapsPlaceUrl = ({
   const params = new URLSearchParams({
     api: '1',
     query:
-      query ||
-      (coordinates ? `${coordinates.lat},${coordinates.lng}` : name),
+      query || (coordinates ? `${coordinates.lat},${coordinates.lng}` : name),
   });
   if (placeId) params.set('query_place_id', placeId);
   return `https://www.google.com/maps/search/?${params.toString()}`;

--- a/apps/frontend/src/components/dump/DumpForm.tsx
+++ b/apps/frontend/src/components/dump/DumpForm.tsx
@@ -1,6 +1,9 @@
+import { useState } from 'react';
+
 import { DUMP_TEXT } from '../../utils/constants';
 
 import './DumpForm.css';
+import DumpGuideDialog from './DumpGuideDialog';
 
 type DumpFormProps = {
   dumpText: string;
@@ -13,14 +16,17 @@ const PLACEHOLDER = `도쿄 여행 3박 4일 계획중이야`;
 const HELPER_TEXT =
   '메모, 카톡 대화, 검색 기록 등을 자유롭게 붙여넣어 주세요 (최소 10자 이상)';
 
-const EXAMPLE_TEXT = `꼭 가보고 싶은 명소가 몇 군데 있어, 여긴 무조건 갈 거야.
-현지에서 유명한 맛집이랑 분위기 좋은 카페 추천 받고 싶어.
-체험거리도 하나쯤 하고 싶은데 뭐가 좋을지 모르겠어.
-쇼핑은 어디가 좋을지 아직 못 정했어.`;
-
 const DumpForm = ({ dumpText, dumpTextCount, onTextChange }: DumpFormProps) => {
+  const [guideOpen, setGuideOpen] = useState(false);
+
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onTextChange(event.target.value);
+  };
+
+  const handleAddGuideText = (guideText: string) => {
+    const separator = dumpText.trim() ? '\n\n' : '';
+    const nextText = `${dumpText.trimEnd()}${separator}${guideText}`;
+    onTextChange(nextText.slice(0, DUMP_TEXT.MAX_LENGTH));
   };
 
   const getStatusMessage = () => {
@@ -49,9 +55,9 @@ const DumpForm = ({ dumpText, dumpTextCount, onTextChange }: DumpFormProps) => {
         <button
           type="button"
           className="dump-form__example-btn"
-          onClick={() => onTextChange(EXAMPLE_TEXT)}
+          onClick={() => setGuideOpen(true)}
         >
-          가이드 문장 채우기
+          가이드로 시작하기
         </button>
       </div>
 
@@ -69,6 +75,12 @@ const DumpForm = ({ dumpText, dumpTextCount, onTextChange }: DumpFormProps) => {
       </div>
 
       <p className="dump-status-message">{getStatusMessage()}</p>
+
+      <DumpGuideDialog
+        open={guideOpen}
+        onOpenChange={setGuideOpen}
+        onAdd={handleAddGuideText}
+      />
     </div>
   );
 };

--- a/apps/frontend/src/components/dump/DumpGuideDialog.tsx
+++ b/apps/frontend/src/components/dump/DumpGuideDialog.tsx
@@ -1,0 +1,265 @@
+import { Sparkles } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+type GuideOption = {
+  id: string;
+  label: string;
+  sentence: string;
+};
+
+type DumpGuideDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdd: (text: string) => void;
+};
+
+const PACE_OPTIONS: GuideOption[] = [
+  {
+    id: 'relaxed',
+    label: '여유롭게',
+    sentence: '여유롭게 둘러보는 일정을 원해요.',
+  },
+  {
+    id: 'packed',
+    label: '알차게',
+    sentence: '짧은 시간에도 알차게 둘러보고 싶어요.',
+  },
+  {
+    id: 'spontaneous',
+    label: '즉흥적으로',
+    sentence: '상황에 따라 유연하게 움직이고 싶어요.',
+  },
+];
+
+const INTEREST_OPTIONS: GuideOption[] = [
+  { id: 'food', label: '맛집', sentence: '현지 맛집' },
+  { id: 'cafe', label: '카페', sentence: '분위기 좋은 카페' },
+  { id: 'sightseeing', label: '관광', sentence: '대표 관광지' },
+  { id: 'shopping', label: '쇼핑', sentence: '쇼핑' },
+  { id: 'nature', label: '자연', sentence: '자연과 풍경' },
+  { id: 'activity', label: '체험', sentence: '현지 체험' },
+];
+
+const PRIORITY_OPTIONS: GuideOption[] = [
+  {
+    id: 'route',
+    label: '짧은 동선',
+    sentence: '이동 동선이 너무 길지 않았으면 좋겠어요.',
+  },
+  {
+    id: 'budget',
+    label: '예산',
+    sentence: '가격 대비 만족도가 좋은 곳을 선호해요.',
+  },
+  {
+    id: 'local',
+    label: '현지 분위기',
+    sentence: '관광객용 장소보다 현지 분위기를 느끼고 싶어요.',
+  },
+  {
+    id: 'photo',
+    label: '사진',
+    sentence: '사진 찍기 좋은 장소도 가고 싶어요.',
+  },
+];
+
+const AVOID_OPTIONS: GuideOption[] = [
+  {
+    id: 'waiting',
+    label: '긴 웨이팅',
+    sentence: '웨이팅이 너무 긴 곳은 피하고 싶어요.',
+  },
+  {
+    id: 'early',
+    label: '이른 일정',
+    sentence: '아침 일찍 시작하는 일정은 피하고 싶어요.',
+  },
+  {
+    id: 'crowds',
+    label: '붐비는 곳',
+    sentence: '지나치게 붐비는 장소는 피하고 싶어요.',
+  },
+  {
+    id: 'long-travel',
+    label: '장거리 이동',
+    sentence: '한 장소를 위해 오래 이동하는 일정은 피하고 싶어요.',
+  },
+];
+
+const joinKorean = (items: string[]) => {
+  if (items.length <= 1) return items[0] ?? '';
+  return `${items.slice(0, -1).join(', ')}과 ${items.at(-1)}`;
+};
+
+const OptionGroup = ({
+  title,
+  description,
+  options,
+  selected,
+  onToggle,
+}: {
+  title: string;
+  description: string;
+  options: GuideOption[];
+  selected: string[];
+  onToggle: (id: string) => void;
+}) => (
+  <section>
+    <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+    <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+    <div className="mt-3 flex flex-wrap gap-2">
+      {options.map((option) => {
+        const active = selected.includes(option.id);
+        return (
+          <button
+            key={option.id}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onToggle(option.id)}
+            className={cn(
+              'rounded-full border px-3.5 py-1.5 text-sm transition-colors',
+              active
+                ? 'border-primary/40 bg-primary/10 font-medium text-primary'
+                : 'border-input bg-background text-foreground hover:bg-muted/60'
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  </section>
+);
+
+const DumpGuideDialog = ({
+  open,
+  onOpenChange,
+  onAdd,
+}: DumpGuideDialogProps) => {
+  const [pace, setPace] = useState<string[]>([]);
+  const [interests, setInterests] = useState<string[]>([]);
+  const [priorities, setPriorities] = useState<string[]>([]);
+  const [avoidances, setAvoidances] = useState<string[]>([]);
+
+  const toggleSingle = (id: string) =>
+    setPace((prev) => (prev[0] === id ? [] : [id]));
+  const toggleMany =
+    (setter: React.Dispatch<React.SetStateAction<string[]>>) => (id: string) =>
+      setter((prev) =>
+        prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]
+      );
+
+  const generatedText = useMemo(() => {
+    const sentences: string[] = [];
+    const paceOption = PACE_OPTIONS.find((option) => option.id === pace[0]);
+    if (paceOption) sentences.push(paceOption.sentence);
+
+    const interestLabels = INTEREST_OPTIONS.filter((option) =>
+      interests.includes(option.id)
+    ).map((option) => option.sentence);
+    if (interestLabels.length > 0) {
+      sentences.push(`${joinKorean(interestLabels)}에 관심이 많아요.`);
+    }
+
+    for (const option of PRIORITY_OPTIONS) {
+      if (priorities.includes(option.id)) sentences.push(option.sentence);
+    }
+    for (const option of AVOID_OPTIONS) {
+      if (avoidances.includes(option.id)) sentences.push(option.sentence);
+    }
+
+    sentences.push(
+      '아직 정하지 못한 장소나 맛집은 제 취향에 맞게 추천받고 싶어요.'
+    );
+    return sentences.join(' ');
+  }, [avoidances, interests, pace, priorities]);
+
+  const hasSelection =
+    pace.length + interests.length + priorities.length + avoidances.length > 0;
+
+  const handleAdd = () => {
+    onAdd(generatedText);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <div className="mb-2 flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Sparkles className="size-5" aria-hidden="true" />
+          </div>
+          <DialogTitle>어떤 여행을 원하세요?</DialogTitle>
+          <DialogDescription>
+            취향을 골라주시면 여행 정보 입력을 시작할 문장을 만들어드릴게요.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-6 py-2 sm:grid-cols-2">
+          <OptionGroup
+            title="여행 속도"
+            description="한 가지만 선택할 수 있어요"
+            options={PACE_OPTIONS}
+            selected={pace}
+            onToggle={toggleSingle}
+          />
+          <OptionGroup
+            title="관심사"
+            description="여러 개 선택할 수 있어요"
+            options={INTEREST_OPTIONS}
+            selected={interests}
+            onToggle={toggleMany(setInterests)}
+          />
+          <OptionGroup
+            title="중요한 기준"
+            description="장소와 일정을 고를 때 참고해요"
+            options={PRIORITY_OPTIONS}
+            selected={priorities}
+            onToggle={toggleMany(setPriorities)}
+          />
+          <OptionGroup
+            title="피하고 싶은 것"
+            description="원하지 않는 일정도 알려주세요"
+            options={AVOID_OPTIONS}
+            selected={avoidances}
+            onToggle={toggleMany(setAvoidances)}
+          />
+        </div>
+
+        <div className="rounded-2xl border border-primary/20 bg-primary/5 p-4">
+          <p className="text-xs font-semibold text-primary">생성될 문장</p>
+          <p className="mt-2 text-sm leading-6 text-foreground">
+            {generatedText}
+          </p>
+        </div>
+
+        <div className="rounded-xl bg-muted/60 px-4 py-3 text-sm leading-6 text-muted-foreground">
+          문장을 입력창에 추가한 뒤, 꼭 가고 싶은 장소나 이미 예약한 일정이
+          있다면 직접 이어서 적어주세요.
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
+          <Button disabled={!hasSelection} onClick={handleAdd}>
+            입력창에 추가
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DumpGuideDialog;

--- a/apps/frontend/src/components/grouping/SelectCardDetailPanel.tsx
+++ b/apps/frontend/src/components/grouping/SelectCardDetailPanel.tsx
@@ -10,6 +10,7 @@ type SelectCardDetailPanelProps = {
   card: PlaceCardViewModel | null;
   pending?: boolean;
   error?: string | null;
+  mapContext?: string;
   onConfirm?: (payload: { choices: string[]; answer: string }) => void;
   onExclude?: () => void;
   onSaveMemo?: (memo: string) => void;
@@ -17,7 +18,8 @@ type SelectCardDetailPanelProps = {
 };
 
 const toCommonCard = (
-  card: PlaceCardViewModel | null
+  card: PlaceCardViewModel | null,
+  mapContext?: string
 ): CommonCardDetailCard | null => {
   if (!card?.selectDetail) return null;
   const detail = card.selectDetail;
@@ -40,6 +42,7 @@ const toCommonCard = (
       address: detail.address,
       question: detail.question,
       choices: detail.choices,
+      choiceMapContext: mapContext ?? card.region,
       selectedChoices: detail.selectedChoices,
       answer: detail.answer,
       memo: detail.memo,
@@ -52,13 +55,14 @@ const SelectCardDetailPanel = ({
   card,
   pending = false,
   error = null,
+  mapContext,
   onConfirm,
   ...props
 }: SelectCardDetailPanelProps) => {
   return (
     <CardDetailPanel
       {...props}
-      card={toCommonCard(card)}
+      card={toCommonCard(card, mapContext)}
       onConfirmSelection={onConfirm}
       resolving={pending}
       resolveError={error}

--- a/apps/frontend/src/pages/GroupingPage.tsx
+++ b/apps/frontend/src/pages/GroupingPage.tsx
@@ -820,6 +820,9 @@ const GroupingPage = () => {
           if (!open) setAwaitingSelectId(null);
         }}
         card={selectCard}
+        mapContext={summary.destinations
+          .filter((item) => item !== '-')
+          .join(' ')}
         pending={busy || awaitingSelectId != null}
         error={state.phase === 'ready' ? state.errorMessage : null}
         onConfirm={async (payload) => {


### PR DESCRIPTION
Dump의 가이드 입력 부분을 취향 칩을 선택하여 예시 텍스트를 받아 덤프 파싱을 탈 수 있도록 리팩토링했습니다.

또한 선택이 필요한 카드에 대해서 각 옵션을 사용자가 확인가능하도록 google map 링크를 걸어 확인 가능하도록 했습니다.
다만 텍스트 기반의 검색이므로, 정확성이 떨어지는 상황입니다.