### PR TITLE
fix: 여행 기간에 맞춰 장소 카드 생성

### DIFF
--- a/apps/ai-engine/app/prompts/core_parse.py
+++ b/apps/ai-engine/app/prompts/core_parse.py
@@ -77,6 +77,12 @@ def build_core_parse_prompt(req: ParseRequest) -> str:
 - When the user asks for broad recommendations without a subtype, create one undecided ready_partial card that asks the user to choose a subtype/preference first.
   - Pattern: "음식점 추천" → one food card with options like ["스시", "라멘", "오코노미야키", "카페"], not restaurant venues yet.
   - Pattern: "관광지 추천" → one place card with options like ["랜드마크", "사찰/신사", "전망/야경", "쇼핑거리"], not attraction venues yet.
+- When the user provides an abstract whole-trip style such as "휴양", "힐링", "여유롭게", or "쉬는 여행"
+  together with a trip duration, treat it as a request for an initial itinerary rather than a subtype-selection question.
+  Generate exactly travel_days distinct, concrete, real venue cards that fit that style and destination, up to 7 cards.
+  Keep the set varied (for example a spa/onsen, a quiet park or garden, a relaxed cafe, and a low-intensity cultural venue)
+  without creating generic style/category cards. Every generated card must be a place that Google Places can resolve.
+  - Pattern: "도쿄 3박 4일 휴양을 하고 싶어요" with travel_days=4 → four concrete Tokyo venue cards, not one "휴양" card.
 - When the user asks for recommendations for a specific type, cuisine, neighborhood, mood, or activity in dump_text, create one undecided card for that requested type and provide 2~4 concrete venue/place options.
   - Pattern: "{{destination}} {{requested_type}} 추천" where requested_type is specific → one undecided card named "{{requested_type}}" with concrete venue options.
   - Pattern: "{{cuisine_or_food}} 맛집 아직 못 정했어" → one undecided food card named "{{cuisine_or_food}} 맛집" with concrete restaurant options.
@@ -84,7 +90,8 @@ def build_core_parse_prompt(req: ParseRequest) -> str:
 - Only generate is_ai_generated: true recommendation cards when:
   - the user asks for general recommendations without a specific type or category, or
   - the dump only contains destination-level context with no specific places at all.
-- Even then, generate at most 3 recommendation cards.
+- Even then, generate at most 3 recommendation cards, except whole-trip style requests with an explicit duration;
+  for those, generate min(travel_days, 7) concrete recommendation cards as described above.
 - Do not create generic category cards such as "{{destination}} restaurants", "{{destination}} attractions",
   "{{destination}} activities", "{{destination}} shopping", "{{destination}} cafes", or "{{destination}} nightlife" as open_question.
 - If a generated recommendation card is not a concrete venue/place, classify it as undecided:

--- a/apps/ai-engine/tests/test_parse_service.py
+++ b/apps/ai-engine/tests/test_parse_service.py
@@ -192,6 +192,9 @@ def test_core_parse_prompt_requires_destination_aware_responses() -> None:
     assert "broad recommendation cards" in prompt
     assert "subcategories/preferences" in prompt
     assert "Do not mix subcategory options and venue options" in prompt
+    assert '"도쿄 3박 4일 휴양을 하고 싶어요"' in prompt
+    assert "Generate exactly travel_days distinct, concrete, real venue cards" in prompt
+    assert "four concrete Tokyo venue cards" in prompt
     assert "must explain what is currently missing" in prompt
     assert "what kind of answer the user can provide" in prompt
 


### PR DESCRIPTION
## 📝 작업 내용

> 휴양·힐링 등 여행 스타일이 포함된 추천 요청에서 장소 카드가 1개만 생성되는 문제를 수정했습니다.

- 여행 스타일과 기간이 함께 입력되면 `travel_days`만큼 실제 장소 카드를 생성하도록 AI 프롬프트를 보완했습니다.
- 생성되는 장소가 휴양 의도와 여행지에 맞으면서 서로 중복되지 않도록 명시했습니다.
- 카드가 과도하게 생성되지 않도록 최대 7개로 제한했습니다.
- `도쿄 3박 4일 휴양을 하고 싶어요` 입력 시 실제 도쿄 장소 카드 4개를 생성하도록 회귀 기준을 추가했습니다.

## 🔗 관련 이슈

closes #이슈번호

## 🗂️ 변경 범위

어떤 레이어를 건드렸나요? (해당하는 것 체크)

- [ ] Frontend (apps/frontend)
- [ ] Backend (apps/backend)
- [x] AI Engine (apps/ai-engine)
- [ ] 공통 / 설정 / 문서

## ✅ 작업 체크리스트

- [x] 로컬에서 정상 

## 머지 이후 스테이징 사이트에서 확인 테스트 진행 후 메인 머지 예정입니다